### PR TITLE
config_parser: Introduce stricter syntax conventions

### DIFF
--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -23,34 +23,22 @@ class config {
   using file_list = vector<string>;
 
   using make_type = const config&;
-  static make_type make(string path = "",
-      string bar = "",
-      sectionmap_t sections = {},
-      file_list included = {},
-      bool use_xrm = false);
+  static make_type make(string path = "", string bar = "");
 
-  config(const logger& logger,
-      string&& path = "",
-      string&& bar = "",
-      sectionmap_t sections = {},
-      file_list included = {},
-      bool use_xrm = false)
-    : m_log(logger),
-    m_file(forward<string>(path)),
-    m_barname(forward<string>(bar)),
-    m_sections(sections),
-    m_included(included) {
-#if WITH_XRM
-  // Initialize the xresource manage if there are any xrdb refs
-  // present in the configuration
-  if (use_xrm) {
-    m_xrm.reset(new xresource_manager{connection::make()});
-  }
-#endif
-    };
+  config(const logger& logger, string&& path = "", string&& bar = "")
+    : m_log(logger), m_file(forward<string>(path)), m_barname(forward<string>(bar)) {};
 
   string filepath() const;
   string section() const;
+
+  /**
+   * \brief Instruct the config to connect to the xresource manager
+   */
+  void use_xrm();
+
+  void set_sections(sectionmap_t sections);
+
+  void set_included(file_list included);
 
   void warn_deprecated(const string& section, const string& key, string replacement) const;
 

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -24,14 +24,13 @@ using file_list = vector<string>;
 
 class config {
  public:
-
   using make_type = const config&;
   static make_type make(string path = "", string bar = "");
 
-  config(const logger& logger, string&& path = "", string&& bar = "")
-    : m_log(logger), m_file(forward<string>(path)), m_barname(forward<string>(bar)) {};
+  explicit config(const logger& logger, string&& path = "", string&& bar = "")
+      : m_log(logger), m_file(move(path)), m_barname(move(bar)){};
 
-  string filepath() const;
+  const string& filepath() const;
   string section() const;
 
   /**

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -25,14 +25,31 @@ class config {
   using file_list = vector<string>;
 
   using make_type = const config&;
-  static make_type make(string path = "", string bar = "", sectionmap_t sections = {}, file_list included = {});
+  static make_type make(string path = "",
+      string bar = "",
+      sectionmap_t sections = {},
+      file_list included = {},
+      bool use_xrm = false);
 
-  config(const logger& logger, string&& path = "", string&& bar = "", sectionmap_t sections = {}, file_list included = {})
+  config(const logger& logger,
+      string&& path = "",
+      string&& bar = "",
+      sectionmap_t sections = {},
+      file_list included = {},
+      bool use_xrm = false)
     : m_log(logger),
     m_file(forward<string>(path)),
     m_barname(forward<string>(bar)),
     m_sections(sections),
-    m_included(included) {};
+    m_included(included) {
+#if WITH_XRM
+  // Initialize the xresource manage if there are any xrdb refs
+  // present in the configuration
+  if (use_xrm) {
+    m_xrm.reset(new xresource_manager{connection::make()});
+  }
+#endif
+    };
 
   string filepath() const;
   string section() const;
@@ -199,7 +216,6 @@ class config {
   }
 
  protected:
-  void parse_file();
   void copy_inherited();
 
   template <typename T>

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "common.hpp"
 #include "components/logger.hpp"
 #include "errors.hpp"
@@ -16,11 +18,12 @@ POLYBAR_NS
 DEFINE_ERROR(value_error);
 DEFINE_ERROR(key_error);
 
+using valuemap_t = std::unordered_map<string, string>;
+using sectionmap_t = std::map<string, valuemap_t>;
+using file_list = vector<string>;
+
 class config {
  public:
-  using valuemap_t = std::map<string, string>;
-  using sectionmap_t = std::map<string, valuemap_t>;
-  using file_list = vector<string>;
 
   using make_type = const config&;
   static make_type make(string path = "", string bar = "");

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -369,7 +369,8 @@ class config {
   sectionmap_t m_sections{};
 
   /**
-   * All files parsed while parsing this config (actual config file excluded)
+   * Absolute path of all files that were parsed in the process of parsing the
+   * config (Path of the main config file also included)
    */
   file_list m_included;
 #if WITH_XRM

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <unordered_map>
-
 #include "common.hpp"
 #include "components/logger.hpp"
 #include "errors.hpp"

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -20,13 +20,19 @@ DEFINE_ERROR(key_error);
 
 class config {
  public:
-  using valuemap_t = std::unordered_map<string, string>;
+  using valuemap_t = std::map<string, string>;
   using sectionmap_t = std::map<string, valuemap_t>;
+  using file_list = vector<string>;
 
   using make_type = const config&;
-  static make_type make(string path = "", string bar = "");
+  static make_type make(string path = "", string bar = "", sectionmap_t sections = {}, file_list included = {});
 
-  explicit config(const logger& logger, string&& path = "", string&& bar = "");
+  config(const logger& logger, string&& path = "", string&& bar = "", sectionmap_t sections = {}, file_list included = {})
+    : m_log(logger),
+    m_file(forward<string>(path)),
+    m_barname(forward<string>(bar)),
+    m_sections(sections),
+    m_included(included) {};
 
   string filepath() const;
   string section() const;
@@ -356,6 +362,11 @@ class config {
   string m_file;
   string m_barname;
   sectionmap_t m_sections{};
+
+  /**
+   * All files parsed while parsing this config (actual config file excluded)
+   */
+  file_list m_included;
 #if WITH_XRM
   unique_ptr<xresource_manager> m_xrm;
 #endif

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -35,6 +35,8 @@ class syntax_error : public parser_error {
       return ("Syntax error at " + file + ":" + to_string(line_no) + " " + msg).c_str();
     }
 
+    string get_msg() { return msg; };
+
   private:
     string file;
     int line_no;
@@ -234,6 +236,15 @@ class config_parser {
      */
     std::pair<string, string> parse_key(string line);
 
+    /**
+     * \brief Name of all the files the config includes values from
+     *
+     * The line_t struct uses indices to this vector to map lines to their
+     * original files. This allows us to point the user to the exact location
+     * of errors
+     */
+    file_list files;
+
   private:
 
     /**
@@ -248,15 +259,6 @@ class config_parser {
      * \brief Full path to the main config file
      */
     string m_file;
-
-    /**
-     * \brief Name of all the files the config includes values from
-     *
-     * The line_t struct uses indices to this vector to map lines to their
-     * original files. This allows us to point the user to the exact location
-     * of errors
-     */
-    file_list files;
 
     /*
      * \brief List of all the lines in the config (with included files)

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -96,10 +96,6 @@ struct line_t {
 class config_parser {
   public:
 
-    using valuemap_t = std::map<string, string>;
-    using sectionmap_t = std::map<string, valuemap_t>;
-    using file_list = vector<string>;
-
     config_parser(const logger& logger, string&& file, string&& bar);
 
     /**

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -144,6 +144,8 @@ class config_parser {
      *
      * This method directly resolves `include-file` directives and checks for
      * cyclic dependencies
+     *
+     * file is expected to be an already resolved absolute or relative path
      */
     void parse_file(string file, file_list path);
 

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -42,6 +42,18 @@ class syntax_error : public parser_error {
 };
 
 /**
+ * \brief syntax_error subclass for invalid names
+ */
+class invalid_name_error : public syntax_error {
+  public:
+    /**
+     * type is the type of name (Header, Key)
+     */
+    invalid_name_error(string type, string name)
+      : syntax_error(type + " '" + name + "' is an invalid name") {}
+};
+
+/**
  * \enum line_type
  * \brief All different types a line in a config can be
  */

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -237,6 +237,13 @@ class config_parser {
      */
     bool is_valid_name(string name);
 
+    /**
+     * \brief Whether or not an xresource manager should be used
+     *
+     * Is set to true if any ${xrdb...} references are found
+     */
+    bool use_xrm{false};
+
     const logger& m_log;
 
     /**

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -56,8 +56,8 @@ enum line_type {KEY, HEADER, COMMENT, EMPTY, UNKNOWN};
  */
 struct line_t {
   /**
-   * Whether or not this struct contains a "useful" line
-   * I set to true for header and key-value lines
+   * Whether or not this struct represents a "useful" line, a line that has
+   * any semantic significance (key-value or header line)
    * If false all other fields are not set.
    * Set this to false, if you want to return a line that has no effect
    * (for example when you parse a comment line)

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -192,6 +192,7 @@ class config_parser {
     /**
      * \brief Deterimes the type of a line read from a config file
      *
+     * Expects that line is trimmed
      * This only looks at the first character and doesn't check if the line is
      * actually syntactically correct.
      * HEADER ('['), COMMENT (';' or '#') and EMPTY (None) are uniquely

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <set>
 
 #include "common.hpp"
 #include "errors.hpp"
@@ -263,6 +264,16 @@ class config_parser {
      * \brief None of these characters can be used in the key and section names
      */
     string forbidden_chars{"\"'=;#[](){}:.$\\%"};
+
+    /*
+     * \brief List of names that cannot be used as section names
+     *
+     * These strings have inside references and so the section [self] could
+     * never be referenced.
+     */
+    std::set<string> reserved_section_names = {
+      "self", "BAR", "root",
+    };
 };
 
 POLYBAR_NS_END

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -1,0 +1,262 @@
+#pragma once
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "common.hpp"
+#include "errors.hpp"
+#include "components/logger.hpp"
+#include "utils/file.hpp"
+#include "utils/string.hpp"
+
+POLYBAR_NS
+
+/**
+ * \brief Generic exception for the config_parser
+ */
+DEFINE_ERROR(parser_error);
+
+/**
+ * \brief Exception object for syntax errors
+ *
+ * Contains filepath and line number where syntax error was found
+ */
+class syntax_error : public parser_error {
+
+  public:
+    /**
+     * Default values are used when the thrower doesn't know the position.
+     * parse_line has to catch, set the proper values and rethrow
+     */
+    syntax_error(string msg, string file = "", int line_no = -1)
+      : parser_error(msg), file(file), line_no(line_no), msg(msg) {}
+
+    virtual const char* what() const throw() {
+      return ("Syntax error at " + file + ":" + to_string(line_no) + " " + msg).c_str();
+    }
+
+  private:
+    string file;
+    int line_no;
+    string msg;
+};
+
+/**
+ * \enum line_type
+ * \brief All different types a line in a config can be
+ */
+enum line_type {KEY, HEADER, COMMENT, EMPTY, UNKNOWN};
+
+/**
+ * \struct line_t
+ * \brief Storage for a single config line
+ *
+ * More sanitized than the actual string of the comment line, with information
+ * about line type and structure
+ */
+struct line_t {
+  string header;
+  string key_value[2];
+
+  /**
+   * Whether or not this struct contains a valid line
+   * If false all other fields are not set
+   * Set this to false, if you want to return a line that has no effect
+   * (for example when you parse a comment line), do not use this to signal
+   * any kind of error, throw an exception instead
+   */
+  bool is_valid;
+
+  /**
+   * Index of the config_parser::files vector where this line is from
+   */
+  int file_index;
+  int line_no;
+
+  /**
+   * We access header, if is_header == true otherwise we access key_value
+   */
+  bool is_header;
+};
+
+using valuemap_t = std::unordered_map<string, string>;
+using sectionmap_t = std::map<string, valuemap_t>;
+using file_list = vector<string>;
+
+/**
+ * \brief Represents the whole configuration the user has given
+ */
+struct config_file {
+  /**
+   * Maps sections to a list of its key-value pairs
+   */
+  sectionmap_t sections;
+
+  /**
+   * Full path to the config file
+   */
+  string filename;
+
+  /**
+   * All files included by the config (not including itself)
+   *
+   */
+  file_list included;
+};
+
+class config_parser {
+  public:
+
+    config_parser(const logger& logger, string&& file);
+
+    /**
+     * \brief Performs the parsing of the main config file
+     *
+     * Goes through multiple steps:
+     * - Reads and parses all the lines in the config file while resolving
+     *   include-file directives and detecting cyclic dependencies in those
+     *   directives.
+     * - Builds a graph. The nodes are key value pairs and (u, v) is an edge,
+     *   when the value of u references v (via ${section.key} and the like)
+     * - The topological order is calculated. If that is not possible, there
+     *   are cyclic dependencies in the config and it is not valid. We reverse
+     *   the topological order, traverse the nodes in that order and
+     *   dereference all references. In the end no valid ${...} references
+     *   should be left.
+     * - Builds a second graph. The nodes are sections and (u, v) is and edge,
+     *   iff u has an inherit key that points to v.
+     * - The topological order of this second graph is calculated and all
+     *   sections without an inherit key are ignored.
+     * - The topological order is reversed, the sections are traversed in
+     *   that order, and the keys of the inherited sections are pulled in.
+     *   Here, there shouldn't be any inherit keys left.
+     * - Finally the data is put into a sectionmap_t
+     *
+     * \returns config_file struct containing a
+     *          section <-> list of key-value pair mapping for the caller to
+     *          be used. All references in the value strings will already have
+     *          been resolved and can be used without further processing.
+     *
+     * \throws syntax_error If there was any kind of syntax error
+     * \throws parser_error If aynthing else went wrong
+     */
+    config_file parse();
+
+  protected:
+
+    /**
+     * \brief Parses the given file and extracts key-value pairs and section
+     *        headers and adds them onto the `lines` vector
+     *
+     * This method directly resolves `include-file` directives and checks for
+     * cyclic dependencies
+     *
+     * It is assumed the file exists
+     */
+    void parse_file(string file, file_list path);
+
+    /**
+     * \brief Parses the given line string which occurs in files[file_index] on line
+     *        line_no and creates a line_t struct
+     *
+     * We use the INI file syntax (https://en.wikipedia.org/wiki/INI_file);
+     * Whitespaces (tested with isspace()) at the beginning and end of a line are ignored
+     * Keys and section names can contain any character except for the following:
+     * - spaces
+     * - equal sign (=)
+     * - semicolon (;)
+     * - pound sign (#)
+     * - Any kind of parentheses ([](){})
+     * - colon (:)
+     * - period (.)
+     * - dollar sign ($)
+     * - backslash (\)
+     * - percent sign (%)
+     * - single and double quotes ('")
+     * So basically any character that has any kind of special meaning is prohibited.
+     *
+     * Comment lines have to start with a semicolon (;) or a pound sign (#),
+     * you cannot put a comment after another type of line.
+     *
+     * key and section names are case-sensitive.
+     *
+     * Keys are specified as `key = value`, spaces around the equal sign, as
+     * well as double quotes around the value are ignored
+     *
+     * sections are defined as [section], everything inside the square brackets is part of the name
+     *
+     * \throws syntax_error if the line isn't well formed
+     */
+    line_t parse_line(int file_index, int line_no, string line);
+
+    /**
+     * \brief Deterimes the type of a line read from a config file
+     *
+     * This only looks at the first character and doesn't check if the line is
+     * actually syntactically correct.
+     * HEADER ('['), COMMENT (';' or '#') and EMPTY (None) are uniquely
+     * identified by their first character (or lack thereof). Any line that
+     * is none of the above and contains an equal sign, is treated as KEY.
+     * All others are UNKNOWN
+     */
+    line_type get_line_type(string line);
+
+    /**
+     * \brief Parse a line containing a section header and returns the header name
+     *
+     * Only assumes that the line starts with '[' and is trimmed
+     *
+     * \throws syntax_error if the line doesn't end with ']' or the header name
+     *         contains forbidden characters
+     */
+    string parse_header(string line);
+
+    /**
+     * \brief Parses a line containing a key-value pair and returns the key name
+     *        and the value string inside a std::pair
+     *
+     * Only assumes that the line contains '=' at least once and is trimmed
+     *
+     * \throws syntax_error if the key contains forbidden characters
+     */
+    std::pair<string, string> parse_key(string line);
+
+  private:
+
+    /**
+     * \brief Checks if the given name doesn't contain any spaces or characters
+     *        in config_parser::forbidden_chars
+     */
+    bool is_valid_name(string name);
+
+    const logger& m_log;
+
+    /**
+     * \brief Full path to the main config file
+     */
+    string m_file;
+
+    /**
+     * \brief Name of all the files the config includes values from
+     *
+     * The line_t struct uses indices to this vector to map lines to their
+     * original files. This allows us to point the user to the exact location
+     * of errors
+     */
+    file_list files;
+
+    /*
+     * \brief List of all the lines in the config (with included files)
+     *
+     * The order here matters, as we have not yet associated key-value pairs
+     * with sections
+     */
+    vector<line_t> lines;
+
+    /*
+     * \brief None of these characters can be used in the key and section names
+     */
+    static constexpr auto forbidden_chars = "\"'=;#[](){}:.$\\%";
+};
+
+POLYBAR_NS_END

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <unordered_map>
 
 #include "common.hpp"
 #include "errors.hpp"
@@ -97,9 +96,9 @@ struct line_t {
 class config_parser {
   public:
 
-  using valuemap_t = std::map<string, string>;
-  using sectionmap_t = std::map<string, valuemap_t>;
-  using file_list = vector<string>;
+    using valuemap_t = std::map<string, string>;
+    using sectionmap_t = std::map<string, valuemap_t>;
+    using file_list = vector<string>;
 
     config_parser(const logger& logger, string&& file, string&& bar);
 

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -26,18 +26,12 @@ class syntax_error : public parser_error {
      * Default values are used when the thrower doesn't know the position.
      * parse_line has to catch, set the proper values and rethrow
      */
-    syntax_error(string msg, string file = "", int line_no = -1)
-      : parser_error(msg), file(file), line_no(line_no), msg(msg) {}
-
-    virtual const char* what() const throw() {
-      return ("Syntax error at " + file + ":" + to_string(line_no) + " " + msg).c_str();
-    }
+    explicit syntax_error(string msg, string file = "", int line_no = -1)
+      : parser_error(file + ":" + to_string(line_no) + ": " + msg), msg(msg) {}
 
     string get_msg() { return msg; };
 
   private:
-    string file;
-    int line_no;
     string msg;
 };
 

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -52,7 +52,7 @@ class invalid_name_error : public syntax_error {
      * type is the type of name (Header, Key)
      */
     invalid_name_error(string type, string name)
-      : syntax_error(type + " '" + name + "' is an invalid name") {}
+      : syntax_error(type + " '" + name + "' contains forbidden characters.") {}
 };
 
 /**

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -25,13 +25,13 @@ class syntax_error : public parser_error {
      * Default values are used when the thrower doesn't know the position.
      * parse_line has to catch, set the proper values and rethrow
      */
-    explicit syntax_error(string msg, string file = "", int line_no = -1)
+    explicit syntax_error(const string& msg, const string& file = "", int line_no = -1)
       : parser_error(file + ":" + to_string(line_no) + ": " + msg), msg(msg) {}
 
-    string get_msg() { return msg; };
+    const string get_msg() { return msg; };
 
   private:
-    string msg;
+    const string& msg;
 };
 
 class invalid_name_error : public syntax_error {
@@ -39,7 +39,7 @@ class invalid_name_error : public syntax_error {
     /**
      * type is either Header or Key
      */
-    invalid_name_error(string type, string name)
+    invalid_name_error(const string& type, const string& name)
       : syntax_error(type + " '" + name + "' contains forbidden characters.") {}
 };
 
@@ -89,7 +89,7 @@ struct line_t {
 class config_parser {
   public:
 
-    config_parser(const logger& logger, string&& file, string&& bar);
+    config_parser(const logger& logger, const string&& file, const string&& bar);
 
     /**
      * \brief Performs the parsing of the main config file m_file
@@ -117,7 +117,7 @@ class config_parser {
      *
      * `file` is expected to be an already resolved absolute path
      */
-    void parse_file(string file, file_list path);
+    void parse_file(const string& file, file_list path);
 
     /**
      * \brief Parses the given line string to create a line_t struct
@@ -153,7 +153,7 @@ class config_parser {
      *         doesn't know about those. Whoever calls parse_line needs to
      *         catch those exceptions and set the file path and line number
      */
-    line_t parse_line(string line);
+    line_t parse_line(const string& line);
 
     /**
      * \brief Determines the type of a line read from a config file
@@ -166,7 +166,7 @@ class config_parser {
      * is none of the above and contains an equal sign, is treated as KEY.
      * All others are UNKNOWN
      */
-    line_type get_line_type(string line);
+    line_type get_line_type(const string& line);
 
     /**
      * \brief Parse a line containing a section header and returns the header name
@@ -176,7 +176,7 @@ class config_parser {
      * \throws syntax_error if the line doesn't end with ']' or the header name
      *         contains forbidden characters
      */
-    string parse_header(string line);
+    string parse_header(const string& line);
 
     /**
      * \brief Parses a line containing a key-value pair and returns the key name
@@ -186,7 +186,7 @@ class config_parser {
      *
      * \throws syntax_error if the key contains forbidden characters
      */
-    std::pair<string, string> parse_key(string line);
+    std::pair<string, string> parse_key(const string& line);
 
     /**
      * \brief Name of all the files the config includes values from
@@ -203,7 +203,7 @@ class config_parser {
      * \brief Checks if the given name doesn't contain any spaces or characters
      *        in config_parser::forbidden_chars
      */
-    bool is_valid_name(string name);
+    bool is_valid_name(const string& name);
 
     /**
      * \brief Whether or not an xresource manager should be used

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -164,14 +164,11 @@ class config_parser {
      *
      * This method directly resolves `include-file` directives and checks for
      * cyclic dependencies
-     *
-     * It is assumed the file exists
      */
     void parse_file(string file, file_list path);
 
     /**
-     * \brief Parses the given line string which occurs in files[file_index] on line
-     *        line_no and creates a line_t struct
+     * \brief Parses the given line string creates a line_t struct
      *
      * We use the INI file syntax (https://en.wikipedia.org/wiki/INI_file);
      * Whitespaces (tested with isspace()) at the beginning and end of a line are ignored
@@ -199,9 +196,12 @@ class config_parser {
      *
      * sections are defined as [section], everything inside the square brackets is part of the name
      *
-     * \throws syntax_error if the line isn't well formed
+     * \throws syntax_error if the line isn't well formed. The syntax error
+     *         does not contain the filename or line numbers because parse_line
+     *         doesn't know about those. Whoever calls parse_line needs to
+     *         catch those exceptions and set the file path and line number
      */
-    line_t parse_line(int file_index, int line_no, string line);
+    line_t parse_line(string line);
 
     /**
      * \brief Deterimes the type of a line read from a config file

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <set>
 
 #include "common.hpp"
@@ -72,12 +71,19 @@ struct line_t {
   int line_no;
 
   /**
-   * We access header, if is_header == true otherwise we access key_value
+   * We access header, if is_header == true otherwise we access key, value
    */
   bool is_header;
 
+  /**
+   * Only set for header lines
+   */
   string header;
-  string key_value[2];
+
+  /**
+   * Only set for key-value lines
+   */
+  string key, value;
 };
 
 class config_parser {

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -256,7 +256,7 @@ class config_parser {
     /*
      * \brief None of these characters can be used in the key and section names
      */
-    static constexpr auto forbidden_chars = "\"'=;#[](){}:.$\\%";
+    string forbidden_chars{"\"'=;#[](){}:.$\\%"};
 };
 
 POLYBAR_NS_END

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -57,13 +57,13 @@ enum line_type {KEY, HEADER, COMMENT, EMPTY, UNKNOWN};
  */
 struct line_t {
   /**
-   * Whether or not this struct contains a valid line
-   * If false all other fields are not set
+   * Whether or not this struct contains a "useful" line
+   * I set to true for header and key-value lines
+   * If false all other fields are not set.
    * Set this to false, if you want to return a line that has no effect
-   * (for example when you parse a comment line), do not use this to signal
-   * any kind of error, throw an exception instead
+   * (for example when you parse a comment line)
    */
-  bool is_valid;
+  bool useful;
 
   /**
    * Index of the config_parser::files vector where this line is from

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -67,9 +67,6 @@ enum line_type {KEY, HEADER, COMMENT, EMPTY, UNKNOWN};
  * about line type and structure
  */
 struct line_t {
-  string header;
-  string key_value[2];
-
   /**
    * Whether or not this struct contains a valid line
    * If false all other fields are not set
@@ -89,6 +86,9 @@ struct line_t {
    * We access header, if is_header == true otherwise we access key_value
    */
   bool is_header;
+
+  string header;
+  string key_value[2];
 };
 
 using valuemap_t = std::unordered_map<string, string>;

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -62,6 +62,11 @@ namespace string_util {
    */
   using hash_type = unsigned long;
 
+  /**
+   * Predicate that determines if a given character is not a space
+   */
+  auto isnospace_pred = [](int ch) { return !isspace(ch); };
+
   bool contains(const string& haystack, const string& needle);
   string upper(const string& s);
   string lower(const string& s);
@@ -76,6 +81,10 @@ namespace string_util {
 
   string strip(const string& haystack, char needle);
   string strip_trailing_newline(const string& haystack);
+
+  string ltrim(string value, function<bool(char)> pred);
+  string rtrim(string value, function<bool(char)> pred);
+  string trim(string value, function<bool(char)> pred);
 
   string ltrim(string&& value, const char& needle = ' ');
   string rtrim(string&& value, const char& needle = ' ');

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -65,7 +65,7 @@ namespace string_util {
   /**
    * Predicate that determines if a given character is not a space
    */
-  auto isnospace_pred = [](int ch) { return !isspace(ch); };
+  auto isspace_pred = [](int ch) { return isspace(ch); };
 
   bool contains(const string& haystack, const string& needle);
   string upper(const string& s);

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <sstream>
-#include <cstring>
 
 #include "common.hpp"
 
@@ -27,7 +26,7 @@ namespace {
       a.erase(a.size() - b.size());
     }
   }
-}
+}  // namespace
 
 class sstream {
  public:
@@ -61,11 +60,6 @@ namespace string_util {
    * Hash type
    */
   using hash_type = unsigned long;
-
-  /**
-   * Predicate that determines if a given character is not a space
-   */
-  auto isspace_pred = [](int ch) { return isspace(ch); };
 
   bool contains(const string& haystack, const string& needle);
   string upper(const string& s);
@@ -105,6 +99,6 @@ namespace string_util {
   string filesize(unsigned long long kbytes, size_t precision = 0, bool fixed = false, const string& locale = "");
 
   hash_type hash(const string& src);
-}
+}  // namespace string_util
 
 POLYBAR_NS_END

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -15,8 +15,8 @@ POLYBAR_NS
 /**
  * Create instance
  */
-config::make_type config::make(string path, string bar, sectionmap_t sections, file_list included, bool use_xrm) {
-  return *factory_util::singleton<std::remove_reference_t<config::make_type>>(logger::make(), move(path), move(bar), sections, included, use_xrm);
+config::make_type config::make(string path, string bar) {
+  return *factory_util::singleton<std::remove_reference_t<config::make_type>>(logger::make(), move(path), move(bar));
 }
 
 /**
@@ -31,6 +31,24 @@ string config::filepath() const {
  */
 string config::section() const {
   return "bar/" + m_barname;
+}
+
+void config::use_xrm() {
+#if WITH_XRM
+  // Initialize the xresource manager if there are any xrdb refs
+  // present in the configuration
+  if (!m_xrm) {
+    m_xrm.reset(new xresource_manager{connection::make()});
+  }
+#endif
+}
+
+void config::set_sections(sectionmap_t sections) {
+  m_sections = sections;
+}
+
+void config::set_included(file_list included) {
+  m_included = included;
 }
 
 /**

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -35,8 +35,10 @@ string config::section() const {
 
 void config::use_xrm() {
 #if WITH_XRM
-  // Initialize the xresource manager if there are any xrdb refs
-  // present in the configuration
+  /*
+   * Initialize the xresource manager if there are any xrdb refs
+   * present in the configuration
+   */
   if (!m_xrm) {
     m_log.info("Enabling xresource manager");
     m_xrm.reset(new xresource_manager{connection::make()});
@@ -69,7 +71,7 @@ void config::warn_deprecated(const string& section, const string& key, string re
  * Look for sections set up to inherit from a base section
  * and copy the missing parameters
  *
- *   [sub/seciton]
+ *   [sub/section]
  *   inherit = base/section
  */
 void config::copy_inherited() {
@@ -90,8 +92,10 @@ void config::copy_inherited() {
 
         m_log.trace("config: Copying missing params (sub=\"%s\", base=\"%s\")", section.first, inherit);
 
-        // Iterate the base and copy the parameters
-        // that hasn't been defined for the sub-section
+        /*
+         * Iterate the base and copy the parameters that haven't been defined
+         * for the sub-section
+         */
         for (auto&& base_param : base_section->second) {
           section.second.emplace(base_param.first, base_param.second);
         }

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -38,6 +38,7 @@ void config::use_xrm() {
   // Initialize the xresource manager if there are any xrdb refs
   // present in the configuration
   if (!m_xrm) {
+    m_log.info("Enabling xresource manager");
     m_xrm.reset(new xresource_manager{connection::make()});
   }
 #endif

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -6,8 +6,6 @@
 #include "utils/color.hpp"
 #include "utils/env.hpp"
 #include "utils/factory.hpp"
-#include "utils/file.hpp"
-#include "utils/math.hpp"
 #include "utils/string.hpp"
 
 POLYBAR_NS
@@ -22,7 +20,7 @@ config::make_type config::make(string path, string bar) {
 /**
  * Get path of loaded file
  */
-string config::filepath() const {
+const string& config::filepath() const {
   return m_file;
 }
 
@@ -47,12 +45,12 @@ void config::use_xrm() {
 }
 
 void config::set_sections(sectionmap_t sections) {
-  m_sections = sections;
+  m_sections = move(sections);
   copy_inherited();
 }
 
 void config::set_included(file_list included) {
-  m_included = included;
+  m_included = move(included);
 }
 
 /**
@@ -77,7 +75,7 @@ void config::warn_deprecated(const string& section, const string& key, string re
 void config::copy_inherited() {
   for (auto&& section : m_sections) {
     for (auto&& param : section.second) {
-      if(param.first == "inherit") {
+      if (param.first == "inherit") {
         // Get name of base section
         auto inherit = param.second;
         if ((inherit = dereference<string>(section.first, param.first, inherit, inherit)).empty()) {

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -15,37 +15,8 @@ POLYBAR_NS
 /**
  * Create instance
  */
-config::make_type config::make(string path, string bar) {
-  return *factory_util::singleton<std::remove_reference_t<config::make_type>>(logger::make(), move(path), move(bar));
-}
-
-/**
- * Construct config object
- */
-config::config(const logger& logger, string&& path, string&& bar)
-    : m_log(logger), m_file(forward<string>(path)), m_barname(forward<string>(bar)) {
-  if (!file_util::exists(m_file)) {
-    throw application_error("Could not find config file: " + m_file);
-  }
-
-  m_log.info("Loading config: %s", m_file);
-
-  parse_file();
-  copy_inherited();
-
-  bool found_bar{false};
-  for (auto&& p : m_sections) {
-    if (p.first == section()) {
-      found_bar = true;
-      break;
-    }
-  }
-
-  if (!found_bar) {
-    throw application_error("Undefined bar: " + m_barname);
-  }
-
-  m_log.trace("config: Current bar section: [%s]", section());
+config::make_type config::make(string path, string bar, sectionmap_t sections, file_list included) {
+  return *factory_util::singleton<std::remove_reference_t<config::make_type>>(logger::make(), move(path), move(bar), sections, included);
 }
 
 /**

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -46,6 +46,7 @@ void config::use_xrm() {
 
 void config::set_sections(sectionmap_t sections) {
   m_sections = sections;
+  copy_inherited();
 }
 
 void config::set_included(file_list included) {
@@ -74,7 +75,7 @@ void config::warn_deprecated(const string& section, const string& key, string re
 void config::copy_inherited() {
   for (auto&& section : m_sections) {
     for (auto&& param : section.second) {
-      if (param.first.find("inherit") == 0) {
+      if(param.first == "inherit") {
         // Get name of base section
         auto inherit = param.second;
         if ((inherit = dereference<string>(section.first, param.first, inherit, inherit)).empty()) {
@@ -92,7 +93,7 @@ void config::copy_inherited() {
         // Iterate the base and copy the parameters
         // that hasn't been defined for the sub-section
         for (auto&& base_param : base_section->second) {
-          section.second.insert(make_pair(base_param.first, base_param.second));
+          section.second.emplace(base_param.first, base_param.second);
         }
       }
     }

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -15,8 +15,8 @@ POLYBAR_NS
 /**
  * Create instance
  */
-config::make_type config::make(string path, string bar, sectionmap_t sections, file_list included) {
-  return *factory_util::singleton<std::remove_reference_t<config::make_type>>(logger::make(), move(path), move(bar), sections, included);
+config::make_type config::make(string path, string bar, sectionmap_t sections, file_list included, bool use_xrm) {
+  return *factory_util::singleton<std::remove_reference_t<config::make_type>>(logger::make(), move(path), move(bar), sections, included, use_xrm);
 }
 
 /**
@@ -42,106 +42,6 @@ void config::warn_deprecated(const string& section, const string& key, string re
     m_log.warn(
         "The config parameter `%s.%s` is deprecated, use `%s.%s` instead.", section, key, section, move(replacement));
   } catch (const key_error& err) {
-  }
-}
-
-/**
- * Parse key/value pairs from the configuration file
- */
-void config::parse_file() {
-  vector<pair<int, string>> lines;
-  vector<string> files{m_file};
-
-  std::function<void(int, string&&)> pushline = [&](int lineno, string&& line) {
-    // Ignore empty lines and comments
-    if (line.empty() || line[0] == ';' || line[0] == '#') {
-      return;
-    }
-
-    string key, value;
-    string::size_type pos;
-
-    // Filter lines by:
-    // - key/value pairs
-    // - section headers
-    if ((pos = line.find('=')) != string::npos) {
-      key = forward<string>(string_util::trim(forward<string>(line.substr(0, pos))));
-      value = forward<string>(string_util::trim(line.substr(pos + 1)));
-    } else if (line[0] != '[' || line[line.length() - 1] != ']') {
-      return;
-    }
-
-    if (key == "include-file") {
-      auto file_path = file_util::expand(value);
-      if (file_path.empty() || !file_util::exists(file_path)) {
-        throw value_error("Invalid include file \"" + file_path + "\" defined on line " + to_string(lineno));
-      }
-      if (std::find(files.begin(), files.end(), file_path) != files.end()) {
-        throw value_error("Recursive include file \"" + file_path + "\"");
-      }
-      files.push_back(file_util::expand(file_path));
-      m_log.trace("config: Including file \"%s\"", file_path);
-      for (auto&& l : string_util::split(file_util::contents(file_path), '\n')) {
-        pushline(lineno, forward<string>(l));
-      }
-      files.pop_back();
-    } else {
-      lines.emplace_back(make_pair(lineno, line));
-    }
-  };
-
-  int lineno{0};
-  string line;
-  std::ifstream in(m_file);
-  while (std::getline(in, line)) {
-    pushline(++lineno, string_util::replace_all(line, "\t", ""));
-  }
-
-  string section;
-  for (auto&& l : lines) {
-    auto& lineno = l.first;
-    auto& line = l.second;
-
-    // New section
-    if (line[0] == '[' && line[line.length() - 1] == ']') {
-      section = line.substr(1, line.length() - 2);
-      continue;
-    } else if (section.empty()) {
-      continue;
-    }
-
-    size_t equal_pos;
-
-    // Check for key-value pair equal sign
-    if ((equal_pos = line.find('=')) == string::npos) {
-      continue;
-    }
-
-    string key{forward<string>(string_util::trim(forward<string>(line.substr(0, equal_pos))))};
-    string value;
-
-    auto it = m_sections[section].find(key);
-    if (it != m_sections[section].end()) {
-      throw key_error("Duplicate key name \"" + key + "\" defined on line " + to_string(lineno));
-    }
-
-    if (equal_pos + 1 < line.size()) {
-      value = forward<string>(string_util::trim(line.substr(equal_pos + 1)));
-      size_t len{value.size()};
-      if (len > 2 && value[0] == '"' && value[len - 1] == '"') {
-        value.erase(len - 1, 1).erase(0, 1);
-      }
-    }
-
-#if WITH_XRM
-    // Initialize the xresource manage if there are any xrdb refs
-    // present in the configuration
-    if (!m_xrm && value.find("${xrdb") != string::npos) {
-      m_xrm.reset(new xresource_manager{connection::make()});
-    }
-#endif
-
-    m_sections[section].emplace_hint(it, move(key), move(value));
   }
 }
 

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -21,28 +21,59 @@ void config_parser::parse_file(string file, file_list path) {
 }
 
 line_t config_parser::parse_line(int file_index, int line_no, string line) {
-  return {};
+  line = string_util::trim(line, string_util::isnospace_pred);
+  line_type type = get_line_type(line);
+
+  line_t result = {};
+
+  result.file_index = file_index;
+  result.line_no = line_no;
+
+  if(type == EMPTY || type == COMMENT) {
+    result.is_valid = false;
+    return result;
+  }
+
+  if(type == UNKNOWN) {
+    // TODO handle syntax error
+  }
+
+  result.is_valid = true;
+
+  if(type == HEADER) {
+    result.is_header = true;
+    result.header = parse_header(line);
+  }
+
+  if(type == KEY) {
+    result.is_header = false;
+    auto key_value = parse_key(line);
+    result.key_value[0] = key_value.first;
+    result.key_value[1] = key_value.second;
+  }
+
+  return result;
 }
 
 line_type config_parser::get_line_type(string line) {
   if(line.empty()) {
-    return line_type::EMPTY;
+    return EMPTY;
   }
 
   switch (line[0]) {
     case '[':
-      return line_type::HEADER;
+      return HEADER;
 
     case ';':
     case '#':
-      return line_type::COMMENT;
+      return COMMENT;
 
     default:
       if(string_util::contains(line, "=")) {
-        return line_type::KEY;
+        return KEY;
       }
       else {
-        return line_type::UNKNOWN;
+        return UNKNOWN;
       }
   }
 }

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -130,7 +130,7 @@ void config_parser::parse_file(string file, file_list path) {
     if(!line.is_header && line.key_value[0] == "include-file") {
       file_list cloned_path(path);
 
-      parse_file(line.key_value[1], cloned_path);
+      parse_file(file_util::expand(line.key_value[1]), cloned_path);
     }
     else {
       lines.push_back(line);

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <algorithm>
 
 #include "components/config_parser.hpp"
 
@@ -59,8 +60,8 @@ sectionmap_t config_parser::create_sectionmap() {
             files[line.file_index], line.line_no);
       }
 
-      string key = line.key_value[0];
-      string value = line.key_value[1];
+      string key = line.key;
+      string value = line.value;
 
       valuemap_t& valuemap = sections[current_section];
 
@@ -145,10 +146,10 @@ void config_parser::parse_file(string file, file_list path) {
       continue;
     }
 
-    if(!line.is_header && line.key_value[0] == "include-file") {
+    if(!line.is_header && line.key == "include-file") {
       file_list cloned_path(path);
 
-      parse_file(file_util::expand(line.key_value[1]), cloned_path);
+      parse_file(file_util::expand(line.value), cloned_path);
     } else {
       lines.push_back(line);
     }
@@ -178,8 +179,8 @@ line_t config_parser::parse_line(string line) {
   } else if(type == KEY) {
     result.is_header = false;
     auto key_value = parse_key(line);
-    result.key_value[0] = key_value.first;
-    result.key_value[1] = key_value.second;
+    result.key = key_value.first;
+    result.value = key_value.second;
   }
 
   return result;

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -35,21 +35,29 @@ line_t config_parser::parse_line(int file_index, int line_no, string line) {
   }
 
   if(type == UNKNOWN) {
-    // TODO handle syntax error
+    throw syntax_error("Unknown line type " + line, files[file_index], line_no);
   }
 
   result.is_valid = true;
 
-  if(type == HEADER) {
-    result.is_header = true;
-    result.header = parse_header(line);
-  }
+  try {
+    if(type == HEADER) {
+      result.is_header = true;
+      result.header = parse_header(line);
+    }
 
-  if(type == KEY) {
-    result.is_header = false;
-    auto key_value = parse_key(line);
-    result.key_value[0] = key_value.first;
-    result.key_value[1] = key_value.second;
+    if(type == KEY) {
+      result.is_header = false;
+      auto key_value = parse_key(line);
+      result.key_value[0] = key_value.first;
+      result.key_value[1] = key_value.second;
+    }
+  } catch(syntax_error err) {
+    /*
+     * Exceptions thrown by the other parse functions don't have the line
+     * numbers and files set, so we have to add them here
+     */
+    throw syntax_error(err.get_msg(), files[file_index], line_no);
   }
 
   return result;

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -91,8 +91,7 @@ sectionmap_t config_parser::create_sectionmap() {
 void config_parser::parse_file(string file, file_list path) {
   if(std::find(path.begin(), path.end(), file) != path.end()) {
     // We have already parsed this file in this path, so there are cyclic dependencies
-    // TODO print dependency cycle
-    throw application_error("Cyclic dependency detected while parsing " + file);
+    throw application_error("include-file: Dependency cycle detected at " + file);
   }
 
   int file_index = files.size();

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -10,7 +10,7 @@ config_parser::config_parser(const logger& logger, string&& file, string&& bar)
   m_barname(forward<string>(bar)) {}
 
 config::make_type config_parser::parse() {
-  m_log.trace("Parsing config file: %s", m_file);
+  m_log.info("Parsing config file: %s", m_file);
 
   parse_file(m_file, {});
 
@@ -86,9 +86,19 @@ sectionmap_t config_parser::create_sectionmap() {
 
 void config_parser::parse_file(string file, file_list path) {
   if(std::find(path.begin(), path.end(), file) != path.end()) {
+    string path_str{};
+
+    for (auto p : path) {
+      path_str += ">\t" + p + "\n";
+    }
+
+    path_str += ">\t" + file;
+
     // We have already parsed this file in this path, so there are cyclic dependencies
-    throw application_error("include-file: Dependency cycle detected at " + file);
+    throw application_error("include-file: Dependency cycle detected:\n" + path_str);
   }
+
+  m_log.trace("config_parser: Parsing %s", file);
 
   int file_index = files.size();
   files.push_back(file);

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -54,9 +54,7 @@ sectionmap_t config_parser::create_sectionmap() {
       current_section = line.header;
     }
     else {
-      /*
-       * The first valid line in the config is not a section definition
-       */
+      // The first valid line in the config is not a section definition
       if(current_section == "") {
         throw syntax_error("First valid line in config must be section header",
             files[line.file_index], line.line_no);
@@ -64,8 +62,6 @@ sectionmap_t config_parser::create_sectionmap() {
 
       string key = line.key_value[0];
       string value = line.key_value[1];
-
-      // TODO check value for references
 
       valuemap_t& valuemap = sections[current_section];
 
@@ -207,6 +203,7 @@ string config_parser::parse_header(string line) {
     throw syntax_error("Missing ']' in header '" + line + "'");
   }
 
+  // Stripping square brackets
   string header = line.substr(1, line.size() - 2);
 
   if(!is_valid_name(header)) {
@@ -238,10 +235,10 @@ std::pair<string, string> config_parser::parse_key(string line) {
     value = value.substr(1, value.size() - 2);
   }
 
+  // TODO check value for references
+
 #if WITH_XRM
-  /*
-   * Use xrm, if at least one value is an xrdb reference
-   */
+  // Use xrm, if at least one value is an xrdb reference
   if(!use_xrm && value.find("${xrdb") == 0) {
     use_xrm = true;
   }

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -21,7 +21,7 @@ void config_parser::parse_file(string file, file_list path) {
 }
 
 line_t config_parser::parse_line(string line) {
-  line = string_util::trim(line, string_util::isnospace_pred);
+  line = string_util::trim(line, string_util::isspace_pred);
   line_type type = get_line_type(line);
 
   line_t result = {};
@@ -92,8 +92,8 @@ string config_parser::parse_header(string line) {
 std::pair<string, string> config_parser::parse_key(string line) {
   size_t pos = line.find_first_of('=');
 
-  string key = trim(line.substr(0, pos), string_util::isnospace_pred);
-  string value = trim(line.substr(pos + 1), string_util::isnospace_pred);
+  string key = trim(line.substr(0, pos), string_util::isspace_pred);
+  string value = trim(line.substr(pos + 1), string_util::isspace_pred);
 
   if(!is_valid_name(key)) {
     throw invalid_name_error("Key", key);

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -232,7 +232,7 @@ std::pair<string, string> config_parser::parse_key(string line) {
   /*
    * Use xrm, if at least one value is an xrdb reference
    */
-  if(!use_xrm && value.find("%{xrdb") == 0) {
+  if(!use_xrm && value.find("${xrdb") == 0) {
     use_xrm = true;
   }
 #endif

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -175,9 +175,7 @@ line_t config_parser::parse_line(string line) {
   if(type == HEADER) {
     result.is_header = true;
     result.header = parse_header(line);
-  }
-
-  if(type == KEY) {
+  } else if(type == KEY) {
     result.is_header = false;
     auto key_value = parse_key(line);
     result.key_value[0] = key_value.first;

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -1,23 +1,21 @@
-#include <fstream>
 #include <algorithm>
+#include <fstream>
 
 #include "components/config_parser.hpp"
 
 POLYBAR_NS
 
-config_parser::config_parser(const logger& logger, const string&& file, const string&& bar)
-  : m_log(logger),
-  m_file(file_util::expand(forward<const string>(file))),
-  m_barname(forward<const string>(bar)) {}
+config_parser::config_parser(const logger& logger, string&& file, string&& bar)
+    : m_log(logger), m_config(file_util::expand(file)), m_barname(move(bar)) {}
 
 config::make_type config_parser::parse() {
-  m_log.info("Parsing config file: %s", m_file);
+  m_log.info("Parsing config file: %s", m_config);
 
-  parse_file(m_file, {});
+  parse_file(m_config, {});
 
   sectionmap_t sections = create_sectionmap();
 
-  if(sections.find("bar/" + m_barname) == sections.end()) {
+  if (sections.find("bar/" + m_barname) == sections.end()) {
     throw application_error("Undefined bar: " + m_barname);
   }
 
@@ -26,15 +24,15 @@ config::make_type config_parser::parse() {
    * because it has unique filenames, we can use all the elements from the
    * second element onwards for the included list
    */
-  file_list included(files.begin() + 1, files.end());
-  config::make_type result = config::make(m_file, m_barname);
+  file_list included(m_files.begin() + 1, m_files.end());
+  config::make_type result = config::make(m_config, m_barname);
 
   // Cast to non-const to set sections, included and xrm
   config& m_conf = const_cast<config&>(result);
 
-  m_conf.set_sections(sections);
-  m_conf.set_included(included);
-  if(use_xrm) {
+  m_conf.set_sections(move(sections));
+  m_conf.set_included(move(included));
+  if (use_xrm) {
     m_conf.use_xrm();
   }
 
@@ -44,34 +42,32 @@ config::make_type config_parser::parse() {
 sectionmap_t config_parser::create_sectionmap() {
   sectionmap_t sections{};
 
-  string current_section = "";
+  string current_section{};
 
-  for(line_t line : lines) {
-    if(!line.useful) {
+  for (const line_t& line : m_lines) {
+    if (!line.useful) {
       continue;
     }
 
-    if(line.is_header) {
+    if (line.is_header) {
       current_section = line.header;
     } else {
       // The first valid line in the config is not a section definition
-      if(current_section == "") {
-        throw syntax_error("First valid line in config must be section header",
-            files[line.file_index], line.line_no);
+      if (current_section.empty()) {
+        throw syntax_error("First valid line in config must be section header", m_files[line.file_index], line.line_no);
       }
 
-      string key = line.key;
-      string value = line.value;
+      const string& key = line.key;
+      const string& value = line.value;
 
       valuemap_t& valuemap = sections[current_section];
 
-      if(valuemap.find(key) == valuemap.end()) {
+      if (valuemap.find(key) == valuemap.end()) {
         valuemap.emplace(key, value);
       } else {
         // Key already exists in this section
-        throw syntax_error("Duplicate key name \"" + key
-            + "\" defined in section \"" + current_section + "\"",
-            files[line.file_index], line.line_no);
+        throw syntax_error("Duplicate key name \"" + key + "\" defined in section \"" + current_section + "\"",
+            m_files[line.file_index], line.line_no);
       }
     }
   }
@@ -80,10 +76,10 @@ sectionmap_t config_parser::create_sectionmap() {
 }
 
 void config_parser::parse_file(const string& file, file_list path) {
-  if(std::find(path.begin(), path.end(), file) != path.end()) {
+  if (std::find(path.begin(), path.end(), file) != path.end()) {
     string path_str{};
 
-    for (auto p : path) {
+    for (const auto& p : path) {
       path_str += ">\t" + p + "\n";
     }
 
@@ -97,11 +93,11 @@ void config_parser::parse_file(const string& file, file_list path) {
 
   int file_index;
 
-  auto found = std::find(files.begin(), files.end(), file);
+  auto found = std::find(m_files.begin(), m_files.end(), file);
 
-  if(found == files.end()) {
-    file_index = files.size();
-    files.push_back(file);
+  if (found == m_files.end()) {
+    file_index = m_files.size();
+    m_files.push_back(file);
   } else {
     /*
      * `file` is already in the `files` vector so we calculate its index.
@@ -109,14 +105,14 @@ void config_parser::parse_file(const string& file, file_list path) {
      * This means that the file was already parsed, this can happen without
      * cyclic dependencies, if the file is included twice
      */
-    file_index = found - files.begin();
+    file_index = found - m_files.begin();
   }
 
   path.push_back(file);
 
   int line_no = 0;
 
-  string line_str;
+  string line_str{};
 
   std::ifstream in(file);
 
@@ -133,48 +129,48 @@ void config_parser::parse_file(const string& file, file_list path) {
       // parse_line doesn't set these
       line.file_index = file_index;
       line.line_no = line_no;
-    } catch(syntax_error& err) {
+    } catch (syntax_error& err) {
       /*
        * Exceptions thrown by parse_line doesn't have the line
        * numbers and files set, so we have to add them here
        */
-      throw syntax_error(err.get_msg(), files[file_index], line_no);
+      throw syntax_error(err.get_msg(), m_files[file_index], line_no);
     }
 
     // Skip useless lines (comments, empty lines)
-    if(!line.useful) {
+    if (!line.useful) {
       continue;
     }
 
-    if(!line.is_header && line.key == "include-file") {
+    if (!line.is_header && line.key == "include-file") {
       parse_file(file_util::expand(line.value), path);
     } else {
-      lines.push_back(line);
+      m_lines.push_back(line);
     }
   }
 }
 
 line_t config_parser::parse_line(const string& line) {
-  string line_trimmed = string_util::trim(line, string_util::isspace_pred);
+  string line_trimmed = string_util::trim(line, isspace);
   line_type type = get_line_type(line_trimmed);
 
   line_t result = {};
 
-  if(type == EMPTY || type == COMMENT) {
+  if (type == line_type::EMPTY || type == line_type::COMMENT) {
     result.useful = false;
     return result;
   }
 
-  if(type == UNKNOWN) {
+  if (type == line_type::UNKNOWN) {
     throw syntax_error("Unknown line type: " + line_trimmed);
   }
 
   result.useful = true;
 
-  if(type == HEADER) {
+  if (type == line_type::HEADER) {
     result.is_header = true;
     result.header = parse_header(line_trimmed);
-  } else if(type == KEY) {
+  } else if (type == line_type::KEY) {
     result.is_header = false;
     auto key_value = parse_key(line_trimmed);
     result.key = key_value.first;
@@ -185,40 +181,40 @@ line_t config_parser::parse_line(const string& line) {
 }
 
 line_type config_parser::get_line_type(const string& line) {
-  if(line.empty()) {
-    return EMPTY;
+  if (line.empty()) {
+    return line_type::EMPTY;
   }
 
   switch (line[0]) {
     case '[':
-      return HEADER;
+      return line_type::HEADER;
 
     case ';':
     case '#':
-      return COMMENT;
+      return line_type::COMMENT;
 
     default:
-      if(string_util::contains(line, "=")) {
-        return KEY;
+      if (string_util::contains(line, "=")) {
+        return line_type::KEY;
       } else {
-        return UNKNOWN;
+        return line_type::UNKNOWN;
       }
   }
 }
 
 string config_parser::parse_header(const string& line) {
-  if(line.back() != ']') {
+  if (line.back() != ']') {
     throw syntax_error("Missing ']' in header '" + line + "'");
   }
 
   // Stripping square brackets
   string header = line.substr(1, line.size() - 2);
 
-  if(!is_valid_name(header)) {
+  if (!is_valid_name(header)) {
     throw invalid_name_error("Section", header);
   }
 
-  if(reserved_section_names.find(header) != reserved_section_names.end()) {
+  if (m_reserved_section_names.find(header) != m_reserved_section_names.end()) {
     throw syntax_error("'" + header + "' is reserved and cannot be used as a section name");
   }
 
@@ -228,10 +224,10 @@ string config_parser::parse_header(const string& line) {
 std::pair<string, string> config_parser::parse_key(const string& line) {
   size_t pos = line.find_first_of('=');
 
-  string key = trim(line.substr(0, pos), string_util::isspace_pred);
-  string value = trim(line.substr(pos + 1), string_util::isspace_pred);
+  string key = string_util::trim(line.substr(0, pos), isspace);
+  string value = string_util::trim(line.substr(pos + 1), isspace);
 
-  if(!is_valid_name(key)) {
+  if (!is_valid_name(key)) {
     throw invalid_name_error("Key", key);
   }
 
@@ -239,7 +235,7 @@ std::pair<string, string> config_parser::parse_key(const string& line) {
    * Only if the string is surrounded with double quotes, do we treat them
    * not as part of the value and remove them.
    */
-  if(value.size() >= 2 && value.front() == '"' && value.back() == '"') {
+  if (value.size() >= 2 && value.front() == '"' && value.back() == '"') {
     value = value.substr(1, value.size() - 2);
   }
 
@@ -247,25 +243,24 @@ std::pair<string, string> config_parser::parse_key(const string& line) {
 
 #if WITH_XRM
   // Use xrm, if at least one value is an xrdb reference
-  if(!use_xrm && value.find("${xrdb") == 0) {
+  if (!use_xrm && value.find("${xrdb") == 0) {
     use_xrm = true;
   }
 #endif
 
-  return {key, value};
+  return {move(key), move(value)};
 }
 
 bool config_parser::is_valid_name(const string& name) {
-  if(name.empty()) {
+  if (name.empty()) {
     return false;
   }
 
-  for (size_t i = 0; i < name.size(); i++) {
-    char c = name[i];
+  for (const char c : name) {
     // Names with forbidden chars or spaces are not valid
-    if(isspace(c) || forbidden_chars.find_first_of(c) != string::npos) {
-        return false;
-      }
+    if (isspace(c) || m_forbidden_chars.find_first_of(c) != string::npos) {
+      return false;
+    }
   }
 
   return true;

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -25,7 +25,26 @@ line_t config_parser::parse_line(int file_index, int line_no, string line) {
 }
 
 line_type config_parser::get_line_type(string line) {
-  return line_type::UNKNOWN;
+  if(line.empty()) {
+    return line_type::EMPTY;
+  }
+
+  switch (line[0]) {
+    case '[':
+      return line_type::HEADER;
+
+    case ';':
+    case '#':
+      return line_type::COMMENT;
+
+    default:
+      if(string_util::contains(line, "=")) {
+        return line_type::KEY;
+      }
+      else {
+        return line_type::UNKNOWN;
+      }
+  }
 }
 
 string config_parser::parse_header(string line) {

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -226,6 +226,15 @@ std::pair<string, string> config_parser::parse_key(string line) {
     value = value.substr(1, value.size() - 2);
   }
 
+#if WITH_XRM
+  /*
+   * Use xrm, if at least one value is an xrdb reference
+   */
+  if(!use_xrm && value.find("%{xrdb") == 0) {
+    use_xrm = true;
+  }
+#endif
+
   return {key, value};
 }
 

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -236,8 +236,8 @@ std::pair<string, string> config_parser::parse_key(const string& line) {
   }
 
   /*
-   * Remove double quotes around value, only if it starts end ends with
-   * double quotes
+   * Only if the string is surrounded with double quotes, do we treat them
+   * not as part of the value and remove them.
    */
   if(value.size() >= 2 && value.front() == '"' && value.back() == '"') {
     value = value.substr(1, value.size() - 2);

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -205,6 +205,10 @@ string config_parser::parse_header(string line) {
     throw invalid_name_error("Section", header);
   }
 
+  if(reserved_section_names.find(header) != reserved_section_names.end()) {
+    throw syntax_error("'" + header + "' is reserved and cannot be used as a section name");
+  }
+
   return header;
 }
 

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -44,7 +44,7 @@ config::make_type config_parser::parse() {
   return result;
 }
 
-config_parser::sectionmap_t config_parser::create_sectionmap() {
+sectionmap_t config_parser::create_sectionmap() {
   sectionmap_t sections{};
 
   string current_section = "";

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -202,7 +202,7 @@ string config_parser::parse_header(string line) {
   string header = line.substr(1, line.size() - 2);
 
   if(!is_valid_name(header)) {
-    throw invalid_name_error("Header", header);
+    throw invalid_name_error("Section", header);
   }
 
   return header;

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -30,7 +30,18 @@ config::make_type config_parser::parse() {
    * second element onwards for the included list
    */
   file_list included(files.begin() + 1, files.end());
-  return config::make(m_file, m_barname, sections, included, use_xrm);
+  config::make_type result = config::make(m_file, m_barname);
+
+  // Cast to non-const to set sections, included and xrm
+  config& m_conf = const_cast<config&>(result);
+
+  m_conf.set_sections(sections);
+  m_conf.set_included(included);
+  if(use_xrm) {
+    m_conf.use_xrm();
+  }
+
+  return result;
 }
 
 config_parser::sectionmap_t config_parser::create_sectionmap() {

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -29,7 +29,17 @@ line_type config_parser::get_line_type(string line) {
 }
 
 string config_parser::parse_header(string line) {
-  return "";
+  if(line.back() != ']') {
+    throw syntax_error("Missing ']' in header '" + line + "'");
+  }
+
+  string header = line.substr(1, line.size() - 2);
+
+  if(!is_valid_name(header)) {
+    throw syntax_error("Header '" + header + "' contains forbidden characters");
+  }
+
+  return header;
 }
 
 std::pair<string, string> config_parser::parse_key(string line) {
@@ -37,7 +47,19 @@ std::pair<string, string> config_parser::parse_key(string line) {
 }
 
 bool config_parser::is_valid_name(string name) {
-  return false;
+  if(name.empty()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < name.size(); i++) {
+    char c = name[i];
+    // Names with forbidden chars or spaces are not valid
+    if(isspace(c) || forbidden_chars.find_first_of(c) != string::npos) {
+        return false;
+      }
+  }
+
+  return true;
 }
 
 POLYBAR_NS_END

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -7,11 +7,7 @@ POLYBAR_NS
 config_parser::config_parser(const logger& logger, string&& file, string&& bar)
   : m_log(logger),
   m_file(forward<string>(file)),
-  m_barname(forward<string>(bar)) {
-  if (!file_util::exists(m_file)) {
-    throw application_error("Could not find config file: " + m_file);
-  }
-}
+  m_barname(forward<string>(bar)) {}
 
 config::make_type config_parser::parse() {
   m_log.trace("Parsing config file: %s", m_file);
@@ -102,8 +98,12 @@ void config_parser::parse_file(string file, file_list path) {
 
   string line_str;
 
-  // TODO error handling
   std::ifstream in(file);
+
+  if (!in) {
+    throw application_error("Failed to open config file " + file + ": " + strerror(errno));
+  }
+
   while (std::getline(in, line_str)) {
     line_no++;
     line_t line;
@@ -134,7 +134,6 @@ void config_parser::parse_file(string file, file_list path) {
     else {
       lines.push_back(line);
     }
-
   }
 }
 

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -94,8 +94,23 @@ void config_parser::parse_file(string file, file_list path) {
 
   m_log.trace("config_parser: Parsing %s", file);
 
-  int file_index = files.size();
-  files.push_back(file);
+  int file_index;
+
+  auto found = std::find(files.begin(), files.end(), file);
+
+  if(found == files.end()) {
+    file_index = files.size();
+    files.push_back(file);
+  } else {
+    /*
+     * `file` is already in the `files` vector so we calculate its index.
+     *
+     * This means that the file was already parsed, this can happen without
+     * cyclic dependencies, if the file is included twice
+     */
+    file_index = found - files.begin();
+  }
+
   path.push_back(file);
 
   int line_no = 0;

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -1,0 +1,43 @@
+#include "components/config_parser.hpp"
+
+POLYBAR_NS
+
+config_parser::config_parser(const logger& logger, string&& file)
+  : m_log(logger), m_file(forward<string>(file)) {
+
+    if (!file_util::exists(m_file)) {
+      throw application_error("Could not find config file: " + m_file);
+    }
+
+    m_log.trace("Parsing config file: %s", m_file);
+
+  }
+
+config_file parse() {
+  return {};
+}
+
+void config_parser::parse_file(string file, file_list path) {
+}
+
+line_t config_parser::parse_line(int file_index, int line_no, string line) {
+  return {};
+}
+
+line_type config_parser::get_line_type(string line) {
+  return line_type::UNKNOWN;
+}
+
+string config_parser::parse_header(string line) {
+  return "";
+}
+
+std::pair<string, string> config_parser::parse_key(string line) {
+  return {"", ""};
+}
+
+bool config_parser::is_valid_name(string name) {
+  return false;
+}
+
+POLYBAR_NS_END

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -52,8 +52,7 @@ sectionmap_t config_parser::create_sectionmap() {
 
     if(line.is_header) {
       current_section = line.header;
-    }
-    else {
+    } else {
       // The first valid line in the config is not a section definition
       if(current_section == "") {
         throw syntax_error("First valid line in config must be section header",
@@ -67,8 +66,7 @@ sectionmap_t config_parser::create_sectionmap() {
 
       if(valuemap.find(key) == valuemap.end()) {
         valuemap.emplace(key, value);
-      }
-      else {
+      } else {
         // Key already exists in this section
         throw syntax_error("Duplicate key name \"" + key
             + "\" defined in section \"" + current_section + "\"",
@@ -136,8 +134,7 @@ void config_parser::parse_file(string file, file_list path) {
       file_list cloned_path(path);
 
       parse_file(file_util::expand(line.key_value[1]), cloned_path);
-    }
-    else {
+    } else {
       lines.push_back(line);
     }
   }
@@ -191,8 +188,7 @@ line_type config_parser::get_line_type(string line) {
     default:
       if(string_util::contains(line, "=")) {
         return KEY;
-      }
-      else {
+      } else {
         return UNKNOWN;
       }
   }

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -6,7 +6,7 @@ POLYBAR_NS
 
 config_parser::config_parser(const logger& logger, string&& file, string&& bar)
   : m_log(logger),
-  m_file(forward<string>(file)),
+  m_file(file_util::expand(forward<string>(file))),
   m_barname(forward<string>(bar)) {}
 
 config::make_type config_parser::parse() {

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -30,7 +30,7 @@ config::make_type config_parser::parse() {
    * second element onwards for the included list
    */
   file_list included(files.begin() + 1, files.end());
-  return config::make(m_file, m_barname, sections, included);
+  return config::make(m_file, m_barname, sections, included, use_xrm);
 }
 
 config_parser::sectionmap_t config_parser::create_sectionmap() {

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -20,14 +20,11 @@ config_file parse() {
 void config_parser::parse_file(string file, file_list path) {
 }
 
-line_t config_parser::parse_line(int file_index, int line_no, string line) {
+line_t config_parser::parse_line(string line) {
   line = string_util::trim(line, string_util::isnospace_pred);
   line_type type = get_line_type(line);
 
   line_t result = {};
-
-  result.file_index = file_index;
-  result.line_no = line_no;
 
   if(type == EMPTY || type == COMMENT) {
     result.is_valid = false;
@@ -35,29 +32,21 @@ line_t config_parser::parse_line(int file_index, int line_no, string line) {
   }
 
   if(type == UNKNOWN) {
-    throw syntax_error("Unknown line type " + line, files[file_index], line_no);
+    throw syntax_error("Unknown line type " + line);
   }
 
   result.is_valid = true;
 
-  try {
-    if(type == HEADER) {
-      result.is_header = true;
-      result.header = parse_header(line);
-    }
+  if(type == HEADER) {
+    result.is_header = true;
+    result.header = parse_header(line);
+  }
 
-    if(type == KEY) {
-      result.is_header = false;
-      auto key_value = parse_key(line);
-      result.key_value[0] = key_value.first;
-      result.key_value[1] = key_value.second;
-    }
-  } catch(syntax_error err) {
-    /*
-     * Exceptions thrown by the other parse functions don't have the line
-     * numbers and files set, so we have to add them here
-     */
-    throw syntax_error(err.get_msg(), files[file_index], line_no);
+  if(type == KEY) {
+    result.is_header = false;
+    auto key_value = parse_key(line);
+    result.key_value[0] = key_value.first;
+    result.key_value[1] = key_value.second;
   }
 
   return result;

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -55,14 +55,31 @@ string config_parser::parse_header(string line) {
   string header = line.substr(1, line.size() - 2);
 
   if(!is_valid_name(header)) {
-    throw syntax_error("Header '" + header + "' contains forbidden characters");
+    throw invalid_name_error("Header", header);
   }
 
   return header;
 }
 
 std::pair<string, string> config_parser::parse_key(string line) {
-  return {"", ""};
+  size_t pos = line.find_first_of('=');
+
+  string key = trim(line.substr(0, pos), string_util::isnospace_pred);
+  string value = trim(line.substr(pos + 1), string_util::isnospace_pred);
+
+  if(!is_valid_name(key)) {
+    throw invalid_name_error("Key", key);
+  }
+
+  /*
+   * Remove double quotes around value, only if it starts end ends with
+   * double quotes
+   */
+  if(value.size() >= 2 && value.front() == '"' && value.back() == '"') {
+    value = value.substr(1, value.size() - 2);
+  }
+
+  return {key, value};
 }
 
 bool config_parser::is_valid_name(string name) {

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -46,7 +46,7 @@ sectionmap_t config_parser::create_sectionmap() {
   string current_section = "";
 
   for(line_t line : lines) {
-    if(!line.is_valid) {
+    if(!line.useful) {
       continue;
     }
 
@@ -140,8 +140,8 @@ void config_parser::parse_file(string file, file_list path) {
       throw syntax_error(err.get_msg(), files[file_index], line_no);
     }
 
-    // Not valid means 'not important to us' and never implies a syntax error
-    if(!line.is_valid) {
+    // Skip useless lines (comments, empty lines)
+    if(!line.useful) {
       continue;
     }
 
@@ -162,15 +162,15 @@ line_t config_parser::parse_line(string line) {
   line_t result = {};
 
   if(type == EMPTY || type == COMMENT) {
-    result.is_valid = false;
+    result.useful = false;
     return result;
   }
 
   if(type == UNKNOWN) {
-    throw syntax_error("Unknown line type " + line);
+    throw syntax_error("Unknown line type: " + line);
   }
 
-  result.is_valid = true;
+  result.useful = true;
 
   if(type == HEADER) {
     result.is_header = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,7 +82,8 @@ int main(int argc, char** argv) {
           printf("%s: %ix%i+%i+%i (XRandR monitor%s)\n", mon->name.c_str(), mon->w, mon->h, mon->x, mon->y,
               mon->primary ? ", primary" : "");
         } else {
-          printf("%s: %ix%i+%i+%i%s\n", mon->name.c_str(), mon->w, mon->h, mon->x, mon->y, mon->primary ? " (primary)" : "");
+          printf("%s: %ix%i+%i+%i%s\n", mon->name.c_str(), mon->w, mon->h, mon->x, mon->y,
+              mon->primary ? " (primary)" : "");
         }
       }
       return EXIT_SUCCESS;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "components/bar.hpp"
 #include "components/command_line.hpp"
 #include "components/config.hpp"
+#include "components/config_parser.hpp"
 #include "components/controller.hpp"
 #include "components/ipc.hpp"
 #include "utils/env.hpp"
@@ -112,7 +113,8 @@ int main(int argc, char** argv) {
       throw application_error("Define configuration using --config=PATH");
     }
 
-    config::make_type conf{config::make(move(confpath), cli->get(0))};
+    config_parser parser{logger, move(confpath), cli->get(0)};
+    config::make_type conf = parser.parse();
 
     //==================================================
     // Dump requested data

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -111,6 +111,29 @@ namespace string_util {
   }
 
   /**
+   * Trims all characters that match pred from the left
+   */
+  string ltrim(string value, function<bool(char)> pred) {
+    value.erase(value.begin(), find_if(value.begin(), value.end(), pred));
+    return value;
+  }
+
+  /**
+   * Trims all characters that match pred from the right
+   */
+  string rtrim(string value, function<bool(char)> pred) {
+    value.erase(find_if(value.rbegin(), value.rend(), pred).base(), value.end());
+    return value;
+  }
+
+  /**
+   * Trims all characters that match pred from both sides
+   */
+  string trim(string value, function<bool(char)> pred) {
+    return ltrim(rtrim(value, pred), pred);
+  }
+
+  /**
    * Remove needle from the start of the string
    */
   string ltrim(string&& value, const char& needle) {

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cstring>
 #include <iomanip>
 #include <sstream>
 #include <utility>
@@ -130,7 +129,7 @@ namespace string_util {
    * Trims all characters that match pred from both sides
    */
   string trim(string value, function<bool(char)> pred) {
-    return ltrim(rtrim(value, pred), pred);
+    return ltrim(rtrim(move(value), pred), pred);
   }
 
   /**
@@ -298,6 +297,6 @@ namespace string_util {
   hash_type hash(const string& src) {
     return std::hash<string>()(src);
   }
-}
+}  // namespace string_util
 
 POLYBAR_NS_END

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -114,7 +114,7 @@ namespace string_util {
    * Trims all characters that match pred from the left
    */
   string ltrim(string value, function<bool(char)> pred) {
-    value.erase(value.begin(), find_if(value.begin(), value.end(), pred));
+    value.erase(value.begin(), find_if(value.begin(), value.end(), not1(pred)));
     return value;
   }
 
@@ -122,7 +122,7 @@ namespace string_util {
    * Trims all characters that match pred from the right
    */
   string rtrim(string value, function<bool(char)> pred) {
-    value.erase(find_if(value.rbegin(), value.rend(), pred).base(), value.end());
+    value.erase(find_if(value.rbegin(), value.rend(), not1(pred)).base(), value.end());
     return value;
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_unit_test(components/command_line)
 add_unit_test(components/bar)
 add_unit_test(components/builder)
 add_unit_test(components/parser)
+add_unit_test(components/config_parser)
 
 # Run make check to build and run all unit tests
 add_custom_target(check

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -16,6 +16,7 @@ class TestableConfigParser : public config_parser {
   public: using config_parser::parse_key;
   public: using config_parser::parse_header;
   public: using config_parser::parse_line;
+  public: using config_parser::files;
 };
 
 /**
@@ -24,6 +25,10 @@ class TestableConfigParser : public config_parser {
 class ConfigParser : public ::testing::Test {
   protected:
     unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero");
+
+    virtual void SetUp() {
+      parser->files = {"file1", "file2", "file3"};
+    }
 };
 
 // ParseLineTest {{{
@@ -107,6 +112,10 @@ TEST_P(ParseLineKeyTest, correctness) {
   EXPECT_FALSE(line.is_header);
   EXPECT_EQ(GetParam().first.first, line.key_value[0]);
   EXPECT_EQ(GetParam().first.second, line.key_value[1]);
+}
+
+TEST_F(ParseLineInValidTest, throwsSyntaxError) {
+  EXPECT_THROW(parser->parse_line(FILE_INDEX, LINE_NO, "unknown"), syntax_error);
 }
 // }}}
 

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -70,7 +70,7 @@ INSTANTIATE_TEST_CASE_P(Inst, ParseLineInValidTest,
 TEST_P(ParseLineInValidTest, correctness) {
   line_t line = parser->parse_line(GetParam());
 
-  EXPECT_FALSE(line.is_valid);
+  EXPECT_FALSE(line.useful);
 }
 
 INSTANTIATE_TEST_CASE_P(Inst, ParseLineHeaderTest,
@@ -79,7 +79,7 @@ INSTANTIATE_TEST_CASE_P(Inst, ParseLineHeaderTest,
 TEST_P(ParseLineHeaderTest, correctness) {
   line_t line = parser->parse_line(GetParam().second);
 
-  EXPECT_TRUE(line.is_valid);
+  EXPECT_TRUE(line.useful);
 
   EXPECT_TRUE(line.is_header);
   EXPECT_EQ(GetParam().first, line.header);
@@ -91,7 +91,7 @@ INSTANTIATE_TEST_CASE_P(Inst, ParseLineKeyTest,
 TEST_P(ParseLineKeyTest, correctness) {
   line_t line = parser->parse_line(GetParam().second);
 
-  EXPECT_TRUE(line.is_valid);
+  EXPECT_TRUE(line.useful);
 
   EXPECT_FALSE(line.is_header);
   EXPECT_EQ(GetParam().first.first, line.key_value[0]);

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -122,6 +122,7 @@ TEST_P(ParseKeyTest, correctness) {
  * Tests if exception is thrown for invalid key line
  */
 TEST_F(ParseKeyTest, throwsSyntaxError) {
+  EXPECT_THROW(parser->parse_key("= empty name"), syntax_error);
   EXPECT_THROW(parser->parse_key("forbidden char = value"), syntax_error);
   EXPECT_THROW(parser->parse_key("forbidden\tchar = value"), syntax_error);
 }
@@ -159,6 +160,7 @@ TEST_P(ParseHeaderTest, correctness) {
  * Tests if exception is thrown for invalid header line
  */
 TEST_F(ParseHeaderTest, throwsSyntaxError) {
+  EXPECT_THROW(parser->parse_header("[]"), syntax_error);
   EXPECT_THROW(parser->parse_header("[no_end"), syntax_error);
   EXPECT_THROW(parser->parse_header("[forbidden char]"), syntax_error);
   EXPECT_THROW(parser->parse_header("[forbidden\tchar]"), syntax_error);

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -106,6 +106,7 @@ vector<pair<pair<string, string>, string>> parse_key_list = {
   {{"key", "= value"}, "key == value"},
   {{"key", ""}, "key ="},
   {{"key", ""}, "key =\"\""},
+  {{"key", "\"\""}, "key =\"\"\"\""},
 };
 
 INSTANTIATE_TEST_CASE_P(Inst, ParseKeyTest,

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -239,5 +239,10 @@ TEST_F(ParseHeaderTest, throwsSyntaxError) {
   EXPECT_THROW(parser->parse_header("[no_end"), syntax_error);
   EXPECT_THROW(parser->parse_header("[forbidden char]"), syntax_error);
   EXPECT_THROW(parser->parse_header("[forbidden\tchar]"), syntax_error);
+
+  // Reserved names
+  EXPECT_THROW(parser->parse_header("[self]"), syntax_error);
+  EXPECT_THROW(parser->parse_header("[BAR]"), syntax_error);
+  EXPECT_THROW(parser->parse_header("[root]"), syntax_error);
 }
 // }}}

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -60,9 +60,9 @@ vector<pair<line_type, string>> line_type_transform(vector<string> in, line_type
  * \brief Parameter values for GetLineTypeTest
  */
 auto line_type_key = line_type_transform({"a = b", "  a =b", " a\t =\t \t b", "a = "}, line_type::KEY);
-auto line_type_header = line_type_transform({"[section]", " [section]", "[section/sub]"}, line_type::HEADER);
-auto line_type_comment = line_type_transform({";abc", "#abc", "\t;abc", " #abc", "\t \t;abc"}, line_type::COMMENT);
-auto line_type_empty = line_type_transform({"", " ", "\t" "   \t  \t"}, line_type::EMPTY);
+auto line_type_header = line_type_transform({"[section]", "[section]", "[section/sub]"}, line_type::HEADER);
+auto line_type_comment = line_type_transform({";abc", "#abc", ";", "#"}, line_type::COMMENT);
+auto line_type_empty = line_type_transform({""}, line_type::EMPTY);
 auto line_type_unknown = line_type_transform({"|a", " |a", "a"}, line_type::UNKNOWN);
 
 /**

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -25,16 +25,9 @@ class TestableConfigParser : public config_parser {
 class ConfigParser : public ::testing::Test {
   protected:
     unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero");
-
-    virtual void SetUp() {
-      parser->files = {"file1", "file2", "file3"};
-    }
 };
 
 // ParseLineTest {{{
-#define LINE_NO 1
-#define FILE_INDEX 2
-
 class ParseLineInValidTest :
   public ConfigParser,
   public ::testing::WithParamInterface<string> {
@@ -75,10 +68,7 @@ INSTANTIATE_TEST_CASE_P(Inst, ParseLineInValidTest,
     ::testing::ValuesIn(parse_line_invalid_list),);
 
 TEST_P(ParseLineInValidTest, correctness) {
-  line_t line = parser->parse_line(FILE_INDEX, LINE_NO, GetParam());
-
-  EXPECT_EQ(FILE_INDEX, line.file_index);
-  EXPECT_EQ(LINE_NO, line.line_no);
+  line_t line = parser->parse_line(GetParam());
 
   EXPECT_FALSE(line.is_valid);
 }
@@ -87,10 +77,7 @@ INSTANTIATE_TEST_CASE_P(Inst, ParseLineHeaderTest,
     ::testing::ValuesIn(parse_line_header_list),);
 
 TEST_P(ParseLineHeaderTest, correctness) {
-  line_t line = parser->parse_line(FILE_INDEX, LINE_NO, GetParam().second);
-
-  EXPECT_EQ(FILE_INDEX, line.file_index);
-  EXPECT_EQ(LINE_NO, line.line_no);
+  line_t line = parser->parse_line(GetParam().second);
 
   EXPECT_TRUE(line.is_valid);
 
@@ -102,10 +89,7 @@ INSTANTIATE_TEST_CASE_P(Inst, ParseLineKeyTest,
     ::testing::ValuesIn(parse_line_key_list),);
 
 TEST_P(ParseLineKeyTest, correctness) {
-  line_t line = parser->parse_line(FILE_INDEX, LINE_NO, GetParam().second);
-
-  EXPECT_EQ(FILE_INDEX, line.file_index);
-  EXPECT_EQ(LINE_NO, line.line_no);
+  line_t line = parser->parse_line(GetParam().second);
 
   EXPECT_TRUE(line.is_valid);
 
@@ -115,7 +99,7 @@ TEST_P(ParseLineKeyTest, correctness) {
 }
 
 TEST_F(ParseLineInValidTest, throwsSyntaxError) {
-  EXPECT_THROW(parser->parse_line(FILE_INDEX, LINE_NO, "unknown"), syntax_error);
+  EXPECT_THROW(parser->parse_line("unknown"), syntax_error);
 }
 // }}}
 

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -1,5 +1,5 @@
-#include "common/test.hpp"
 #include "components/config_parser.hpp"
+#include "common/test.hpp"
 #include "components/logger.hpp"
 
 using namespace polybar;
@@ -10,60 +10,62 @@ using namespace std;
  */
 class TestableConfigParser : public config_parser {
   using config_parser::config_parser;
-  public: using config_parser::get_line_type;
-  public: using config_parser::parse_key;
-  public: using config_parser::parse_header;
-  public: using config_parser::parse_line;
-  public: using config_parser::files;
+
+ public:
+  using config_parser::get_line_type;
+
+ public:
+  using config_parser::parse_key;
+
+ public:
+  using config_parser::parse_header;
+
+ public:
+  using config_parser::parse_line;
+
+ public:
+  using config_parser::m_files;
 };
 
 /**
  * \brief Fixture class
  */
 class ConfigParser : public ::testing::Test {
-  protected:
-    unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero", "TEST");
+ protected:
+  unique_ptr<TestableConfigParser> parser =
+      make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero", "TEST");
 };
 
 // ParseLineTest {{{
-class ParseLineInValidTest :
-  public ConfigParser,
-  public ::testing::WithParamInterface<string> {
-  };
+class ParseLineInValidTest : public ConfigParser, public ::testing::WithParamInterface<string> {};
 
-class ParseLineHeaderTest :
-  public ConfigParser,
-  public ::testing::WithParamInterface<pair<string, string>> {
-  };
+class ParseLineHeaderTest : public ConfigParser, public ::testing::WithParamInterface<pair<string, string>> {};
 
-class ParseLineKeyTest :
-  public ConfigParser,
-  public ::testing::WithParamInterface<pair<pair<string, string>, string>> {
-  };
+class ParseLineKeyTest : public ConfigParser,
+                         public ::testing::WithParamInterface<pair<pair<string, string>, string>> {};
 
 vector<string> parse_line_invalid_list = {
-  " # comment",
-  "; comment",
-  "\t#",
-  "",
-  " ",
-  "\t ",
+    " # comment",
+    "; comment",
+    "\t#",
+    "",
+    " ",
+    "\t ",
 };
 
 vector<pair<string, string>> parse_line_header_list = {
-  {"section", "\t[section]"},
-  {"section", "\t[section]  "},
-  {"bar/name", "\t[bar/name]  "},
+    {"section", "\t[section]"},
+    {"section", "\t[section]  "},
+    {"bar/name", "\t[bar/name]  "},
 };
 
 vector<pair<pair<string, string>, string>> parse_line_key_list = {
-  {{"key", "value"}, " key = value"},
-  {{"key", ""}, " key\t = \"\""},
-  {{"key", "\""}, " key\t = \"\"\""},
+    {{"key", "value"}, " key = value"},
+    {{"key", ""}, " key\t = \"\""},
+    {{"key", "\""}, " key\t = \"\"\""},
 };
 
-INSTANTIATE_TEST_SUITE_P(Inst, ParseLineInValidTest,
-    ::testing::ValuesIn(parse_line_invalid_list));
+INSTANTIATE_TEST_SUITE_P(Inst, ParseLineInValidTest, ::testing::ValuesIn(parse_line_invalid_list));
 
 TEST_P(ParseLineInValidTest, correctness) {
   line_t line = parser->parse_line(GetParam());
@@ -71,8 +73,7 @@ TEST_P(ParseLineInValidTest, correctness) {
   EXPECT_FALSE(line.useful);
 }
 
-INSTANTIATE_TEST_SUITE_P(Inst, ParseLineHeaderTest,
-    ::testing::ValuesIn(parse_line_header_list));
+INSTANTIATE_TEST_SUITE_P(Inst, ParseLineHeaderTest, ::testing::ValuesIn(parse_line_header_list));
 
 TEST_P(ParseLineHeaderTest, correctness) {
   line_t line = parser->parse_line(GetParam().second);
@@ -83,8 +84,7 @@ TEST_P(ParseLineHeaderTest, correctness) {
   EXPECT_EQ(GetParam().first, line.header);
 }
 
-INSTANTIATE_TEST_SUITE_P(Inst, ParseLineKeyTest,
-    ::testing::ValuesIn(parse_line_key_list));
+INSTANTIATE_TEST_SUITE_P(Inst, ParseLineKeyTest, ::testing::ValuesIn(parse_line_key_list));
 
 TEST_P(ParseLineKeyTest, correctness) {
   line_t line = parser->parse_line(GetParam().second);
@@ -109,24 +109,21 @@ TEST_F(ParseLineInValidTest, throwsSyntaxError) {
  * Parameters are pairs of the expected line type and a string that should be
  * detected as that line type
  */
-class GetLineTypeTest :
-  public ConfigParser,
-  public ::testing::WithParamInterface<pair<line_type, string>> {
-  };
+class GetLineTypeTest : public ConfigParser, public ::testing::WithParamInterface<pair<line_type, string>> {};
 
 /**
  * \brief Helper function generate GetLineTypeTest parameter values
  */
-vector<pair<line_type, string>> line_type_transform(vector<string> in, line_type type) {
+vector<pair<line_type, string>> line_type_transform(vector<string>&& in, line_type type) {
   vector<pair<line_type, string>> out;
 
-  for (auto i : in) {
+  out.reserve(in.size());
+  for (const auto& i : in) {
     out.emplace_back(type, i);
   }
 
   return out;
 }
-
 
 /**
  * \brief Parameter values for GetLineTypeTest
@@ -163,26 +160,22 @@ TEST_P(GetLineTypeTest, correctness) {
  * The first element of the pair is the expected key-value pair and the second
  * element is the string to be parsed, has to be trimmed and valid.
  */
-class ParseKeyTest :
-  public ConfigParser,
-  public ::testing::WithParamInterface<pair<pair<string, string>, string>> {};
-
+class ParseKeyTest : public ConfigParser, public ::testing::WithParamInterface<pair<pair<string, string>, string>> {};
 
 vector<pair<pair<string, string>, string>> parse_key_list = {
-  {{"key", "value"}, "key = value"},
-  {{"key", "value"}, "key=value"},
-  {{"key", "value"}, "key =\"value\""},
-  {{"key", "value"}, "key\t=\t \"value\""},
-  {{"key", "\"value"}, "key = \"value"},
-  {{"key", "value\""}, "key = value\""},
-  {{"key", "= value"}, "key == value"},
-  {{"key", ""}, "key ="},
-  {{"key", ""}, "key =\"\""},
-  {{"key", "\"\""}, "key =\"\"\"\""},
+    {{"key", "value"}, "key = value"},
+    {{"key", "value"}, "key=value"},
+    {{"key", "value"}, "key =\"value\""},
+    {{"key", "value"}, "key\t=\t \"value\""},
+    {{"key", "\"value"}, "key = \"value"},
+    {{"key", "value\""}, "key = value\""},
+    {{"key", "= value"}, "key == value"},
+    {{"key", ""}, "key ="},
+    {{"key", ""}, R"(key ="")"},
+    {{"key", "\"\""}, R"(key ="""")"},
 };
 
-INSTANTIATE_TEST_SUITE_P(Inst, ParseKeyTest,
-    ::testing::ValuesIn(parse_key_list));
+INSTANTIATE_TEST_SUITE_P(Inst, ParseKeyTest, ::testing::ValuesIn(parse_key_list));
 
 /**
  * Parameterized test for parse_key with valid line
@@ -209,18 +202,15 @@ TEST_F(ParseKeyTest, throwsSyntaxError) {
  * The first element of the pair is the expected key-value pair and the second
  * element is the string to be parsed, has to be trimmed and valid
  */
-class ParseHeaderTest :
-  public ConfigParser,
-  public ::testing::WithParamInterface<pair<string, string>> {};
+class ParseHeaderTest : public ConfigParser, public ::testing::WithParamInterface<pair<string, string>> {};
 
 vector<pair<string, string>> parse_header_list = {
-  {"section", "[section]"},
-  {"bar/name", "[bar/name]"},
-  {"with_underscore", "[with_underscore]"},
+    {"section", "[section]"},
+    {"bar/name", "[bar/name]"},
+    {"with_underscore", "[with_underscore]"},
 };
 
-INSTANTIATE_TEST_SUITE_P(Inst, ParseHeaderTest,
-    ::testing::ValuesIn(parse_header_list));
+INSTANTIATE_TEST_SUITE_P(Inst, ParseHeaderTest, ::testing::ValuesIn(parse_header_list));
 
 /**
  * Parameterized test for parse_header with valid line

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -1,0 +1,166 @@
+#include <algorithm>
+
+#include "common/test.hpp"
+#include "components/config_parser.hpp"
+#include "components/logger.hpp"
+
+using namespace polybar;
+using namespace std;
+
+/**
+ * \brief Testing-only subclass of config_parser to change access level
+ */
+class TestableConfigParser : public config_parser {
+  using config_parser::config_parser;
+  public: using config_parser::get_line_type;
+  public: using config_parser::parse_key;
+  public: using config_parser::parse_header;
+};
+
+/**
+ * \brief Fixture class
+ */
+class ConfigParser : public ::testing::Test {
+  protected:
+    unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero");
+};
+
+// ParseLineTest {{{
+
+// }}}
+
+// GetLineTypeTest {{{
+
+/**
+ * \brief Class for parameterized tests on get_line_type
+ *
+ * Parameters are pairs of the expected line type and a string that should be
+ * detected as that line type
+ */
+class GetLineTypeTest :
+  public ConfigParser,
+  public ::testing::WithParamInterface<pair<line_type, string>> {
+  };
+
+/**
+ * \brief Helper function generate GetLineTypeTest parameter values
+ */
+vector<pair<line_type, string>> line_type_transform(vector<string> in, line_type type) {
+  vector<pair<line_type, string>> out;
+
+  for (auto i : in) {
+    out.emplace_back(type, i);
+  }
+
+  return out;
+}
+
+
+/**
+ * \brief Parameter values for GetLineTypeTest
+ */
+auto line_type_key = line_type_transform({"a = b", "  a =b", " a\t =\t \t b", "a = "}, line_type::KEY);
+auto line_type_header = line_type_transform({"[section]", " [section]", "[section/sub]"}, line_type::HEADER);
+auto line_type_comment = line_type_transform({";abc", "#abc", "\t;abc", " #abc", "\t \t;abc"}, line_type::COMMENT);
+auto line_type_empty = line_type_transform({"", " ", "\t" "   \t  \t"}, line_type::EMPTY);
+auto line_type_unknown = line_type_transform({"|a", " |a", "a"}, line_type::UNKNOWN);
+
+/**
+ * Instantiate GetLineTypeTest for the different line types
+ */
+INSTANTIATE_TEST_CASE_P(LineTypeKey, GetLineTypeTest, ::testing::ValuesIn(line_type_key),);
+INSTANTIATE_TEST_CASE_P(LineTypeHeader, GetLineTypeTest, ::testing::ValuesIn(line_type_header),);
+INSTANTIATE_TEST_CASE_P(LineTypeComment, GetLineTypeTest, ::testing::ValuesIn(line_type_comment),);
+INSTANTIATE_TEST_CASE_P(LineTypeEmpty, GetLineTypeTest, ::testing::ValuesIn(line_type_empty),);
+INSTANTIATE_TEST_CASE_P(LineTypeUnknown, GetLineTypeTest, ::testing::ValuesIn(line_type_unknown),);
+
+/**
+ * \brief Parameterized test for get_line_type
+ */
+TEST_P(GetLineTypeTest, correctness) {
+  EXPECT_EQ(GetParam().first, parser->get_line_type(GetParam().second));
+}
+
+// }}}
+
+// ParseKeyTest {{{
+
+/**
+ * \brief Class for parameterized tests on parse_key
+ *
+ * The first element of the pair is the expected key-value pair and the second
+ * element is the string to be parsed, has to be trimmed and valid.
+ */
+class ParseKeyTest :
+  public ConfigParser,
+  public ::testing::WithParamInterface<pair<pair<string, string>, string>> {};
+
+
+vector<pair<pair<string, string>, string>> parse_key_list = {
+  {{"key", "value"}, "key = value"},
+  {{"key", "value"}, "key=value"},
+  {{"key", "value"}, "key =\"value\""},
+  {{"key", "value"}, "key\t=\t \"value\""},
+  {{"key", "\"value"}, "key = \"value"},
+  {{"key", "value\""}, "key = value\""},
+  {{"key", "= value"}, "key == value"},
+  {{"key", ""}, "key ="},
+  {{"key", ""}, "key =\"\""},
+};
+
+INSTANTIATE_TEST_CASE_P(Inst, ParseKeyTest,
+    ::testing::ValuesIn(parse_key_list),);
+
+/**
+ * Parameterized test for parse_key with valid line
+ */
+TEST_P(ParseKeyTest, correctness) {
+  EXPECT_EQ(GetParam().first, parser->parse_key(GetParam().second));
+}
+
+/**
+ * Tests if exception is thrown for invalid key line
+ */
+TEST_F(ParseKeyTest, throwsSyntaxError) {
+  EXPECT_THROW(parser->parse_key("forbidden char = value"), syntax_error);
+  EXPECT_THROW(parser->parse_key("forbidden\tchar = value"), syntax_error);
+}
+// }}}
+
+// ParseHeaderTest {{{
+
+/**
+ * \brief Class for parameterized tests on parse_key
+ *
+ * The first element of the pair is the expected key-value pair and the second
+ * element is the string to be parsed, has to be trimmed and valid
+ */
+class ParseHeaderTest :
+  public ConfigParser,
+  public ::testing::WithParamInterface<pair<string, string>> {};
+
+vector<pair<string, string>> parse_header_list = {
+  {"section", "[section]"},
+  {"bar/name", "[bar/name]"},
+  {"with_underscore", "[with_underscore]"},
+};
+
+INSTANTIATE_TEST_CASE_P(Inst, ParseHeaderTest,
+    ::testing::ValuesIn(parse_header_list),);
+
+/**
+ * Parameterized test for parse_header with valid line
+ */
+TEST_P(ParseHeaderTest, correctness) {
+  EXPECT_EQ(GetParam().first, parser->parse_header(GetParam().second));
+}
+
+/**
+ * Tests if exception is thrown for invalid header line
+ */
+TEST_F(ParseHeaderTest, throwsSyntaxError) {
+  EXPECT_THROW(parser->parse_header("[no_end"), syntax_error);
+  EXPECT_THROW(parser->parse_header("[forbidden char]"), syntax_error);
+  EXPECT_THROW(parser->parse_header("[forbidden\tchar]"), syntax_error);
+}
+// }}}

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -62,8 +62,8 @@ vector<pair<pair<string, string>, string>> parse_line_key_list = {
   {{"key", "\""}, " key\t = \"\"\""},
 };
 
-INSTANTIATE_TEST_CASE_P(Inst, ParseLineInValidTest,
-    ::testing::ValuesIn(parse_line_invalid_list),);
+INSTANTIATE_TEST_SUITE_P(Inst, ParseLineInValidTest,
+    ::testing::ValuesIn(parse_line_invalid_list));
 
 TEST_P(ParseLineInValidTest, correctness) {
   line_t line = parser->parse_line(GetParam());
@@ -71,8 +71,8 @@ TEST_P(ParseLineInValidTest, correctness) {
   EXPECT_FALSE(line.useful);
 }
 
-INSTANTIATE_TEST_CASE_P(Inst, ParseLineHeaderTest,
-    ::testing::ValuesIn(parse_line_header_list),);
+INSTANTIATE_TEST_SUITE_P(Inst, ParseLineHeaderTest,
+    ::testing::ValuesIn(parse_line_header_list));
 
 TEST_P(ParseLineHeaderTest, correctness) {
   line_t line = parser->parse_line(GetParam().second);
@@ -83,8 +83,8 @@ TEST_P(ParseLineHeaderTest, correctness) {
   EXPECT_EQ(GetParam().first, line.header);
 }
 
-INSTANTIATE_TEST_CASE_P(Inst, ParseLineKeyTest,
-    ::testing::ValuesIn(parse_line_key_list),);
+INSTANTIATE_TEST_SUITE_P(Inst, ParseLineKeyTest,
+    ::testing::ValuesIn(parse_line_key_list));
 
 TEST_P(ParseLineKeyTest, correctness) {
   line_t line = parser->parse_line(GetParam().second);
@@ -140,11 +140,11 @@ auto line_type_unknown = line_type_transform({"|a", " |a", "a"}, line_type::UNKN
 /**
  * Instantiate GetLineTypeTest for the different line types
  */
-INSTANTIATE_TEST_CASE_P(LineTypeKey, GetLineTypeTest, ::testing::ValuesIn(line_type_key),);
-INSTANTIATE_TEST_CASE_P(LineTypeHeader, GetLineTypeTest, ::testing::ValuesIn(line_type_header),);
-INSTANTIATE_TEST_CASE_P(LineTypeComment, GetLineTypeTest, ::testing::ValuesIn(line_type_comment),);
-INSTANTIATE_TEST_CASE_P(LineTypeEmpty, GetLineTypeTest, ::testing::ValuesIn(line_type_empty),);
-INSTANTIATE_TEST_CASE_P(LineTypeUnknown, GetLineTypeTest, ::testing::ValuesIn(line_type_unknown),);
+INSTANTIATE_TEST_SUITE_P(LineTypeKey, GetLineTypeTest, ::testing::ValuesIn(line_type_key));
+INSTANTIATE_TEST_SUITE_P(LineTypeHeader, GetLineTypeTest, ::testing::ValuesIn(line_type_header));
+INSTANTIATE_TEST_SUITE_P(LineTypeComment, GetLineTypeTest, ::testing::ValuesIn(line_type_comment));
+INSTANTIATE_TEST_SUITE_P(LineTypeEmpty, GetLineTypeTest, ::testing::ValuesIn(line_type_empty));
+INSTANTIATE_TEST_SUITE_P(LineTypeUnknown, GetLineTypeTest, ::testing::ValuesIn(line_type_unknown));
 
 /**
  * \brief Parameterized test for get_line_type
@@ -181,8 +181,8 @@ vector<pair<pair<string, string>, string>> parse_key_list = {
   {{"key", "\"\""}, "key =\"\"\"\""},
 };
 
-INSTANTIATE_TEST_CASE_P(Inst, ParseKeyTest,
-    ::testing::ValuesIn(parse_key_list),);
+INSTANTIATE_TEST_SUITE_P(Inst, ParseKeyTest,
+    ::testing::ValuesIn(parse_key_list));
 
 /**
  * Parameterized test for parse_key with valid line
@@ -219,8 +219,8 @@ vector<pair<string, string>> parse_header_list = {
   {"with_underscore", "[with_underscore]"},
 };
 
-INSTANTIATE_TEST_CASE_P(Inst, ParseHeaderTest,
-    ::testing::ValuesIn(parse_header_list),);
+INSTANTIATE_TEST_SUITE_P(Inst, ParseHeaderTest,
+    ::testing::ValuesIn(parse_header_list));
 
 /**
  * Parameterized test for parse_header with valid line

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-
 #include "common/test.hpp"
 #include "components/config_parser.hpp"
 #include "components/logger.hpp"
@@ -94,8 +92,8 @@ TEST_P(ParseLineKeyTest, correctness) {
   EXPECT_TRUE(line.useful);
 
   EXPECT_FALSE(line.is_header);
-  EXPECT_EQ(GetParam().first.first, line.key_value[0]);
-  EXPECT_EQ(GetParam().first.second, line.key_value[1]);
+  EXPECT_EQ(GetParam().first.first, line.key);
+  EXPECT_EQ(GetParam().first.second, line.value);
 }
 
 TEST_F(ParseLineInValidTest, throwsSyntaxError) {

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -24,7 +24,7 @@ class TestableConfigParser : public config_parser {
  */
 class ConfigParser : public ::testing::Test {
   protected:
-    unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero");
+    unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero", "TEST");
 };
 
 // ParseLineTest {{{

--- a/tests/unit_tests/utils/string.cpp
+++ b/tests/unit_tests/utils/string.cpp
@@ -1,4 +1,5 @@
 #include <iomanip>
+#include <functional>
 
 #include "common/test.hpp"
 #include "utils/string.hpp"
@@ -55,6 +56,11 @@ TEST(String, trim) {
   EXPECT_EQ("testxx", string_util::ltrim("xxtestxx", 'x'));
   EXPECT_EQ("xxtest", string_util::rtrim("xxtestxx", 'x'));
   EXPECT_EQ("test", string_util::trim("xxtestxx", 'x'));
+}
+
+TEST(String, trimPredicate) {
+  EXPECT_EQ("x\t x", string_util::trim("\t  x\t x   ", string_util::isnospace_pred));
+  EXPECT_EQ("x\t x", string_util::trim("x\t x   ", string_util::isnospace_pred));
 }
 
 TEST(String, join) {

--- a/tests/unit_tests/utils/string.cpp
+++ b/tests/unit_tests/utils/string.cpp
@@ -1,5 +1,5 @@
-#include "common/test.hpp"
 #include "utils/string.hpp"
+#include "common/test.hpp"
 
 using namespace polybar;
 
@@ -56,8 +56,8 @@ TEST(String, trim) {
 }
 
 TEST(String, trimPredicate) {
-  EXPECT_EQ("x\t x", string_util::trim("\t  x\t x   ", string_util::isspace_pred));
-  EXPECT_EQ("x\t x", string_util::trim("x\t x   ", string_util::isspace_pred));
+  EXPECT_EQ("x\t x", string_util::trim("\t  x\t x   ", isspace));
+  EXPECT_EQ("x\t x", string_util::trim("x\t x   ", isspace));
 }
 
 TEST(String, join) {

--- a/tests/unit_tests/utils/string.cpp
+++ b/tests/unit_tests/utils/string.cpp
@@ -1,6 +1,3 @@
-#include <iomanip>
-#include <functional>
-
 #include "common/test.hpp"
 #include "utils/string.hpp"
 

--- a/tests/unit_tests/utils/string.cpp
+++ b/tests/unit_tests/utils/string.cpp
@@ -59,8 +59,8 @@ TEST(String, trim) {
 }
 
 TEST(String, trimPredicate) {
-  EXPECT_EQ("x\t x", string_util::trim("\t  x\t x   ", string_util::isnospace_pred));
-  EXPECT_EQ("x\t x", string_util::trim("x\t x   ", string_util::isnospace_pred));
+  EXPECT_EQ("x\t x", string_util::trim("\t  x\t x   ", string_util::isspace_pred));
+  EXPECT_EQ("x\t x", string_util::trim("x\t x   ", string_util::isspace_pred));
 }
 
 TEST(String, join) {


### PR DESCRIPTION
This is the next step to merge #1237 in stages.

Currently there are barely any restrictions on how the config can be
written. This causes things like config files with DOS line endings to
not be parsed properly (#1366) because polybar splits by `\n` and when
parsing section headers, it can't deal with the `\r` at the end of the
line and thus doesn't recognize any section headers.

With this PR we introduce some rules as to what characters are allowed
in section names and keys.
Note: When talking about spaces I refer to any character for which
`isspace()` returns `true`.

The rules are as follows:
* A section name or a key name cannot contain any spaces as well as any
of there characters:`"'=;#[](){}:.$\%`
* Spaces at the beginning and end of lines are always ignored when
parsing
* Comment lines start with `;` or `#` and last for the whole line. The
whole line will be ignored by the parser. You cannot start a comment at
the end of a line.
* Section headers have the following form `[HEADER_NAME]`
* Key-value lines look like this:
`KEY_NAME{SPACES}={SPACES}VALUE_STRING` where `{SPACES}` represents any
number of spaces. `VALUE_STRING` can contain any characters. If it is
*surrounded* with double quotes (`"`), those quotes will be removed,
this can be used to add spaces to the beginning or end of the value
* Empty lines are lines with only spaces in them
* If the line has any other form, it is a syntax error

This will introduce the following breaking changes because of how
underdefined the config syntax was before:
* `key = ""` will get treated as an empty string instead of the literal string `""`
* Any section or key name with forbidden characters will now be syntax
errors.
* Certain strings will be forbidden as section names: `self`, `root`, `BAR`. Because they have a special meaning inside references and so a section `[root]` can never be referenced.

This replaces the current parser implementation with a new more robust
one that will later be expanded to also check for dependency cycles and allow for values that contain references mixed with other strings.

This PR also now expands the config paths given over the command line so that `--config=~/.config/polybar/config` resolves properly.

EDIT: 
Closes #1032
Closes #1694