### PR TITLE
Fixed minor menu item-spacing issue

### DIFF
--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -89,12 +89,10 @@ namespace modules {
             builder->node(m_labelseparator);
             builder->space(spacing);
           }
-        } else if (item == m_levels[m_level]->items.back()) {
-          //Insert separator after last menu-item and before menu-toggle for expand-right=false
-          if (!m_expand_right && *m_labelseparator) {
-            builder->space(spacing);
-            builder->node(m_labelseparator);
-          }
+        //Insert separator after last menu-item and before menu-toggle for expand-right=false
+        } else if (!m_expand_right && *m_labelseparator) {
+          builder->space(spacing);
+          builder->node(m_labelseparator);
         }
       }
     } else {

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -74,10 +74,9 @@ namespace modules {
       builder->cmd_close();
     } else if (tag == TAG_MENU && m_level > -1) {
       auto spacing = m_formatter->get(get_format())->spacing;
-      //Insert spacing after menu-items and before menu-toggle for expand-right=true
-      if (m_expand_right) {
-        if (*m_labelseparator)
-          builder->node(m_labelseparator);
+      //Insert separator after menu-toggle and before menu-items for expand-right=true
+      if (m_expand_right && *m_labelseparator) {
+        builder->node(m_labelseparator);
         builder->space(spacing);
       }
       for (auto&& item : m_levels[m_level]->items) {
@@ -91,11 +90,10 @@ namespace modules {
             builder->space(spacing);
           }
         } else if (item == m_levels[m_level]->items.back()) {
-        //Insert spacing after menu-toggle and before menu-items for expand-right=false
-          if (!m_expand_right) {
+          //Insert separator after last menu-item and before menu-toggle for expand-right=false
+          if (!m_expand_right && *m_labelseparator) {
             builder->space(spacing);
-            if (*m_labelseparator)
-              builder->node(m_labelseparator);
+            builder->node(m_labelseparator);
           }
         }
       }

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -74,38 +74,29 @@ namespace modules {
       builder->cmd_close();
     } else if (tag == TAG_MENU && m_level > -1) {
       auto spacing = m_formatter->get(get_format())->spacing;
+      //Insert spacing after menu-items and before menu-toggle for expand-right=true
+      if (m_expand_right) {
+        if (*m_labelseparator)
+          builder->node(m_labelseparator);
+        builder->space(spacing);
+      }
       for (auto&& item : m_levels[m_level]->items) {
-        /*
-         * Depending on whether the menu items are to the left or right of the toggle label, the items need to be
-         * drawn before or after the spacings and the separator
-         *
-         * If the menu expands to the left, the separator should be drawn on the right side because otherwise the menu
-         * would look like this:
-         * | x | y <label-toggle>
-         */
-        if(!m_expand_right) {
-          builder->cmd(mousebtn::LEFT, item->exec);
-          builder->node(item->label);
-          builder->cmd_close();
-        }
-
-        if (*m_labelseparator) {
-          if (item != m_levels[m_level]->items[0]) {
+        builder->cmd(mousebtn::LEFT, item->exec);
+        builder->node(item->label);
+        builder->cmd_close();
+        if (item != m_levels[m_level]->items.back()) {
+          builder->space(spacing);
+          if (*m_labelseparator) {
+            builder->node(m_labelseparator);
             builder->space(spacing);
           }
-          builder->node(m_labelseparator);
-          builder->space(spacing);
-        }
-
-        /*
-         * If the menu expands to the right, the separator should be drawn on the left side because otherwise the menu
-         * would look like this:
-         * <label-toggle> x | y |
-         */
-        if(m_expand_right) {
-          builder->cmd(mousebtn::LEFT, item->exec);
-          builder->node(item->label);
-          builder->cmd_close();
+        } else if (item == m_levels[m_level]->items.back()) {
+        //Insert spacing after menu-toggle and before menu-items for expand-right=false
+          if (!m_expand_right) {
+            builder->space(spacing);
+            if (*m_labelseparator)
+              builder->node(m_labelseparator);
+          }
         }
       }
     } else {


### PR DESCRIPTION
There was missing some spacing between item+separator in my menu using `expand-right=false`.
Thought this would be a great opportunity for first-time pull-request.

Searching for 'menu' in the issues-tracker reveals no pertinent issues to me.

In this image, you can see the missing spacing between my the 'reboot' label and its separator in the top-right. I've fixed this behaviour, and it works regardless of `expand-right=true` or `expand-right=false`
![2019-02-17-172128-scrot](https://user-images.githubusercontent.com/5731041/52923397-350a0d80-32ed-11e9-987c-26a94a180cd4.png)
