### PR TITLE
Make text module a label

### DIFF
--- a/include/modules/text.hpp
+++ b/include/modules/text.hpp
@@ -10,8 +10,14 @@ namespace modules {
     explicit text_module(const bar_settings&, string);
 
     void update() {}
-    string get_format() const;
+
     string get_output();
+    bool build(builder* builder, const string& tag) const;
+
+   private:
+    static constexpr auto TAG_CONTENT{"<content>"};
+
+    label_t m_label;
   };
 }
 

--- a/src/modules/text.cpp
+++ b/src/modules/text.cpp
@@ -1,4 +1,5 @@
 #include "modules/text.hpp"
+#include "drawtypes/label.hpp"
 
 #include "modules/meta/base.inl"
 
@@ -8,18 +9,10 @@ namespace modules {
   template class module<text_module>;
 
   text_module::text_module(const bar_settings& bar, string name_) : static_module<text_module>(bar, move(name_)) {
-    m_formatter->add("content", "", {});
-
-    if (m_formatter->get("content")->value.empty()) {
-      throw module_error(name() + ".content is empty or undefined");
+    m_formatter->add(DEFAULT_FORMAT, TAG_CONTENT, {TAG_CONTENT});
+    if (m_formatter->has(TAG_CONTENT, DEFAULT_FORMAT)) {
+      m_label = load_label(m_conf, name(), TAG_CONTENT);
     }
-
-    m_formatter->get("content")->value =
-        string_util::replace_all(m_formatter->get("content")->value, " ", BUILDER_SPACE_TOKEN);
-  }
-
-  string text_module::get_format() const {
-    return "content";
   }
 
   string text_module::get_output() {
@@ -54,6 +47,16 @@ namespace modules {
 
     return m_builder->flush();
   }
+
+  bool text_module::build(builder* builder, const string& tag) const {
+    if (tag == TAG_CONTENT) {
+      builder->node(m_label);
+    } else {
+      return false;
+    }
+    return true;
+  }
+
 }
 
 POLYBAR_NS_END


### PR DESCRIPTION
Fixes https://github.com/jaagr/polybar/issues/1331

**Reviewer Note:** This PR introduces breaking changes to the text module. It should be merged in the merge window where breaking changes can be introduced for the next major release (generally directly before the next major release).

```
refactor(text): Make content a label (#1342)

This adds the `format` key to the text module with `<content>` as its 
only (label) tag.

This change is not backwards compatible for all configs that make use of 
the `-margin`, `-spacing`, `-prefix` or `-suffix` properties of 
`content`, because `content` is converted from a format to a label.
It would be otherwise because by default `format = <content>` and if 
only `content` is set, the module will behave as before.
This will allow users to use all the label formatting options in the 
text module as well.

Sample configuration:
[module/text]
type = custom/text
format = <content>
content = Content of the text module

Fixes #1331

```