### PR TITLE
Some issues with syntax tags

### DIFF
--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -76,6 +76,8 @@ class builder {
 
   string m_background{};
   string m_foreground{};
+
+  bool m_ignore_syntax_tags{false}; // tagfix:
 };
 
 POLYBAR_NS_END

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -37,6 +37,7 @@ enum class syntaxtag {
   R,  // flip colors
   o,  // overline color
   u,  // underline color
+  X   // tagfix: ignore syntax tags
 };
 
 enum class mousebtn { NONE = 0, LEFT, MIDDLE, RIGHT, SCROLL_UP, SCROLL_DOWN, DOUBLE_LEFT, DOUBLE_MIDDLE, DOUBLE_RIGHT };

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -39,11 +39,12 @@ namespace drawtypes {
     side_values m_margin{0U,0U};
     size_t m_maxlen{0_z};
     bool m_ellipsis{true};
+    bool m_ignore_syntax_tags{false};
 
     explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
     explicit label(string text, string foreground = ""s, string background = ""s, string underline = ""s,
         string overline = ""s, int font = 0, struct side_values padding = {0U,0U}, struct side_values margin = {0U,0U},
-        size_t maxlen = 0_z, bool ellipsis = true, vector<token>&& tokens = {})
+        size_t maxlen = 0_z, bool ellipsis = true, vector<token>&& tokens = {}, bool ignore_syntax_tags = false)
         : m_foreground(foreground)
         , m_background(background)
         , m_underline(underline)
@@ -53,6 +54,7 @@ namespace drawtypes {
         , m_margin(margin)
         , m_maxlen(maxlen)
         , m_ellipsis(ellipsis)
+        , m_ignore_syntax_tags(ignore_syntax_tags)
         , m_text(text)
         , m_tokenized(m_text)
         , m_tokens(forward<vector<token>>(tokens)) {}

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -514,16 +514,18 @@ bool controller::process_update(bool force) {
       block_contents += padding_right;
     }
 
+    // tagfix:
     // Strip unnecessary reset tags
-    block_contents = string_util::replace_all(block_contents, "T-}%{T", "T");
-    block_contents = string_util::replace_all(block_contents, "B-}%{B#", "B#");
-    block_contents = string_util::replace_all(block_contents, "F-}%{F#", "F#");
-    block_contents = string_util::replace_all(block_contents, "U-}%{U#", "U#");
-    block_contents = string_util::replace_all(block_contents, "u-}%{u#", "u#");
-    block_contents = string_util::replace_all(block_contents, "o-}%{o#", "o#");
+    // block_contents = string_util::replace_all(block_contents, "T-}%{T", "T");
+    // block_contents = string_util::replace_all(block_contents, "B-}%{B#", "B#");
+    // block_contents = string_util::replace_all(block_contents, "F-}%{F#", "F#");
+    // block_contents = string_util::replace_all(block_contents, "U-}%{U#", "U#");
+    // block_contents = string_util::replace_all(block_contents, "u-}%{u#", "u#");
+    // block_contents = string_util::replace_all(block_contents, "o-}%{o#", "o#");
 
     // Join consecutive tags
-    contents += string_util::replace_all(block_contents, "}%{", " ");
+    // contents += string_util::replace_all(block_contents, "}%{", " ");
+    contents += block_contents;
   }
 
   try {

--- a/src/components/parser.cpp
+++ b/src/components/parser.cpp
@@ -35,7 +35,20 @@ void parser::parse(const bar_settings& bar, string data) {
   while (!data.empty()) {
     size_t pos{string::npos};
 
-    if (data.compare(0, 2, "%{") == 0 && (pos = data.find('}')) != string::npos) {
+    if (data.compare(0, 3, "%{X") == 0 && (pos = data.find('}')) != string::npos) {
+      // tagfix: if %{X<skip_count>} tag is found, parse next 'skip_count' characters after the
+      // closing brace as text instead of a clodeblock
+      size_t skip_count = 0;
+
+      try {
+        skip_count = std::stoi(data.substr(3, pos - 3));
+      } catch(...) {
+      }
+
+      data.erase(0, pos + 1);
+      data.erase(0, text(data.substr(0, skip_count)));
+
+    } else if (data.compare(0, 2, "%{") == 0 && (pos = data.find('}')) != string::npos) {
       codeblock(data.substr(2, pos - 2), bar);
       data.erase(0, pos + 1);
     } else if ((pos = data.find("%{")) != string::npos) {

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -22,7 +22,7 @@ namespace drawtypes {
       std::copy(m_tokens.begin(), m_tokens.end(), back_it);
     }
     return factory_util::shared<label>(m_text, m_foreground, m_background, m_underline, m_overline, m_font, m_padding,
-        m_margin, m_maxlen, m_ellipsis, move(tokens));
+        m_margin, m_maxlen, m_ellipsis, move(tokens), m_ignore_syntax_tags);
   }
 
   void label::clear() {
@@ -232,7 +232,8 @@ namespace drawtypes {
         margin,
         conf.get(section, name + "-maxlen", 0_z),
         conf.get(section, name + "-ellipsis", true),
-        move(tokens));
+        move(tokens),
+        conf.get(section, name + "-notags", false)); // tagfix:
     // clang-format on
   }
 

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -218,7 +218,10 @@ namespace modules {
         cmd.erase(0, strlen(EVENT_CLICK));
         if (i3_util::focused_workspace(conn)->name != cmd) {
           m_log.info("%s: Sending workspace focus command to ipc handler", name());
-          conn.send_command("workspace " + cmd);
+
+          // tagfix: ignore everything after semicolon to prevent injection of additional commands
+          size_t pos = cmd.find(';');
+          conn.send_command("workspace " + cmd.substr(0, pos));
         }
         return true;
       }

--- a/src/modules/text.cpp
+++ b/src/modules/text.cpp
@@ -52,7 +52,10 @@ namespace modules {
 
     m_builder->append(output);
 
-    return m_builder->flush();
+    // tagfix: this module seems to use builder directly (circumventing builder::node() construction)
+    // so we have to replace BUILDER_SPACE_TOKEN back to " " manually because that was removed from
+    // builder::flush() to play nice with the new %{X<skip_count>} tag
+    return string_util::replace_all(m_builder->flush(), BUILDER_SPACE_TOKEN, " ");
   }
 }
 

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -78,6 +78,8 @@ namespace modules {
 
     if (m_formatter->has(TAG_LABEL)) {
       m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%title%");
+      // tagfix: force this label to ignore syntax tags
+      m_label->m_ignore_syntax_tags = true;
     }
   }
 


### PR DESCRIPTION
## Problem

There is a serious issue with the way syntax tags (i.e %{..}) are parsed. Say you have `xwindow` module enabled that shows the title of currently focused window and that title contains some syntax tags. Eg. if a user navigates to some webpage that has the following contents:

`<html>`
`<head>`
`  <title>%{F#f00}red title%{F-}</title>`
`</head>`
`<body>`
`lorem...`
`</body>`

then her browser will set contents inside `<title>..</title>` as window title (+ name of a browser) and `xwindow` module will use that string as contents for a label. This will then go through `builder` where these syntax tags will be parsed and you will see a red "red title" in your bar. This is innocent enough but consider action tags, eg. if contents inside `<title>` are

`<title>%{A1:some_command:}click me%{A}</title>`

you will only see "click me" in your bar and upon left-clicking on it, a value in between `:`s will end up in `controller::process_inputdata()` where it will iterate through modules looking for the ones that implement `input_handler` class and then call their `::input()` method with `"some_command"` as argument. If no `input_handler`s will handle this command it will then execute `"some_command"` directly in a shell! This is *very* bad! Consider something like:

`<title>%{A1:touch ~/pwnd:}polybar warning: click here to dismiss%{A}</title>`

you'll find a file name `pwnd` in your home directory upon left-clicking on it.

Acctually I just noticed that as I was writing this PR. Originally I found a bug in `i3` module (which implements `input_handler` class) where its `::input()` method would look at the command and see if it starts with `"i3wm-wsfocus-"`. If so then it would strip away that part, prepend `"workspace "` and send it over IPC to i3. But i3 IPC accepts `';'`-seperated list of commands so if the command was something like `"i3wm-wsfocus-1;exec touch pwnd"` it would strip away `"i3wm-wsfocus-"` and send `"workspace 1; exec touch pwnd"` to i3. That was bad enough but this is way, way worse.

## Solution

The solution involves allowing `label`s to ignore syntax tags in their contents. From a user perspective you can now set "-notags" option on your label, eg:

`somelabel            = %{T1}some text%{T-} %some_token%`
`somelabel-foreground = #f00`
`somelabel-notags     = true`

so you can still style your labels with `-foreground`, `-background` etc. but in this case `%{T1}` and `%{T-}` would not be parsed and simply displayed as-is.

Implementing this turned out to be not so trivial because of the way all contents of modules in a bar are dumped into one big string and then parsed all at once, but I can try to walk through the changes I made so it is easier to review this.

So first stop is `drawtypes/label.hpp|cpp`. `label` class gets a new member `m_ignore_syntax_tags` which is set to `false` by default and it's constructor and `clone()` method  are modified accordingly. Also in `load_label()` function it reads "-notags" value from config file (again, defaulting to `false` if it's not set explicitly, so it's buisness as usual)

Next is `components/builder.hpp|cpp` and `components/types.hpp`. `enum class syntaxtag` gets a new tag, `syntaxtag::X`. The idea is to insert this tag just before the text that needs its syntax tags ignored. So eg. in

`%{X11}%{T1}a%{T-} rest of the text`

the next 11 characters after the closing brace of the `X` tag, ie. `%{T1}a%{T-}` would be parsed as-is.

Ok so `builder::node(const label_t& label, ...)` method now checks if label wants its syntax tags ignored and if so adds `%{X<skip_count>}` (where `skip_count` is length of labels text) just before calling `builder::node(string str, ...)` method. This is done in `builder::tag_open(tag, value)` just like for other tags. Now `builder::node(string str, ...)` checks if `builder` is in `m_ignore_syntax_tags` state and simply appends `str` to its output without going through all the shebang of parsing tags inside it.

Finally in `components/parser.cpp` `parser::parse(...)` method first looks for our special `%{X<skip_count>}` tag, parses the number inside it and sends `skip_count` characters after the closing brace to `parser::text(..)` method instead of `parser::codeblock(..)`.

Thats it, except not quite so. There are a few things that mess this all up. 

At the end of `builder::flush()` all `"%__"` in its output are replaced by `" "` so if there were `"%__"`s in a text we want to interpret as-is, they would be replaced by single character `' '` and now `%{X<skip_count>}` would also include text outside its intended range. So I moved the line that does it to the end of `builder::node(string str, ...)` instead. Logic behind it is that

`output = replace_all(a + b + c, "%__", " ");`

is essentially the same as 

`a = replace_all(a, "%__", " ");`
`b = replace_all(b, "%__", " ");`
`c = replace_all(c, "%__", " ");`
`output = a + b + c;`

except maybe if the last two characters of `a` were `"%_"` and the first character of `b` was `'_'` or for some other such contrived edge case.

Yeah but now `modules/text.cpp` breaks a little (?) bit because it circumvents `builder::node()` construction and does it's own thing, eventually expecting `builder::flush()` to replace `"%__"` by `" "`. So I help it a little by doing it at the end of `text_module::get_output()`. There are no `label`s in this module so `m_ignore_syntax_tags` is not in play anyway, but I still feel a little bit uneasy about this if some other class inherits this and then uses `label`s, etc.

Finally the last issue was in `components/controller.cpp` where in `controller::process_update()` method it concatenates all the outputs from all the modules in the bar and then replaces things like `"T-}{T1"` with just `"T1"` etc. and joins adjacent tags under same scope. That is

`%{F#0f0}%{B#00f}text%{B-}%{F-}`

becomes

`%{F#0f0 B#00f}text%{B- F-}`

thus again potentially messing up any text that follows our new `X` tag. 

Ok so semanticaly these operations don't change anything and the parser will handle either form the same way so I simply commented these lines out. I was worried a bit that things would get slower but I measured and its same same (in my case all these `replace_all` functions took 0.2ms compared to ~2ms it takes to render the whole bar!). Turns out `string_util::replace_all` is a bit inefficient if a thing you are replacing with is of different length than the thing you are replacing.

Finally in `modules/xwindow.cpp` I force the label to ignore syntax tags and we're done. My rice is safe!
