### PR TITLE
Networkclick

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -2,6 +2,7 @@
 
 #include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "utils/command.hpp"
 
 POLYBAR_NS
 
@@ -38,6 +39,12 @@ namespace modules {
     ramp_t m_rampload_core;
     label_t m_label;
     int m_ramp_padding;
+
+    // added for click actions
+    map<mousebtn, string> m_actions;
+    int m_counter{0};
+    unique_ptr<command> m_command;
+    bool m_tail;
 
     vector<cpu_time_t> m_cputimes;
     vector<cpu_time_t> m_cputimes_prev;

--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -3,6 +3,7 @@
 #include "components/config.hpp"
 #include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "utils/command.hpp"
 
 POLYBAR_NS
 
@@ -65,6 +66,13 @@ namespace modules {
 
     // used while formatting output
     size_t m_index{0_z};
+
+    // added for click events
+    map<mousebtn, string> m_actions;
+    unique_ptr<command> m_command;
+    bool m_tail;
+    int m_counter{0};
+
   };
 }
 

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -3,6 +3,7 @@
 #include "adapters/net.hpp"
 #include "components/config.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "utils/command.hpp"
 
 POLYBAR_NS
 
@@ -52,6 +53,12 @@ namespace modules {
     int m_udspeed_minwidth{0};
     bool m_accumulate{false};
     bool m_unknown_up{false};
+
+    // added for click events
+    map<mousebtn, string> m_actions;
+    unique_ptr<command> m_command;
+    bool m_tail;
+
   };
 }
 

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -38,6 +38,17 @@ namespace modules {
     if (m_formatter->has(TAG_LABEL)) {
       m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%percentage%%");
     }
+
+    // Load configured click handlers
+    m_actions[mousebtn::LEFT] = m_conf.get(name(), "click-left", ""s);
+    m_actions[mousebtn::MIDDLE] = m_conf.get(name(), "click-middle", ""s);
+    m_actions[mousebtn::RIGHT] = m_conf.get(name(), "click-right", ""s);
+    m_actions[mousebtn::DOUBLE_LEFT] = m_conf.get(name(), "double-click-left", ""s);
+    m_actions[mousebtn::DOUBLE_MIDDLE] = m_conf.get(name(), "double-click-middle", ""s);
+    m_actions[mousebtn::DOUBLE_RIGHT] = m_conf.get(name(), "double-click-right", ""s);
+    m_actions[mousebtn::SCROLL_UP] = m_conf.get(name(), "scroll-up", ""s);
+    m_actions[mousebtn::SCROLL_DOWN] = m_conf.get(name(), "scroll-down", ""s);
+
   }
 
   bool cpu_module::update() {
@@ -77,27 +88,28 @@ namespace modules {
       }
     }
 
-    // Add click action
-    auto click_left = m_conf.get(name(), "click-left", ""s);
-    auto click_middle = m_conf.get(name(), "click-middle", ""s);
-    auto click_right = m_conf.get(name(), "click-right", ""s);
-    auto scroll_up = m_conf.get(name(), "scroll-up", ""s);
-    auto scroll_down = m_conf.get(name(), "scroll-down", ""s);
+    // Added for click actions
+    string cnt{to_string(m_counter)};
 
-    if (!click_left.empty()) {
-      m_builder->cmd(mousebtn::LEFT, click_left);
-    }
-    if (!click_middle.empty()) {
-      m_builder->cmd(mousebtn::MIDDLE, click_middle);
-    }
-    if (!click_right.empty()) {
-      m_builder->cmd(mousebtn::RIGHT, click_right);
-    }
-    if (!scroll_up.empty()) {
-      m_builder->cmd(mousebtn::SCROLL_UP, scroll_up);
-    }
-    if (!scroll_down.empty()) {
-      m_builder->cmd(mousebtn::SCROLL_DOWN, scroll_down);
+    for (auto btn : {mousebtn::LEFT, mousebtn::MIDDLE, mousebtn::RIGHT,
+                     mousebtn::DOUBLE_LEFT, mousebtn::DOUBLE_MIDDLE,
+                     mousebtn::DOUBLE_RIGHT, mousebtn::SCROLL_UP,
+                     mousebtn::SCROLL_DOWN}) {
+
+      auto action = m_actions[btn];
+
+      if (!action.empty()) {
+        auto action_replaced = string_util::replace_all(action, "%counter%", cnt);
+
+        /*
+         * The pid token is only for tailed commands.
+         * If the command is not specified or running, replacement is unnecessary as well
+         */
+        if(m_tail && m_command && m_command->is_running()) {
+          action_replaced = string_util::replace_all(action_replaced, "%pid%", to_string(m_command->get_pid()));
+        }
+        m_builder->cmd(btn, action_replaced);
+      }
     }
 
     return true;

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -20,29 +20,6 @@ namespace modules {
 
     m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-coreload-spacing", 1);
 
-    // Add click action
-    auto click_left = m_conf.get(name(), "click-left", ""s);
-    auto click_middle = m_conf.get(name(), "click-middle", ""s);
-    auto click_right = m_conf.get(name(), "click-right", ""s);
-    auto scroll_up = m_conf.get(name(), "scroll-up", ""s);
-    auto scroll_down = m_conf.get(name(), "scroll-down", ""s);
-
-    if (!click_left.empty()) {
-      m_builder->cmd(mousebtn::LEFT, click_left);
-    }
-    if (!click_middle.empty()) {
-      m_builder->cmd(mousebtn::MIDDLE, click_middle);
-    }
-    if (!click_right.empty()) {
-      m_builder->cmd(mousebtn::RIGHT, click_right);
-    }
-    if (!scroll_up.empty()) {
-      m_builder->cmd(mousebtn::SCROLL_UP, scroll_up);
-    }
-    if (!scroll_down.empty()) {
-      m_builder->cmd(mousebtn::SCROLL_DOWN, scroll_down);
-    }
-
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 
     // warmup cpu times

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -20,6 +20,29 @@ namespace modules {
 
     m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-coreload-spacing", 1);
 
+    // Add click action
+    auto click_left = m_conf.get(name(), "click-left", ""s);
+    auto click_middle = m_conf.get(name(), "click-middle", ""s);
+    auto click_right = m_conf.get(name(), "click-right", ""s);
+    auto scroll_up = m_conf.get(name(), "scroll-up", ""s);
+    auto scroll_down = m_conf.get(name(), "scroll-down", ""s);
+
+    if (!click_left.empty()) {
+      m_builder->cmd(mousebtn::LEFT, click_left);
+    }
+    if (!click_middle.empty()) {
+      m_builder->cmd(mousebtn::MIDDLE, click_middle);
+    }
+    if (!click_right.empty()) {
+      m_builder->cmd(mousebtn::RIGHT, click_right);
+    }
+    if (!scroll_up.empty()) {
+      m_builder->cmd(mousebtn::SCROLL_UP, scroll_up);
+    }
+    if (!scroll_down.empty()) {
+      m_builder->cmd(mousebtn::SCROLL_DOWN, scroll_down);
+    }
+
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 
     // warmup cpu times
@@ -75,6 +98,29 @@ namespace modules {
       for (size_t i = 0; i < percentage_cores.size(); i++) {
         m_label->replace_token("%percentage-core" + to_string(i + 1) + "%", percentage_cores[i]);
       }
+    }
+
+    // Add click action
+    auto click_left = m_conf.get(name(), "click-left", ""s);
+    auto click_middle = m_conf.get(name(), "click-middle", ""s);
+    auto click_right = m_conf.get(name(), "click-right", ""s);
+    auto scroll_up = m_conf.get(name(), "scroll-up", ""s);
+    auto scroll_down = m_conf.get(name(), "scroll-down", ""s);
+
+    if (!click_left.empty()) {
+      m_builder->cmd(mousebtn::LEFT, click_left);
+    }
+    if (!click_middle.empty()) {
+      m_builder->cmd(mousebtn::MIDDLE, click_middle);
+    }
+    if (!click_right.empty()) {
+      m_builder->cmd(mousebtn::RIGHT, click_right);
+    }
+    if (!scroll_up.empty()) {
+      m_builder->cmd(mousebtn::SCROLL_UP, scroll_up);
+    }
+    if (!scroll_down.empty()) {
+      m_builder->cmd(mousebtn::SCROLL_DOWN, scroll_down);
     }
 
     return true;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -24,6 +24,16 @@ namespace modules {
 
     m_conf.warn_deprecated(name(), "udspeed-minwidth", "%downspeed:min:max% and %upspeed:min:max%");
 
+    // Load configured click handlers
+    m_actions[mousebtn::LEFT] = m_conf.get(name(), "click-left", ""s);
+    m_actions[mousebtn::MIDDLE] = m_conf.get(name(), "click-middle", ""s);
+    m_actions[mousebtn::RIGHT] = m_conf.get(name(), "click-right", ""s);
+    m_actions[mousebtn::DOUBLE_LEFT] = m_conf.get(name(), "double-click-left", ""s);
+    m_actions[mousebtn::DOUBLE_MIDDLE] = m_conf.get(name(), "double-click-middle", ""s);
+    m_actions[mousebtn::DOUBLE_RIGHT] = m_conf.get(name(), "double-click-right", ""s);
+    m_actions[mousebtn::SCROLL_UP] = m_conf.get(name(), "scroll-up", ""s);
+    m_actions[mousebtn::SCROLL_DOWN] = m_conf.get(name(), "scroll-down", ""s);
+
     // Add formats
     m_formatter->add(FORMAT_CONNECTED, TAG_LABEL_CONNECTED, {TAG_RAMP_SIGNAL, TAG_RAMP_QUALITY, TAG_LABEL_CONNECTED});
     m_formatter->add(FORMAT_DISCONNECTED, TAG_LABEL_DISCONNECTED, {TAG_LABEL_DISCONNECTED});
@@ -141,26 +151,27 @@ namespace modules {
     }
 
     // Add click action
-    auto click_left = m_conf.get(name(), "click-left", ""s);
-    auto click_middle = m_conf.get(name(), "click-middle", ""s);
-    auto click_right = m_conf.get(name(), "click-right", ""s);
-    auto scroll_up = m_conf.get(name(), "scroll-up", ""s);
-    auto scroll_down = m_conf.get(name(), "scroll-down", ""s);
+    string cnt{to_string(m_counter)};
 
-    if (!click_left.empty()) {
-      m_builder->cmd(mousebtn::LEFT, click_left);
-    }
-    if (!click_middle.empty()) {
-      m_builder->cmd(mousebtn::MIDDLE, click_middle);
-    }
-    if (!click_right.empty()) {
-      m_builder->cmd(mousebtn::RIGHT, click_right);
-    }
-    if (!scroll_up.empty()) {
-      m_builder->cmd(mousebtn::SCROLL_UP, scroll_up);
-    }
-    if (!scroll_down.empty()) {
-      m_builder->cmd(mousebtn::SCROLL_DOWN, scroll_down);
+    for (auto btn : {mousebtn::LEFT, mousebtn::MIDDLE, mousebtn::RIGHT,
+                     mousebtn::DOUBLE_LEFT, mousebtn::DOUBLE_MIDDLE,
+                     mousebtn::DOUBLE_RIGHT, mousebtn::SCROLL_UP,
+                     mousebtn::SCROLL_DOWN}) {
+
+      auto action = m_actions[btn];
+
+      if (!action.empty()) {
+        auto action_replaced = string_util::replace_all(action, "%counter%", cnt);
+
+        /*
+         * The pid token is only for tailed commands.
+         * If the command is not specified or running, replacement is unnecessary as well
+         */
+        if(m_tail && m_command && m_command->is_running()) {
+          action_replaced = string_util::replace_all(action_replaced, "%pid%", to_string(m_command->get_pid()));
+        }
+        m_builder->cmd(btn, action_replaced);
+      }
     }
 
     return true;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -140,6 +140,29 @@ namespace modules {
       replace_tokens(m_label[connection_state::DISCONNECTED]);
     }
 
+    // Add click action
+    auto click_left = m_conf.get(name(), "click-left", ""s);
+    auto click_middle = m_conf.get(name(), "click-middle", ""s);
+    auto click_right = m_conf.get(name(), "click-right", ""s);
+    auto scroll_up = m_conf.get(name(), "scroll-up", ""s);
+    auto scroll_down = m_conf.get(name(), "scroll-down", ""s);
+
+    if (!click_left.empty()) {
+      m_builder->cmd(mousebtn::LEFT, click_left);
+    }
+    if (!click_middle.empty()) {
+      m_builder->cmd(mousebtn::MIDDLE, click_middle);
+    }
+    if (!click_right.empty()) {
+      m_builder->cmd(mousebtn::RIGHT, click_right);
+    }
+    if (!scroll_up.empty()) {
+      m_builder->cmd(mousebtn::SCROLL_UP, scroll_up);
+    }
+    if (!scroll_down.empty()) {
+      m_builder->cmd(mousebtn::SCROLL_DOWN, scroll_down);
+    }
+
     return true;
   }
 


### PR DESCRIPTION
First time submitting a PR for a non-python project, hopefully its not too sloppy.

Basically I wanted to be able to launch wicd-curses when I click on the network so I took the code from text.cpp and added it to network.cpp to allow configuration of click events in the config file. I then wanted the same thing for the cpu.cpp module so I could launch htop. Both appear to work well from my local testing and have added a ton of useful functionality to my polybar setup.

Ideally I wanted this to add the click events to the prefix (which I use mainly for icons in my polybar setup), however I couldnt get that to work. Happy to have another crack at it though if someone could point me in the right direction.