### PR TITLE
Toggleable labels

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -88,6 +88,7 @@ namespace modules {
     void add(string name, string fallback, vector<string>&& tags, vector<string>&& whitelist = {});
     bool has(const string& tag, const string& format_name);
     bool has(const string& tag);
+    bool has_non_tag(const string& format_name);
     shared_ptr<module_format> get(const string& format_name);
 
    protected:

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -3,13 +3,15 @@
 #include "adapters/net.hpp"
 #include "components/config.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "modules/meta/input_handler.hpp"
 
 POLYBAR_NS
 
 namespace modules {
   enum class connection_state { NONE = 0, CONNECTED, DISCONNECTED, PACKETLOSS };
 
-  class network_module : public timer_module<network_module> {
+  class network_module : public timer_module<network_module>,
+                         public input_handler {
    public:
     explicit network_module(const bar_settings&, string);
 
@@ -17,9 +19,11 @@ namespace modules {
     bool update();
     string get_format() const;
     bool build(builder* builder, const string& tag) const;
+    string get_output();
 
    protected:
     void subthread_routine();
+    bool input(string&& cmd);
 
    private:
     static constexpr auto FORMAT_CONNECTED = "format-connected";
@@ -28,9 +32,12 @@ namespace modules {
     static constexpr auto TAG_RAMP_SIGNAL = "<ramp-signal>";
     static constexpr auto TAG_RAMP_QUALITY = "<ramp-quality>";
     static constexpr auto TAG_LABEL_CONNECTED = "<label-connected>";
+    static constexpr auto TAG_LABEL_ALT_CONNECTED = "<label-alt-connected>";
     static constexpr auto TAG_LABEL_DISCONNECTED = "<label-disconnected>";
     static constexpr auto TAG_LABEL_PACKETLOSS = "<label-packetloss>";
+    static constexpr auto TAG_LABEL_ALT_PACKETLOSS = "<label-alt-packetloss>";
     static constexpr auto TAG_ANIMATION_PACKETLOSS = "<animation-packetloss>";
+    static constexpr auto EVENT_TOGGLE = "networktoggle";
 
     net::wired_t m_wired;
     net::wireless_t m_wireless;
@@ -39,9 +46,12 @@ namespace modules {
     ramp_t m_ramp_quality;
     animation_t m_animation_packetloss;
     map<connection_state, label_t> m_label;
+    map<connection_state, label_t> m_label_alt;
 
     atomic<bool> m_connected{false};
     atomic<bool> m_packetloss{false};
+    atomic<bool> m_toggleable{false};
+    atomic<bool> m_toggled{false};
 
     int m_signal{0};
     int m_quality{0};

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -249,19 +249,19 @@ namespace modules {
     };
 
     switch (m_state) {
-      case state::FULL:
+      case battery_module::state::FULL:
         replace_tokens(m_label_full);
         replace_tokens(m_label_alt_full);
         break;
-      case state::DISCHARGING:
+      case battery_module::state::DISCHARGING:
         replace_tokens(m_label_discharging);
         replace_tokens(m_label_alt_discharging);
         break;
-      case state::CHARGING:
+      case battery_module::state::CHARGING:
         replace_tokens(m_label_charging);
         replace_tokens(m_label_alt_charging);
         break;
-      case state::NONE:
+      case battery_module::state::NONE:
         // fall-through
       default:
         m_log.warn("Unsupported battery state: %d", m_state);

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -149,6 +149,26 @@ namespace modules {
     return false;
   }
 
+  bool module_formatter::has_non_tag(const string& format_name) {
+    auto format = m_formats.find(format_name);
+    if (format == m_formats.end()) {
+      throw undefined_format(format_name);
+    }
+    string value{format->second->value};
+    size_t start, end;
+    while ((start = value.find('<')) != string::npos &&
+           (end = value.find('>', start)) != string::npos) {
+      if (start > 0) {
+          auto trimmed = string_util::ltrim(value.substr(0, start), ' ');
+          if (!trimmed.empty()) {
+            return true;
+          }
+      }
+      value.erase(0, end + 1);
+    }
+    return !value.empty();
+  }
+
   shared_ptr<module_format> module_formatter::get(const string& format_name) {
     auto format = m_formats.find(format_name);
     if (format == m_formats.end()) {


### PR DESCRIPTION
I like feature of date module when you can switch two different formats of displayed information. It is very useful when you don't want to see some info all the time, e.g. date module may display current time usually and show date additionally by click.

There are two other modules which don't have input handlers by default: network and battery. They can implement same behavior, e.g. battery usually shows current percentage or nice ramp icon, but when you click on it then time to charge is shown additionally.

Fixes #781.