### PR TITLE
controller: Print error for duplicate modules

### DIFF
--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <moodycamel/blockingconcurrentqueue.h>
+
 #include <thread>
 
 #include "common.hpp"
-#include "settings.hpp"
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
 #include "events/types.hpp"
+#include "settings.hpp"
 #include "utils/file.hpp"
 #include "x11/types.hpp"
 
@@ -27,16 +28,17 @@ class signal_emitter;
 namespace modules {
   struct module_interface;
   class input_handler;
-}
+}  // namespace modules
 using module_t = shared_ptr<modules::module_interface>;
 using modulemap_t = std::map<alignment, vector<module_t>>;
 
 // }}}
 
-class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eventqueue::exit_terminate, signals::eventqueue::exit_reload,
-                       signals::eventqueue::notify_change, signals::eventqueue::notify_forcechange, signals::eventqueue::check_state, signals::ipc::action,
-                       signals::ipc::command, signals::ipc::hook, signals::ui::ready, signals::ui::button_press,
-                       signals::ui::update_background> {
+class controller
+    : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eventqueue::exit_terminate,
+          signals::eventqueue::exit_reload, signals::eventqueue::notify_change, signals::eventqueue::notify_forcechange,
+          signals::eventqueue::check_state, signals::ipc::action, signals::ipc::command, signals::ipc::hook,
+          signals::ui::ready, signals::ui::button_press, signals::ui::update_background> {
  public:
   using make_type = unique_ptr<controller>;
   static make_type make(unique_ptr<ipc>&& ipc, unique_ptr<inotify_watch>&& config_watch);

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -28,7 +28,7 @@ namespace modules {
   struct module_interface;
   class input_handler;
 }
-using module_t = unique_ptr<modules::module_interface>;
+using module_t = shared_ptr<modules::module_interface>;
 using modulemap_t = std::map<alignment, vector<module_t>>;
 
 // }}}
@@ -103,7 +103,12 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
   /**
    * \brief Loaded modules
    */
-  modulemap_t m_modules;
+  vector<module_t> m_modules;
+
+  /**
+   * \brief Loaded modules grouped by block
+   */
+  modulemap_t m_blocks;
 
   /**
    * \brief Module input handlers

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -69,6 +69,8 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
   bool on(const signals::ui::update_background& evt);
 
  private:
+  size_t setup_modules(alignment align);
+
   connection& m_connection;
   signal_emitter& m_sig;
   const logger& m_log;


### PR DESCRIPTION
You can't use the same name twice inside the module lists

E.g.
```dosini
modules-left = a b c
modules-center = a
modules-right = b
```
would print an error.

We only print an error for now because we don't want to break existing
configs. But in the future this should be properly enforced.

This is in preparation for fixing #1172, because I plan on making modules uniquely identifiable by their name.