### PR TITLE
[WIP] Fix tray restacking issues

### DIFF
--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -58,7 +58,7 @@ struct tray_settings {
   unsigned int height{0U};
   unsigned int height_fill{0U};
   unsigned int spacing{0U};
-  unsigned int sibling{0U};
+  xcb_window_t bar{XCB_NONE};
   unsigned int background{0U};
   bool transparent{false};
   bool detached{false};
@@ -137,6 +137,8 @@ class tray_manager
   bool on(const signals::ui::update_background& evt);
 
  private:
+  void reparent_window();
+
   connection& m_connection;
   signal_emitter& m_sig;
   const logger& m_log;

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -62,6 +62,17 @@ struct tray_settings {
   unsigned int background{0U};
   bool transparent{false};
   bool detached{false};
+
+  /**
+   * Allows users to turn off reparenting in favor of being able to use the
+   * offsets without restrictions.
+   *
+   * If the bar window is reparented by the WM under a window that has the
+   * exact same size as the bar (openbox does this), if the tray is also
+   * reparented, it is not possible to move the tray outside of the bounds of
+   * the bar window.
+   */
+  bool reparent{true};
 };
 
 class tray_manager

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -80,6 +80,7 @@ void tray_manager::setup(const bar_settings& bar_opts) {
   }
 
   m_opts.detached = conf.get(bs, "tray-detached", false);
+  m_opts.reparent = conf.get(bs, "tray-reparent", m_opts.reparent);
   m_opts.height = bar_opts.size.h;
   m_opts.height -= bar_opts.borders.at(edge::BOTTOM).size;
   m_opts.height -= bar_opts.borders.at(edge::TOP).size;
@@ -608,7 +609,9 @@ void tray_manager::restack_window() {
     return;
   }
 
-  reparent_window();
+  if (m_opts.reparent) {
+    reparent_window();
+  }
 
   try {
     m_log.trace("tray: Restacking tray window");


### PR DESCRIPTION
**EDIT:** Maybe it's a better idea to just make the tray window a child window of polybar. Then repositioning should get a lot easier.
Alternatively, have a main window and have the bar and the tray as two separate child windows.

---

The restacking issues observed in #1355 and #425 is caused by the WM reparenting the polybar window but not the tray window when `override-redirect = false`. Because of this the two windows are no longer siblings, causing the `XCB_MATCH` error.

Automatic reparenting causes problems with `tray-offset-*` not being applied in at least openbox and maybe other WMs. The reason for that is that openbox reparents the bar window into a window that hast the same dimensions as the bar window, if we also move the tray under that window, the tray cannot be drawn outside of the bar bounds. My solution here is a somewhat breaking change because by default reparenting is turned on. I think this is fine because it's only a breaking change in WMs that make the bar a child of a window with tight bounds and in configs that use the tray offset to move the tray outside of the bar's bounds. There is no other way to fix two linked issues in those WMs.

To not totally break people's configs that may want to move the tray outside of the bar bounds on those WMs, I have introduced a new key in the bar section:
```dosini
; Make sure that the bar and tray windows are siblings
; This option generally doesn't need to be modified unless you have issues with
; the tray offset not working.
; If set to false, you may get `tray: Failed to put tray above ...` errors and
; the tray may appear on top of fullscreen windows.
tray-reparent = true
```

Fixes #1355 
Fixes #425
Fixes #1813 
Fixes #1995

This fix could also work for #898 
This fix could also work for #2460
This fix could also work for #2433
This fix could also work for #1995
This fix could also work for #789
This fix could also work for #1537
Closes #1657
Fixes #2035 