### PR TITLE
[WIP] config: Handle config read errors

### DIFF
--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -122,6 +122,11 @@ void config::parse_file() {
   int lineno{0};
   string line;
   std::ifstream in(m_file);
+
+  if (in.fail()) {
+    throw application_error(sstream() << "Couldn't open config file: " << strerror(errno));
+  }
+
   while (std::getline(in, line)) {
     pushline(++lineno, string_util::replace_all(line, "\t", ""));
   }

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -110,8 +110,13 @@ void config::parse_file() {
       }
       files.push_back(file_util::expand(file_path));
       m_log.trace("config: Including file \"%s\"", file_path);
-      for (auto&& l : string_util::split(file_util::contents(file_path), '\n')) {
-        pushline(lineno, forward<string>(l));
+
+      try {
+        for (auto&& l : string_util::split(file_util::contents(file_path), '\n')) {
+          pushline(lineno, forward<string>(l));
+        }
+      } catch(const application_error& err) {
+        throw application_error("Could not read include file defined on line " + to_string(lineno) + ": " + err.what());
       }
       files.pop_back();
     } else {

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -13,6 +13,8 @@
 
 POLYBAR_NS
 
+DEFINE_ERROR(file_read_error);
+
 // implementation of file_ptr {{{
 
 file_ptr::file_ptr(const string& path, const string& mode) : m_path(string(path)), m_mode(string(mode)) {
@@ -187,12 +189,21 @@ namespace file_util {
 
   /**
    * Gets the contents of the given file
+   *
+   * Throws application_error, containing only the filename and the errno
+   * error message, if the file cannot be properly read
    */
   string contents(const string& filename) {
     try {
       string contents;
       string line;
       std::ifstream in(filename, std::ifstream::in);
+
+      // There was a problem opening the file
+      if (in.fail()) {
+        throw file_read_error(sstream() << filename << ": " << strerror(errno));
+      }
+
       while (std::getline(in, line)) {
         contents += line + '\n';
       }


### PR DESCRIPTION
Right now, if for some reason the config file (or one of its included files) can
not be successfully read, polybar will treat all its content as an empty string
(unless the file doesn't exist) because of how ifstream works.

We want to print meaningful error messages or even stop the program, if
something goes wrong.