### PR TITLE
Add units support for polybar #1651 #951

### DIFF
--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -32,7 +32,7 @@ class tray_manager;
  * Converts geometry format into pixel.
  */
 inline unsigned int geom_format_to_pixels(geometry_format_values g_format, double max, double dpi) {
-  auto offset_pixel = unit_utils::geometry_type_to_pixel(g_format.offset, dpi);
+  auto offset_pixel = unit_utils::geometry_to_pixel(g_format.offset, dpi);
 
   return static_cast<unsigned int>(math_util::max<double>(
       0, math_util::percentage_to_value<double, double>(g_format.percentage, max) + offset_pixel));

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -10,6 +10,7 @@
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
 #include "utils/math.hpp"
+#include "utils/unit.hpp"
 #include "settings.hpp"
 #include "x11/types.hpp"
 #include "x11/window.hpp"
@@ -28,24 +29,13 @@ class tray_manager;
 // }}}
 
 /**
- * Allows a new format for pixel sizes (like width in the bar section)
- *
- * The new format is X%:Z, where X is in [0, 100], and Z is any real value
- * describing a pixel offset. The actual value is calculated by X% * max + Z
+ * Converts geometry format into pixel.
  */
-inline double geom_format_to_pixels(std::string str, double max) {
-  size_t i;
-  if ((i = str.find(':')) != std::string::npos) {
-    std::string a = str.substr(0, i - 1);
-    std::string b = str.substr(i + 1);
-    return math_util::max<double>(0,math_util::percentage_to_value<double>(strtod(a.c_str(), nullptr), max) + strtod(b.c_str(), nullptr));
-  } else {
-    if (str.find('%') != std::string::npos) {
-      return math_util::percentage_to_value<double>(strtod(str.c_str(), nullptr), max);
-    } else {
-      return strtod(str.c_str(), nullptr);
-    }
-  }
+inline unsigned int geom_format_to_pixels(geometry_format_values g_format, double max, double dpi) {
+  auto offset_pixel = unit_utils::size_with_unit_to_pixel(g_format.offset, dpi);
+
+  return static_cast<unsigned int>(math_util::max<double>(
+      0, math_util::percentage_to_value<double, double>(g_format.percentage, max) + offset_pixel));
 }
 
 class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::property_notify, evt::enter_notify,

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <cstdlib>
 #include <atomic>
+#include <cstdlib>
 #include <mutex>
 
 #include "common.hpp"
@@ -9,9 +9,9 @@
 #include "errors.hpp"
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
+#include "settings.hpp"
 #include "utils/math.hpp"
 #include "utils/unit.hpp"
-#include "settings.hpp"
 #include "x11/types.hpp"
 #include "x11/window.hpp"
 
@@ -32,12 +32,13 @@ class tray_manager;
  * Converts geometry format into pixel.
  */
 inline unsigned int geom_format_to_pixels(geometry_format_values g_format, double max, double dpi) {
-  auto offset_pixel = unit_utils::size_with_unit_to_pixel(g_format.offset, dpi);
+  auto offset_pixel = unit_utils::geometry_type_to_pixel(g_format.offset, dpi);
 
   return static_cast<unsigned int>(math_util::max<double>(
       0, math_util::percentage_to_value<double, double>(g_format.percentage, max) + offset_pixel));
 }
 
+// clang-format off
 class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::property_notify, evt::enter_notify,
                 evt::leave_notify, evt::motion_notify, evt::destroy_notify, evt::client_message, evt::configure_notify>,
             public signal_receiver<SIGN_PRIORITY_BAR, signals::eventqueue::start, signals::ui::tick,
@@ -47,6 +48,7 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
 #endif
 		> {
  public:
+  // clang-format on
   using make_type = unique_ptr<bar>;
   static make_type make(bool only_initialize_values = false);
 

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -28,7 +28,7 @@ class builder {
   void node(const label_t& label, bool add_space = false);
   void node_repeat(const string& str, size_t n, bool add_space = false);
   void node_repeat(const label_t& label, size_t n, bool add_space = false);
-  void offset(int pixels = 0);
+  void offset(geometry pixels = GEOMETRY_ZERO_PIXEL);
   void space(space_size size);
   void space();
   void remove_trailing_space(size_t len);

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -29,7 +29,7 @@ class builder {
   void node_repeat(const string& str, size_t n, bool add_space = false);
   void node_repeat(const label_t& label, size_t n, bool add_space = false);
   void offset(int pixels = 0);
-  void space(size_with_unit size);
+  void space(space_size size);
   void space();
   void remove_trailing_space(size_t len);
   void remove_trailing_space();

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -29,7 +29,7 @@ class builder {
   void node_repeat(const string& str, size_t n, bool add_space = false);
   void node_repeat(const label_t& label, size_t n, bool add_space = false);
   void offset(int pixels = 0);
-  void space(size_t width);
+  void space(size_with_unit size);
   void space();
   void remove_trailing_space(size_t len);
   void remove_trailing_space();

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -55,6 +55,7 @@ class builder {
   void cmd(mousebtn index, string action, const label_t& label);
   void cmd_close(bool condition = true);
 
+  static string add_surrounding_tag(const space_size& space);
  protected:
   string background_hex();
   string foreground_hex();

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -28,6 +28,7 @@ struct alignment_block {
   cairo_pattern_t* pattern;
   double x;
   double y;
+  double width;
 };
 
 class renderer

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -60,6 +60,7 @@ class renderer
   void fill_underline(double x, double w);
   void fill_borders();
   void draw_text(const string& contents);
+  void draw_offset(double x, double w);
 
  protected:
   double block_x(alignment a) const;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -34,7 +34,7 @@ class renderer
     : public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot, signals::parser::change_background,
           signals::parser::change_foreground, signals::parser::change_underline, signals::parser::change_overline,
           signals::parser::change_font, signals::parser::change_alignment, signals::parser::reverse_colors,
-          signals::parser::offset_pixel, signals::parser::attribute_set, signals::parser::attribute_unset,
+          signals::parser::offset, signals::parser::attribute_set, signals::parser::attribute_unset,
           signals::parser::attribute_toggle, signals::parser::action_begin, signals::parser::action_end,
           signals::parser::text, signals::parser::control> {
  public:
@@ -79,7 +79,7 @@ class renderer
   bool on(const signals::parser::change_font& evt);
   bool on(const signals::parser::change_alignment& evt);
   bool on(const signals::parser::reverse_colors&);
-  bool on(const signals::parser::offset_pixel& evt);
+  bool on(const signals::parser::offset& evt);
   bool on(const signals::parser::attribute_set& evt);
   bool on(const signals::parser::attribute_unset& evt);
   bool on(const signals::parser::attribute_toggle& evt);

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -83,20 +83,12 @@ enum class space_type { SPACE, POINT, PIXEL };
 
 enum class size_type { POINT, PIXEL };
 
-namespace details {
-  template <typename T>
-  struct size_with_unit_impl {
-    space_type type{space_type::SPACE};
-    T value{0U};
-  };
-}  // namespace details
-
 struct space_size {
   space_type type{space_type::SPACE};
   float value{0.f};
 };
 
-struct ssize_with_unit {
+struct geometry {
   size_type type{size_type::PIXEL};
   float value{0.f};
 };
@@ -108,7 +100,7 @@ struct side_values {
 
 struct geometry_format_values {
   double percentage{0.};
-  ssize_with_unit offset{size_type::PIXEL, 0};
+  geometry offset{size_type::PIXEL, 0};
 };
 
 struct edge_values {

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -80,10 +80,16 @@ struct size {
 
 enum class unit_type { SPACE, POINT, PIXEL };
 
-struct size_with_unit {
-  unit_type type{unit_type::SPACE};
-  int value{0U};
-};
+namespace details {
+  template <typename T>
+  struct size_with_unit_impl {
+    unit_type type{unit_type::SPACE};
+    T value{0U};
+  };
+}  // namespace details
+
+using size_with_unit = details::size_with_unit_impl<unsigned long int>;
+using ssize_with_unit = details::size_with_unit_impl<long int>;
 
 struct side_values {
   size_with_unit left{unit_type::SPACE, 0U};
@@ -91,8 +97,8 @@ struct side_values {
 };
 
 struct geometry_format_values {
-    double percentage{0.};
-    size_with_unit offset{unit_type::PIXEL, 0U};
+  double percentage{0.};
+  ssize_with_unit offset{unit_type::PIXEL, 0U};
 };
 
 struct edge_values {

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -88,19 +88,23 @@ struct space_size {
   float value{0.f};
 };
 
+static constexpr space_size ZERO_SPACE = {space_type::SPACE, 0.};
+
 struct geometry {
   size_type type{size_type::PIXEL};
   float value{0.f};
 };
 
+static constexpr geometry GEOMETRY_ZERO_PIXEL = {size_type::PIXEL, 0.f};
+
 struct side_values {
-  space_size left{space_type::SPACE, 0_z};
-  space_size right{space_type::SPACE, 0_z};
+  space_size left{ZERO_SPACE};
+  space_size right{ZERO_SPACE};
 };
 
 struct geometry_format_values {
   double percentage{0.};
-  geometry offset{size_type::PIXEL, 0};
+  geometry offset{GEOMETRY_ZERO_PIXEL};
 };
 
 struct edge_values {

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -78,9 +78,21 @@ struct size {
   unsigned int h{1U};
 };
 
+enum class unit_type { SPACE, POINT, PIXEL };
+
+struct size_with_unit {
+  unit_type type{unit_type::SPACE};
+  int value{0U};
+};
+
 struct side_values {
-  unsigned int left{0U};
-  unsigned int right{0U};
+  size_with_unit left{unit_type::SPACE, 0U};
+  size_with_unit right{unit_type::SPACE, 0U};
+};
+
+struct geometry_format_values {
+    double percentage{0.};
+    size_with_unit offset{unit_type::PIXEL, 0U};
 };
 
 struct edge_values {
@@ -141,11 +153,15 @@ struct bar_settings {
   struct size size {
     1U, 1U
   };
+
+  double dpi_x{0.};
+  double dpi_y{0.};
+
   position pos{0, 0};
   position offset{0, 0};
-  side_values padding{0U, 0U};
-  side_values margin{0U, 0U};
-  side_values module_margin{0U, 0U};
+  side_values padding{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
+  side_values margin{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
+  side_values module_margin{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
   edge_values strut{0U, 0U, 0U, 0U};
 
   unsigned int background{0xFF000000};
@@ -158,7 +174,7 @@ struct bar_settings {
   std::unordered_map<edge, border_settings, enum_hash> borders{};
 
   struct radius radius {};
-  int spacing{0};
+  size_with_unit spacing{unit_type::SPACE, 0};
   string separator{};
 
   string wmname{};

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -2,6 +2,7 @@
 
 #include <xcb/xcb.h>
 
+#include <cassert>
 #include <string>
 #include <unordered_map>
 
@@ -78,27 +79,36 @@ struct size {
   unsigned int h{1U};
 };
 
-enum class unit_type { SPACE, POINT, PIXEL };
+enum class space_type { SPACE, POINT, PIXEL };
+
+enum class size_type { POINT, PIXEL };
 
 namespace details {
   template <typename T>
   struct size_with_unit_impl {
-    unit_type type{unit_type::SPACE};
+    space_type type{space_type::SPACE};
     T value{0U};
   };
 }  // namespace details
 
-using size_with_unit = details::size_with_unit_impl<unsigned long int>;
-using ssize_with_unit = details::size_with_unit_impl<long int>;
+struct space_size {
+  space_type type{space_type::SPACE};
+  float value{0.f};
+};
+
+struct ssize_with_unit {
+  size_type type{size_type::PIXEL};
+  float value{0.f};
+};
 
 struct side_values {
-  size_with_unit left{unit_type::SPACE, 0U};
-  size_with_unit right{unit_type::SPACE, 0U};
+  space_size left{space_type::SPACE, 0_z};
+  space_size right{space_type::SPACE, 0_z};
 };
 
 struct geometry_format_values {
   double percentage{0.};
-  ssize_with_unit offset{unit_type::PIXEL, 0U};
+  ssize_with_unit offset{size_type::PIXEL, 0};
 };
 
 struct edge_values {
@@ -165,9 +175,9 @@ struct bar_settings {
 
   position pos{0, 0};
   position offset{0, 0};
-  side_values padding{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
-  side_values margin{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
-  side_values module_margin{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
+  side_values padding{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
+  side_values margin{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
+  side_values module_margin{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
   edge_values strut{0U, 0U, 0U, 0U};
 
   unsigned int background{0xFF000000};
@@ -180,7 +190,7 @@ struct bar_settings {
   std::unordered_map<edge, border_settings, enum_hash> borders{};
 
   struct radius radius {};
-  size_with_unit spacing{unit_type::SPACE, 0};
+  space_size spacing{space_type::SPACE, 0_z};
   string separator{};
 
   string wmname{};

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -28,8 +28,8 @@ namespace drawtypes {
     string m_underline{};
     string m_overline{};
     int m_font{0};
-    side_values m_padding{0U,0U};
-    side_values m_margin{0U,0U};
+    side_values m_padding{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
+    side_values m_margin{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
 
     /*
      * If m_ellipsis is true, m_maxlen MUST be larger or equal to the length of
@@ -41,20 +41,22 @@ namespace drawtypes {
     size_t m_maxlen{0_z};
     bool m_ellipsis{true};
 
-    explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
+    explicit label(string text, int font) : m_font(font), m_text(move(text)), m_tokenized(m_text) {}
     explicit label(string text, string foreground = ""s, string background = ""s, string underline = ""s,
-        string overline = ""s, int font = 0, struct side_values padding = {0U,0U}, struct side_values margin = {0U,0U},
-        size_t maxlen = 0_z, bool ellipsis = true, vector<token>&& tokens = {})
-        : m_foreground(foreground)
-        , m_background(background)
-        , m_underline(underline)
-        , m_overline(overline)
+        string overline = ""s, int font = 0,
+        side_values padding = {{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}},
+        side_values margin = {{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}}, size_t maxlen = 0_z,
+        bool ellipsis = true, vector<token>&& tokens = {})
+        : m_foreground(move(foreground))
+        , m_background(move(background))
+        , m_underline(move(underline))
+        , m_overline(move(overline))
         , m_font(font)
         , m_padding(padding)
         , m_margin(margin)
         , m_maxlen(maxlen)
         , m_ellipsis(ellipsis)
-        , m_text(text)
+        , m_text(move(text))
         , m_tokenized(m_text)
         , m_tokens(forward<vector<token>>(tokens)) {
           assert(!m_ellipsis || (m_maxlen == 0 || m_maxlen >= 3));

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -28,8 +28,8 @@ namespace drawtypes {
     string m_underline{};
     string m_overline{};
     int m_font{0};
-    side_values m_padding{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
-    side_values m_margin{{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}};
+    side_values m_padding{{space_type::SPACE, 0U}, {space_type::SPACE, 0U}};
+    side_values m_margin{{space_type::SPACE, 0U}, {space_type::SPACE, 0U}};
 
     /*
      * If m_ellipsis is true, m_maxlen MUST be larger or equal to the length of
@@ -43,9 +43,8 @@ namespace drawtypes {
 
     explicit label(string text, int font) : m_font(font), m_text(move(text)), m_tokenized(m_text) {}
     explicit label(string text, string foreground = ""s, string background = ""s, string underline = ""s,
-        string overline = ""s, int font = 0,
-        side_values padding = {{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}},
-        side_values margin = {{unit_type::SPACE, 0U}, {unit_type::SPACE, 0U}}, size_t maxlen = 0_z,
+        string overline = ""s, int font = 0, side_values padding = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}},
+        side_values margin = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}}, size_t maxlen = 0_z,
         bool ellipsis = true, vector<token>&& tokens = {})
         : m_foreground(move(foreground))
         , m_background(move(background))
@@ -59,11 +58,11 @@ namespace drawtypes {
         , m_text(move(text))
         , m_tokenized(m_text)
         , m_tokens(forward<vector<token>>(tokens)) {
-          assert(!m_ellipsis || (m_maxlen == 0 || m_maxlen >= 3));
-        }
+      assert(!m_ellipsis || (m_maxlen == 0 || m_maxlen >= 3));
+    }
 
     string get() const;
-    operator bool();
+    explicit operator bool();
     label_t clone();
     void clear();
     void reset_tokens();
@@ -81,6 +80,6 @@ namespace drawtypes {
 
   label_t load_label(const config& conf, const string& section, string name, bool required = true, string def = ""s);
   label_t load_optional_label(const config& conf, string section, string name, string def = ""s);
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -152,7 +152,7 @@ namespace signals {
     struct reverse_colors : public detail::base_signal<reverse_colors> {
       using base_type::base_type;
     };
-    struct offset_pixel : public detail::value_signal<offset_pixel, int> {
+    struct offset : public detail::value_signal<offset, string> {
       using base_type::base_type;
     };
     struct attribute_set : public detail::value_signal<attribute_set, attribute> {

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -152,7 +152,7 @@ namespace signals {
     struct reverse_colors : public detail::base_signal<reverse_colors> {
       using base_type::base_type;
     };
-    struct offset : public detail::value_signal<offset, string> {
+    struct offset : public detail::value_signal<offset, geometry> {
       using base_type::base_type;
     };
     struct attribute_set : public detail::value_signal<attribute_set, attribute> {

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -52,7 +52,7 @@ namespace signals {
     struct change_font;
     struct change_alignment;
     struct reverse_colors;
-    struct offset_pixel;
+    struct offset;
     struct attribute_set;
     struct attribute_unset;
     struct attribute_toggle;

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -37,7 +37,7 @@ namespace modules {
     ramp_t m_rampload;
     ramp_t m_rampload_core;
     label_t m_label;
-    size_with_unit m_ramp_padding{unit_type::SPACE, 1U};
+    space_size m_ramp_padding{space_type::SPACE, 1U};
 
     vector<cpu_time_t> m_cputimes;
     vector<cpu_time_t> m_cputimes_prev;
@@ -45,6 +45,6 @@ namespace modules {
     float m_total = 0;
     vector<float> m_load;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -37,7 +37,7 @@ namespace modules {
     ramp_t m_rampload;
     ramp_t m_rampload_core;
     label_t m_label;
-    int m_ramp_padding;
+    size_with_unit m_ramp_padding{unit_type::SPACE, 1U};
 
     vector<cpu_time_t> m_cputimes;
     vector<cpu_time_t> m_cputimes_prev;

--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <utility>
+
 #include "components/config.hpp"
-#include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -25,7 +27,7 @@ namespace modules {
     int percentage_free{0};
     int percentage_used{0};
 
-    explicit fs_mount(const string& mountpoint, bool mounted = false) : mountpoint(mountpoint), mounted(mounted) {}
+    explicit fs_mount(string mountpoint, bool mounted = false) : mountpoint(std::move(mountpoint)), mounted(mounted) {}
   };
 
   using fs_mount_t = unique_ptr<fs_mount>;
@@ -61,11 +63,11 @@ namespace modules {
     vector<fs_mount_t> m_mounts;
     bool m_fixed{false};
     bool m_remove_unmounted{false};
-    size_with_unit m_spacing{unit_type::SPACE, 2U};
+    space_size m_spacing{space_type::SPACE, 2U};
 
     // used while formatting output
     size_t m_index{0_z};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -61,7 +61,7 @@ namespace modules {
     vector<fs_mount_t> m_mounts;
     bool m_fixed{false};
     bool m_remove_unmounted{false};
-    int m_spacing{2};
+    size_with_unit m_spacing{unit_type::SPACE, 2U};
 
     // used while formatting output
     size_t m_index{0_z};

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -68,9 +68,9 @@ namespace modules {
     string ol{};
     size_t ulsize{0};
     size_t olsize{0};
-    size_with_unit spacing{unit_type::SPACE, 0U};
-    size_with_unit padding{unit_type::SPACE, 0U};
-    size_with_unit margin{unit_type::SPACE, 0U};
+    space_size spacing{space_type::SPACE, 0U};
+    space_size padding{space_type::SPACE, 0U};
+    space_size margin{space_type::SPACE, 0U};
     int offset{0};
     int font{0};
 

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -68,9 +68,9 @@ namespace modules {
     string ol{};
     size_t ulsize{0};
     size_t olsize{0};
-    space_size spacing{space_type::SPACE, 0U};
-    space_size padding{space_type::SPACE, 0U};
-    space_size margin{space_type::SPACE, 0U};
+    space_size spacing{ZERO_SPACE};
+    space_size padding{ZERO_SPACE};
+    space_size margin{ZERO_SPACE};
     int offset{0};
     int font{0};
 

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -39,7 +39,7 @@ namespace drawtypes {
   using animation_t = shared_ptr<animation>;
   class iconset;
   using iconset_t = shared_ptr<iconset>;
-}
+}  // namespace drawtypes
 
 class builder;
 class config;
@@ -68,9 +68,9 @@ namespace modules {
     string ol{};
     size_t ulsize{0};
     size_t olsize{0};
-    size_t spacing{0};
-    size_t padding{0};
-    size_t margin{0};
+    size_with_unit spacing{unit_type::SPACE, 0U};
+    size_with_unit padding{unit_type::SPACE, 0U};
+    size_with_unit margin{unit_type::SPACE, 0U};
     int offset{0};
     int font{0};
 
@@ -162,6 +162,6 @@ namespace modules {
   };
 
   // }}}
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -71,7 +71,7 @@ namespace modules {
     space_size spacing{ZERO_SPACE};
     space_size padding{ZERO_SPACE};
     space_size margin{ZERO_SPACE};
-    int offset{0};
+    geometry offset{GEOMETRY_ZERO_PIXEL};
     int font{0};
 
     string decorate(builder* builder, string output);

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -133,7 +133,7 @@ namespace modules {
     bool no_tag_built{true};
     bool fake_no_tag_built{false};
     bool tag_built{false};
-    auto mingap = std::max(1_z, format->spacing);
+    auto mingap = std::max(1, format->spacing.value);
     size_t start, end;
     string value{format->value};
     while ((start = value.find('<')) != string::npos && (end = value.find('>', start)) != string::npos) {

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -133,7 +133,7 @@ namespace modules {
     bool no_tag_built{true};
     bool fake_no_tag_built{false};
     bool tag_built{false};
-    auto mingap = std::max(1, format->spacing.value);
+    auto mingap = std::max(1UL, format->spacing.value);
     size_t start, end;
     string value{format->value};
     while ((start = value.find('<')) != string::npos && (end = value.find('>', start)) != string::npos) {

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -133,7 +133,7 @@ namespace modules {
     bool no_tag_built{true};
     bool fake_no_tag_built{false};
     bool tag_built{false};
-    auto mingap = std::max(1UL, format->spacing.value);
+    auto mingap = std::max(1.f, format->spacing.value);
     size_t start, end;
     string value{format->value};
     while ((start = value.find('<')) != string::npos && (end = value.find('>', start)) != string::npos) {

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+
+#include "components/types.hpp"
+
+POLYBAR_NS
+
+namespace unit_utils {
+  template <typename ValueType, typename ReturnType = int>
+  ReturnType point_to_pixel(ValueType point, ValueType dpi) {
+    return static_cast<ReturnType>(dpi * point / ValueType(72));
+  }
+
+  template <typename ReturnType = int>
+  ReturnType size_with_unit_to_pixel(size_with_unit size, double dpi) {
+    if (size.type == unit_type::PIXEL) {
+      return size.value;
+    }
+
+    return point_to_pixel<double, ReturnType>(size.value, dpi);
+  }
+
+  inline string size_with_unit_to_string(size_with_unit size, double dpi) {
+    if (size.value > 0) {
+      if (size.type == unit_type::SPACE) {
+        return string(static_cast<string::size_type>(size.value), ' ');
+      } else {
+        if (size.type == unit_type::POINT) {
+          size.value = point_to_pixel(static_cast<double>(size.value), dpi);
+        }
+
+        return "%{O" + to_string(size.value) + "}";
+      }
+    }
+    return {};
+  }
+}  // namespace unit_utils
+
+POLYBAR_NS_END

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -7,13 +7,13 @@
 POLYBAR_NS
 
 namespace unit_utils {
-  template <typename ValueType, typename ReturnType = int>
+  template <typename ValueType, typename ReturnType = long unsigned int>
   ReturnType point_to_pixel(ValueType point, ValueType dpi) {
     return static_cast<ReturnType>(dpi * point / ValueType(72));
   }
 
-  template <typename ReturnType = int>
-  ReturnType size_with_unit_to_pixel(size_with_unit size, double dpi) {
+  template <typename ReturnType = int, typename T>
+  ReturnType size_with_unit_to_pixel(details::size_with_unit_impl<T> size, double dpi) {
     if (size.type == unit_type::PIXEL || size.type == unit_type::SPACE) { // For this function space are interpreted as PIXEL
       return size.value;
     }
@@ -24,7 +24,7 @@ namespace unit_utils {
   inline string size_with_unit_to_string(size_with_unit size, double dpi) {
     if (size.value > 0) {
       if (size.type == unit_type::SPACE) {
-        return string(static_cast<string::size_type>(size.value), ' ');
+        return string(size.value, ' ');
       } else {
         if (size.type == unit_type::POINT) {
           size.value = point_to_pixel(static_cast<double>(size.value), dpi);

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -14,7 +14,7 @@ namespace unit_utils {
 
   template <typename ReturnType = int>
   ReturnType size_with_unit_to_pixel(size_with_unit size, double dpi) {
-    if (size.type == unit_type::PIXEL) {
+    if (size.type == unit_type::PIXEL || size.type == unit_type::SPACE) { // For this function space are interpreted as PIXEL
       return size.value;
     }
 

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -70,6 +70,24 @@ namespace unit_utils {
 
     return size;
   }
+
+  inline string geometry_to_string(geometry geometry) {
+    if (geometry.value > 0) {
+      switch (geometry.type) {
+        case size_type::POINT: {
+          auto str = to_string(geometry.value);
+          str += "pt";
+          return str;
+        }
+        case size_type::PIXEL: {
+          return to_string(static_cast<int>(geometry.value));
+        }
+      }
+    }
+
+    return {};
+  }
+
 }  // namespace unit_utils
 
 POLYBAR_NS_END

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -12,21 +12,32 @@ namespace unit_utils {
     return static_cast<ReturnType>(dpi * point / ValueType(72));
   }
 
-  template <typename ReturnType = int, typename T>
-  ReturnType size_with_unit_to_pixel(details::size_with_unit_impl<T> size, double dpi) {
-    if (size.type == unit_type::PIXEL || size.type == unit_type::SPACE) { // For this function space are interpreted as PIXEL
+  template <typename ReturnType = int>
+  ReturnType space_type_to_pixel(space_size size, double dpi) {
+    assert(size.type != space_type::SPACE);
+
+    if (size.type == space_type::PIXEL) {
       return size.value;
     }
 
     return point_to_pixel<double, ReturnType>(size.value, dpi);
   }
 
-  inline string size_with_unit_to_string(size_with_unit size, double dpi) {
+  template <typename ReturnType = int>
+  ReturnType geometry_type_to_pixel(ssize_with_unit size, double dpi) {
+    if (size.type == size_type::PIXEL) {
+      return size.value;
+    }
+
+    return point_to_pixel<double, ReturnType>(size.value, dpi);
+  }
+
+  inline string size_with_unit_to_string(space_size size, double dpi) {
     if (size.value > 0) {
-      if (size.type == unit_type::SPACE) {
-        return string(size.value, ' ');
+      if (size.type == space_type::SPACE) {
+        return string(static_cast<string::size_type>(size.value), ' ');
       } else {
-        if (size.type == unit_type::POINT) {
+        if (size.type == space_type::POINT) {
           size.value = point_to_pixel(static_cast<double>(size.value), dpi);
         }
 

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -217,17 +217,7 @@ void builder::offset(geometry pixels) {
  */
 void builder::space(space_size size) {
   if (size.value > 0.) {
-    switch (size.type) {
-      case space_type::SPACE:
-        m_output += string(static_cast<string::size_type>(size.value), ' ');
-        break;
-      case space_type::POINT:
-      case space_type::PIXEL:
-        m_output += "%{O";
-        m_output += unit_utils::space_size_to_string(size);
-        m_output += "}";
-        break;
-    }
+    m_output += add_surrounding_tag(size);
   } else {
     space();
   }
@@ -627,6 +617,24 @@ void builder::tag_close(attribute attr) {
       append("%{-o}");
       break;
   }
+}
+string builder::add_surrounding_tag(const space_size& space) {
+  if (space.value == 0) {
+    return "";
+  }
+
+  string out;
+  if (space.type == space_type::POINT || space.type == space_type::PIXEL) {
+    out += "%{O";
+  }
+
+  out += unit_utils::space_size_to_string(space);
+
+  if (space.type == space_type::POINT || space.type == space_type::PIXEL) {
+    out += '}';
+  }
+
+  return out;
 }
 
 POLYBAR_NS_END

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -5,6 +5,8 @@
 #include "utils/color.hpp"
 #include "utils/string.hpp"
 #include "utils/time.hpp"
+#include "utils/unit.hpp"
+
 POLYBAR_NS
 
 builder::builder(const bar_settings& bar) : m_bar(bar) {
@@ -126,7 +128,7 @@ void builder::node(const label_t& label, bool add_space) {
 
   auto text = get_label_text(label);
 
-  if (label->m_margin.left > 0) {
+  if (label->m_margin.left.value > 0) {
     space(label->m_margin.left);
   }
 
@@ -144,13 +146,13 @@ void builder::node(const label_t& label, bool add_space) {
     color(label->m_foreground);
   }
 
-  if (label->m_padding.left > 0) {
+  if (label->m_padding.left.value > 0) {
     space(label->m_padding.left);
   }
 
   node(text, label->m_font, add_space);
 
-  if (label->m_padding.right > 0) {
+  if (label->m_padding.right.value > 0) {
     space(label->m_padding.right);
   }
 
@@ -161,14 +163,14 @@ void builder::node(const label_t& label, bool add_space) {
     color_close();
   }
 
-  if (!label->m_underline.empty()) {
+  if (!label->m_underline.empty() || (label->m_margin.right.value > 0 && m_tags[syntaxtag::u] > 0)) {
     underline_close();
   }
-  if (!label->m_overline.empty()) {
+  if (!label->m_overline.empty() || (label->m_margin.right.value > 0 && m_tags[syntaxtag::o] > 0)) {
     overline_close();
   }
 
-  if (label->m_margin.right > 0) {
+  if (label->m_margin.right.value > 0) {
     space(label->m_margin.right);
   }
 }
@@ -213,15 +215,17 @@ void builder::offset(int pixels) {
 /**
  * Insert spaces
  */
-void builder::space(size_t width) {
-  if (width) {
-    m_output.append(width, ' ');
+void builder::space(size_with_unit size) {
+  if (size.value > 0) {
+    m_output += unit_utils::size_with_unit_to_string(size, m_bar.dpi_x);
   } else {
     space();
   }
 }
 void builder::space() {
-  m_output.append(m_bar.spacing, ' ');
+  if (m_bar.spacing.value > 0) {
+    space(m_bar.spacing);
+  }
 }
 
 /**
@@ -235,7 +239,7 @@ void builder::remove_trailing_space(size_t len) {
   }
 }
 void builder::remove_trailing_space() {
-  remove_trailing_space(m_bar.spacing);
+  remove_trailing_space(static_cast<size_t>(m_bar.spacing.value));
 }
 
 /**

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -215,8 +215,8 @@ void builder::offset(int pixels) {
 /**
  * Insert spaces
  */
-void builder::space(size_with_unit size) {
-  if (size.value > 0) {
+void builder::space(space_size size) {
+  if (size.value > 0.) {
     m_output += unit_utils::size_with_unit_to_string(size, m_bar.dpi_x);
   } else {
     space();

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -205,11 +205,11 @@ void builder::node_repeat(const label_t& label, size_t n, bool add_space) {
 /**
  * Insert tag that will offset the contents by given pixels
  */
-void builder::offset(int pixels) {
-  if (pixels == 0) {
+void builder::offset(geometry pixels) {
+  if (pixels.value == 0) {
     return;
   }
-  tag_open(syntaxtag::O, to_string(pixels));
+  tag_open(syntaxtag::O, unit_utils::geometry_to_string(pixels));
 }
 
 /**

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -217,7 +217,17 @@ void builder::offset(int pixels) {
  */
 void builder::space(space_size size) {
   if (size.value > 0.) {
-    m_output += unit_utils::size_with_unit_to_string(size, m_bar.dpi_x);
+    switch (size.type) {
+      case space_type::SPACE:
+        m_output += string(static_cast<string::size_type>(size.value), ' ');
+        break;
+      case space_type::POINT:
+      case space_type::PIXEL:
+        m_output += "%{O";
+        m_output += unit_utils::space_size_to_string(size);
+        m_output += "}";
+        break;
+    }
   } else {
     space();
   }

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -3,6 +3,7 @@
 
 #include "cairo/utils.hpp"
 #include "components/config.hpp"
+#include "components/types.hpp"
 #include "utils/color.hpp"
 #include "utils/env.hpp"
 #include "utils/factory.hpp"

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -210,6 +210,11 @@ space_size config::convert(string&& value) const {
   return size;
 }
 
+template <>
+geometry config::convert(std::string&& value) const {
+  return unit_utils::geometry_from_string(move(value));
+}
+
 /**
  * Allows a new format for pixel sizes (like width in the bar section)
  *
@@ -224,11 +229,11 @@ geometry_format_values config::convert(string&& value) const {
     if (value.find('%') != std::string::npos) {
       return {strtod(value.c_str(), nullptr), {}};
     } else {
-      return {0., unit_utils::geometry_from_string(move(value))};
+      return {0., convert<geometry>(move(value))};
     }
   } else {
     std::string percentage = value.substr(0, i - 1);
-    return {strtod(percentage.c_str(), nullptr), unit_utils::geometry_from_string(value.substr(i + 1))};
+    return {strtod(percentage.c_str(), nullptr), convert<geometry>(value.substr(i + 1))};
   }
 }
 

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -9,6 +9,7 @@
 #include "utils/env.hpp"
 #include "utils/factory.hpp"
 #include "utils/string.hpp"
+#include "utils/unit.hpp"
 
 POLYBAR_NS
 
@@ -209,24 +210,6 @@ space_size config::convert(string&& value) const {
   return size;
 }
 
-template <>
-ssize_with_unit config::convert(string&& value) const {
-  char* new_end;
-  auto size_value = std::strtof(value.c_str(), &new_end);
-
-  ssize_with_unit size{size_type::PIXEL, size_value};
-
-  string unit = string_util::trim(new_end);
-  if (!unit.empty()) {
-    if (unit == "px") {
-      size.value = static_cast<ssize_t>(std::trunc(size.value));
-    } else if (unit == "pt") {
-      size.type = size_type::POINT;
-    }
-  }
-
-  return size;
-}
 /**
  * Allows a new format for pixel sizes (like width in the bar section)
  *
@@ -241,11 +224,11 @@ geometry_format_values config::convert(string&& value) const {
     if (value.find('%') != std::string::npos) {
       return {strtod(value.c_str(), nullptr), {}};
     } else {
-      return {0., convert<ssize_with_unit>(move(value))};
+      return {0., unit_utils::geometry_from_string(move(value))};
     }
   } else {
     std::string percentage = value.substr(0, i - 1);
-    return {strtod(percentage.c_str(), nullptr), convert<ssize_with_unit>(value.substr(i + 1))};
+    return {strtod(percentage.c_str(), nullptr), unit_utils::geometry_from_string(value.substr(i + 1))};
   }
 }
 

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -1,4 +1,5 @@
 #include <climits>
+#include <cmath>
 #include <fstream>
 
 #include "cairo/utils.hpp"
@@ -183,22 +184,25 @@ unsigned long long config::convert(string&& value) const {
 }
 
 template <>
-size_with_unit config::convert(string&& value) const {
+space_size config::convert(string&& value) const {
   char* new_end;
-  auto size_value = std::strtol(value.c_str(), &new_end, 10);
+  auto size_value = std::strtof(value.c_str(), &new_end);
 
   if (size_value < 0) {
     throw application_error(sstream() << "Value: " << value << " must be positive ");
   }
 
-  size_with_unit size{unit_type::SPACE, static_cast<long unsigned int>(size_value)};
+  space_size size{space_type::SPACE, size_value};
 
   string unit = string_util::trim(new_end);
   if (!unit.empty()) {
     if (unit == "px") {
-      size.type = unit_type::PIXEL;
+      size.type = space_type::PIXEL;
+      size.value = std::trunc(size.value);
     } else if (unit == "pt") {
-      size.type = unit_type::POINT;
+      size.type = space_type::POINT;
+    } else {
+      size.value = std::trunc(size.value);
     }
   }
 
@@ -208,16 +212,16 @@ size_with_unit config::convert(string&& value) const {
 template <>
 ssize_with_unit config::convert(string&& value) const {
   char* new_end;
-  auto size_value = std::strtol(value.c_str(), &new_end, 10);
+  auto size_value = std::strtof(value.c_str(), &new_end);
 
-  ssize_with_unit size{unit_type::SPACE, size_value};
+  ssize_with_unit size{size_type::PIXEL, size_value};
 
   string unit = string_util::trim(new_end);
   if (!unit.empty()) {
     if (unit == "px") {
-      size.type = unit_type::PIXEL;
+      size.value = static_cast<ssize_t>(std::trunc(size.value));
     } else if (unit == "pt") {
-      size.type = unit_type::POINT;
+      size.type = size_type::POINT;
     }
   }
 
@@ -231,24 +235,17 @@ ssize_with_unit config::convert(string&& value) const {
  */
 template <>
 geometry_format_values config::convert(string&& value) const {
-  auto get_space_value = [this](string&& str) -> ssize_with_unit {
-    auto s_value = convert<ssize_with_unit>(move(str));
-    s_value.type = (s_value.type == unit_type::SPACE) ? unit_type::PIXEL : s_value.type;
-
-    return s_value;
-  };
-
   size_t i = value.find(':');
 
   if (i == std::string::npos) {
     if (value.find('%') != std::string::npos) {
       return {strtod(value.c_str(), nullptr), {}};
     } else {
-      return {0., get_space_value(move(value))};
+      return {0., convert<ssize_with_unit>(move(value))};
     }
   } else {
     std::string percentage = value.substr(0, i - 1);
-    return {strtod(percentage.c_str(), nullptr), get_space_value(value.substr(i + 1))};
+    return {strtod(percentage.c_str(), nullptr), convert<ssize_with_unit>(value.substr(i + 1))};
   }
 }
 

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -461,29 +461,10 @@ bool controller::process_update(bool force) {
   string contents;
   string separator{bar.separator};
 
-  auto add_surrounding_tag = [](const space_size& space_size) -> std::string {
-    if (space_size.value == 0) {
-      return "";
-    }
-
-    string out;
-    if (space_size.type == space_type::POINT || space_size.type == space_type::PIXEL) {
-      out += "%{O";
-    }
-
-    out += unit_utils::space_size_to_string(space_size);
-
-    if (space_size.type == space_type::POINT || space_size.type == space_type::PIXEL) {
-      out += '}';
-    }
-
-    return out;
-  };
-
-  string padding_left = add_surrounding_tag(bar.padding.left);
-  string padding_right = add_surrounding_tag(bar.padding.right);
-  string margin_left = add_surrounding_tag(bar.module_margin.left);
-  string margin_right = add_surrounding_tag(bar.module_margin.right);
+  string padding_left = builder::add_surrounding_tag(bar.padding.left);
+  string padding_right = builder::add_surrounding_tag(bar.padding.right);
+  string margin_left = builder::add_surrounding_tag(bar.module_margin.left);
+  string margin_right = builder::add_surrounding_tag(bar.module_margin.right);
 
   for (const auto& block : m_modules) {
     string block_contents;

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -460,10 +460,10 @@ bool controller::process_update(bool force) {
   const bar_settings& bar{m_bar->settings()};
   string contents;
   string separator{bar.separator};
-  string padding_left(bar.padding.left, ' ');
-  string padding_right(bar.padding.right, ' ');
-  string margin_left(bar.module_margin.left, ' ');
-  string margin_right(bar.module_margin.right, ' ');
+  string padding_left = unit_utils::size_with_unit_to_string(bar.padding.left, bar.dpi_x);
+  string padding_right = unit_utils::size_with_unit_to_string(bar.padding.right, bar.dpi_x);
+  string margin_left = unit_utils::size_with_unit_to_string(bar.margin.left, bar.dpi_x);
+  string margin_right = unit_utils::size_with_unit_to_string(bar.margin.right, bar.dpi_x);
 
   for (const auto& block : m_modules) {
     string block_contents;

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -462,8 +462,8 @@ bool controller::process_update(bool force) {
   string separator{bar.separator};
   string padding_left = unit_utils::size_with_unit_to_string(bar.padding.left, bar.dpi_x);
   string padding_right = unit_utils::size_with_unit_to_string(bar.padding.right, bar.dpi_x);
-  string margin_left = unit_utils::size_with_unit_to_string(bar.margin.left, bar.dpi_x);
-  string margin_right = unit_utils::size_with_unit_to_string(bar.margin.right, bar.dpi_x);
+  string margin_left = unit_utils::size_with_unit_to_string(bar.module_margin.left, bar.dpi_x);
+  string margin_right = unit_utils::size_with_unit_to_string(bar.module_margin.right, bar.dpi_x);
 
   for (const auto& block : m_modules) {
     string block_contents;

--- a/src/components/parser.cpp
+++ b/src/components/parser.cpp
@@ -9,6 +9,7 @@
 #include "utils/factory.hpp"
 #include "utils/memory.hpp"
 #include "utils/string.hpp"
+#include "utils/unit.hpp"
 
 POLYBAR_NS
 
@@ -131,7 +132,7 @@ void parser::codeblock(string&& data, const bar_settings& bar) {
         break;
 
       case 'O':
-        m_sig.emit(offset{string{value}});
+        m_sig.emit(offset{unit_utils::geometry_from_string(string{value})});
         break;
 
       case 'l':

--- a/src/components/parser.cpp
+++ b/src/components/parser.cpp
@@ -131,7 +131,7 @@ void parser::codeblock(string&& data, const bar_settings& bar) {
         break;
 
       case 'O':
-        m_sig.emit(offset_pixel{static_cast<int>(std::strtol(value.c_str(), nullptr, 10))});
+        m_sig.emit(offset{string{value}});
         break;
 
       case 'l':

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -757,11 +757,10 @@ bool renderer::on(const signals::parser::reverse_colors&) {
 bool renderer::on(const signals::parser::offset& evt) {
   m_log.trace_x("renderer: offset(%f)", evt.cast());
 
-  auto& x_offset = m_blocks[m_align].x;
   auto offset_width = unit_utils::geometry_to_pixel(unit_utils::geometry_from_string(evt.cast()), m_bar.dpi_x);
+  draw_offset(m_blocks[m_align].x, offset_width);
+  m_blocks[m_align].x += offset_width;
 
-  draw_offset(x_offset, offset_width);
-  x_offset += offset_width;
   return true;
 }
 

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -7,6 +7,7 @@
 #include "events/signal_receiver.hpp"
 #include "utils/factory.hpp"
 #include "utils/math.hpp"
+#include "utils/unit.hpp"
 #include "x11/atoms.hpp"
 #include "x11/background_manager.hpp"
 #include "x11/connection.hpp"
@@ -642,8 +643,8 @@ void renderer::draw_offset(double x, double w) {
     m_context->save();
     *m_context << m_comp_bg;
     *m_context << m_bg;
-    *m_context << cairo::rect{m_rect.x + x, static_cast<double>(m_rect.y), w,
-                              static_cast<double>(m_rect.y + m_rect.height)};
+    *m_context << cairo::rect{
+        m_rect.x + x, static_cast<double>(m_rect.y), w, static_cast<double>(m_rect.y + m_rect.height)};
     m_context->fill();
     m_context->restore();
   }
@@ -753,10 +754,14 @@ bool renderer::on(const signals::parser::reverse_colors&) {
   return true;
 }
 
-bool renderer::on(const signals::parser::offset_pixel& evt) {
-  m_log.trace_x("renderer: offset_pixel(%f)", evt.cast());
-  draw_offset(m_blocks[m_align].x, evt.cast());
-  m_blocks[m_align].x += evt.cast();
+bool renderer::on(const signals::parser::offset& evt) {
+  m_log.trace_x("renderer: offset(%f)", evt.cast());
+
+  auto& x_offset = m_blocks[m_align].x;
+  auto offset_width = unit_utils::geometry_to_pixel(unit_utils::geometry_from_string(evt.cast()), m_bar.dpi_x);
+
+  draw_offset(x_offset, offset_width);
+  x_offset += offset_width;
   return true;
 }
 

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -118,31 +118,6 @@ renderer::renderer(connection& conn, signal_emitter& sig, const config& conf, co
 
   m_log.trace("renderer: Load fonts");
   {
-    double dpi_x = 96, dpi_y = 96;
-    if (m_conf.has(m_conf.section(), "dpi")) {
-      dpi_x = dpi_y = m_conf.get<double>("dpi");
-    } else {
-      if (m_conf.has(m_conf.section(), "dpi-x")) {
-        dpi_x = m_conf.get<double>("dpi-x");
-      }
-      if (m_conf.has(m_conf.section(), "dpi-y")) {
-        dpi_y = m_conf.get<double>("dpi-y");
-      }
-    }
-
-    // dpi to be comptued
-    if (dpi_x <= 0 || dpi_y <= 0) {
-      auto screen = m_connection.screen();
-      if (dpi_x <= 0) {
-        dpi_x = screen->width_in_pixels * 25.4 / screen->width_in_millimeters;
-      }
-      if (dpi_y <= 0) {
-        dpi_y = screen->height_in_pixels * 25.4 / screen->height_in_millimeters;
-      }
-    }
-
-    m_log.info("Configured DPI = %gx%g", dpi_x, dpi_y);
-
     auto fonts = m_conf.get_list<string>(m_conf.section(), "font", {});
     if (fonts.empty()) {
       m_log.warn("No fonts specified, using fallback font \"fixed\"");
@@ -157,7 +132,7 @@ renderer::renderer(connection& conn, signal_emitter& sig, const config& conf, co
         offset = std::strtol(pattern.substr(pos + 1).c_str(), nullptr, 10);
         pattern.erase(pos);
       }
-      auto font = cairo::make_font(*m_context, string{pattern}, offset, dpi_x, dpi_y);
+      auto font = cairo::make_font(*m_context, string{pattern}, offset, m_bar.dpi_x, m_bar.dpi_y);
       m_log.info("Loaded font \"%s\" (name=%s, offset=%i, file=%s)", pattern, font->name(), offset, font->file());
       *m_context << move(font);
     }

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -1,4 +1,5 @@
 #include "components/renderer.hpp"
+
 #include "cairo/context.hpp"
 #include "components/config.hpp"
 #include "events/signal.hpp"
@@ -635,6 +636,19 @@ void renderer::draw_text(const string& contents) {
   }
 }
 
+void renderer::draw_offset(double x, double w) {
+  if (w > 0. && m_bg != m_bar.background) {
+    m_log.trace_x("renderer: offset(x=%f, w=%f)", x, w);
+    m_context->save();
+    *m_context << m_comp_bg;
+    *m_context << m_bg;
+    *m_context << cairo::rect{m_rect.x + x, static_cast<double>(m_rect.y), w,
+                              static_cast<double>(m_rect.y + m_rect.height)};
+    m_context->fill();
+    m_context->restore();
+  }
+}
+
 /**
  * Colorize the bounding box of created action blocks
  */
@@ -741,6 +755,7 @@ bool renderer::on(const signals::parser::reverse_colors&) {
 
 bool renderer::on(const signals::parser::offset_pixel& evt) {
   m_log.trace_x("renderer: offset_pixel(%f)", evt.cast());
+  draw_offset(m_blocks[m_align].x, evt.cast());
   m_blocks[m_align].x += evt.cast();
   return true;
 }

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -79,16 +79,16 @@ namespace drawtypes {
     if (label->m_font != 0) {
       m_font = label->m_font;
     }
-    if (label->m_padding.left != 0U) {
+    if (label->m_padding.left.value != 0U) {
       m_padding.left = label->m_padding.left;
     }
-    if (label->m_padding.right != 0U) {
+    if (label->m_padding.right.value != 0U) {
       m_padding.right = label->m_padding.right;
     }
-    if (label->m_margin.left != 0U) {
+    if (label->m_margin.left.value != 0U) {
       m_margin.left = label->m_margin.left;
     }
-    if (label->m_margin.right != 0U) {
+    if (label->m_margin.right.value != 0U) {
       m_margin.right = label->m_margin.right;
     }
     if (label->m_maxlen != 0_z) {
@@ -113,16 +113,16 @@ namespace drawtypes {
     if (m_font == 0 && label->m_font != 0) {
       m_font = label->m_font;
     }
-    if (m_padding.left == 0U && label->m_padding.left != 0U) {
+    if (m_padding.left.value == 0U && label->m_padding.left.value != 0U) {
       m_padding.left = label->m_padding.left;
     }
-    if (m_padding.right == 0U && label->m_padding.right != 0U) {
+    if (m_padding.right.value == 0U && label->m_padding.right.value != 0U) {
       m_padding.right = label->m_padding.right;
     }
-    if (m_margin.left == 0U && label->m_margin.left != 0U) {
+    if (m_margin.left.value == 0U && label->m_margin.left.value != 0U) {
       m_margin.left = label->m_margin.left;
     }
-    if (m_margin.right == 0U && label->m_margin.right != 0U) {
+    if (m_margin.right.value == 0U && label->m_margin.right.value != 0U) {
       m_margin.right = label->m_margin.right;
     }
     if (m_maxlen == 0_z && label->m_maxlen != 0_z) {
@@ -151,11 +151,11 @@ namespace drawtypes {
       text = conf.get(section, name, move(def));
     }
 
-    const auto get_left_right = [&](string key) {
-      auto value = conf.get(section, key, 0U);
+    const auto get_left_right = [&](string&& key) {
+      auto value = conf.get(section, key, size_with_unit{});
       auto left = conf.get(section, key + "-left", value);
       auto right = conf.get(section, key + "-right", value);
-      return side_values{static_cast<unsigned short int>(left), static_cast<unsigned short int>(right)};
+      return side_values{left, right};
     };
 
     padding = get_left_right(name + "-padding");

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -148,11 +148,11 @@ namespace drawtypes {
     if (required) {
       text = conf.get(section, name);
     } else {
-      text = conf.get(section, name, move(def));
+      text = conf.get(section, name, def);
     }
 
     const auto get_left_right = [&](string&& key) {
-      const auto parse_or_throw = [&](const string& key, size_with_unit default_value) {
+      const auto parse_or_throw = [&](const string& key, space_size default_value) {
         try {
           return conf.get(section, key, default_value);
         } catch (const std::exception& err) {
@@ -161,7 +161,7 @@ namespace drawtypes {
         }
       };
 
-      auto value = parse_or_throw(key, size_with_unit{});
+      auto value = parse_or_throw(key, space_size{});
       auto left = parse_or_throw(key + "-left", value);
       auto right = parse_or_throw(key + "-right", value);
       return side_values{left, right};
@@ -229,12 +229,14 @@ namespace drawtypes {
     size_t maxlen = conf.get(section, name + "-maxlen", 0_z);
     bool ellipsis = conf.get(section, name + "-ellipsis", true);
 
+    // clang-format off
     if(ellipsis && maxlen > 0 && maxlen < 3) {
       throw application_error(sstream()
           << "Label " << section << "." << name
           << " has maxlen " << maxlen
           << ", which is smaller than length of ellipsis (3)");
     }
+    // clang-format on
 
     // clang-format off
     return factory_util::shared<label>(text,
@@ -255,9 +257,9 @@ namespace drawtypes {
    * Create a label by loading optional values from the configuration
    */
   label_t load_optional_label(const config& conf, string section, string name, string def) {
-    return load_label(conf, move(section), move(name), false, move(def));
+    return load_label(conf, section, move(name), false, move(def));
   }
 
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -152,9 +152,18 @@ namespace drawtypes {
     }
 
     const auto get_left_right = [&](string&& key) {
-      auto value = conf.get(section, key, size_with_unit{});
-      auto left = conf.get(section, key + "-left", value);
-      auto right = conf.get(section, key + "-right", value);
+      const auto parse_or_throw = [&](const string& key, size_with_unit default_value) {
+        try {
+          return conf.get(section, key, default_value);
+        } catch (const std::exception& err) {
+          throw application_error(
+              sstream() << "Failed to set " << section << "." << key << " (reason: " << err.what() << ")");
+        }
+      };
+
+      auto value = parse_or_throw(key, size_with_unit{});
+      auto left = parse_or_throw(key + "-left", value);
+      auto right = parse_or_throw(key + "-right", value);
       return side_values{left, right};
     };
 

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -18,7 +18,7 @@ namespace modules {
   cpu_module::cpu_module(const bar_settings& bar, string name_) : timer_module<cpu_module>(bar, move(name_)) {
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
 
-    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-coreload-spacing", 1);
+    m_ramp_padding = m_conf.get(name(), "ramp-coreload-spacing", m_ramp_padding);
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -14,7 +14,7 @@ namespace modules {
       builder->flush();
       return "";
     }
-    if (offset != 0) {
+    if (offset.value != 0) {
       builder->offset(offset);
     }
     if (margin.value > 0) {

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -17,7 +17,7 @@ namespace modules {
     if (offset != 0) {
       builder->offset(offset);
     }
-    if (margin > 0) {
+    if (margin.value > 0) {
       builder->space(margin);
     }
     if (!bg.empty()) {
@@ -35,7 +35,7 @@ namespace modules {
     if(font > 0) {
       builder->font(font);
     }
-    if (padding > 0) {
+    if (padding.value > 0) {
       builder->space(padding);
     }
 
@@ -57,7 +57,7 @@ namespace modules {
     builder->append(move(output));
     builder->node(suffix);
 
-    if (padding > 0) {
+    if (padding.value > 0) {
       builder->space(padding);
     }
     if(font > 0) {
@@ -75,7 +75,7 @@ namespace modules {
     if (!bg.empty()) {
       builder->background_close();
     }
-    if (margin > 0) {
+    if (margin.value > 0) {
       builder->space(margin);
     }
 

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -17,26 +17,26 @@ vector<pair<unsigned int, geometry_format_values>> to_pixels_no_offset_list = {
     {0, geometry_format_values{0.}},
     {1000, geometry_format_values{150.}},
     {100, geometry_format_values{10.}},
-    {0, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 0}}},
-    {1234, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 1234}}},
-    {1, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 1}}},
+    {0, geometry_format_values{0., geometry{size_type::PIXEL, 0}}},
+    {1234, geometry_format_values{0., geometry{size_type::PIXEL, 1234}}},
+    {1, geometry_format_values{0., geometry{size_type::PIXEL, 1}}},
 };
 
 vector<pair<unsigned int, geometry_format_values>> to_pixels_with_offset_list = {
-    {1000, geometry_format_values{100., ssize_with_unit{size_type::PIXEL, 0}}},
-    {1010, geometry_format_values{100., ssize_with_unit{size_type::PIXEL, 10}}},
-    {990, geometry_format_values{100., ssize_with_unit{size_type::PIXEL, -10}}},
-    {10, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 10}}},
-    {1000, geometry_format_values{99., ssize_with_unit{size_type::PIXEL, 10}}},
-    {0, geometry_format_values{1., ssize_with_unit{size_type::PIXEL, -100}}},
+    {1000, geometry_format_values{100., geometry{size_type::PIXEL, 0}}},
+    {1010, geometry_format_values{100., geometry{size_type::PIXEL, 10}}},
+    {990, geometry_format_values{100., geometry{size_type::PIXEL, -10}}},
+    {10, geometry_format_values{0., geometry{size_type::PIXEL, 10}}},
+    {1000, geometry_format_values{99., geometry{size_type::PIXEL, 10}}},
+    {0, geometry_format_values{1., geometry{size_type::PIXEL, -100}}},
 };
 
 vector<pair<unsigned int, geometry_format_values>> to_pixels_with_units_list = {
-    {1013, geometry_format_values{100., ssize_with_unit{size_type::POINT, 10}}},
-    {987, geometry_format_values{100., ssize_with_unit{size_type::POINT, -10}}},
-    {1003, geometry_format_values{99., ssize_with_unit{size_type::POINT, 10}}},
-    {13, geometry_format_values{0., ssize_with_unit{size_type::POINT, 10}}},
-    {0, geometry_format_values{0, ssize_with_unit{size_type::POINT, -10}}},
+    {1013, geometry_format_values{100., geometry{size_type::POINT, 10}}},
+    {987, geometry_format_values{100., geometry{size_type::POINT, -10}}},
+    {1003, geometry_format_values{99., geometry{size_type::POINT, 10}}},
+    {13, geometry_format_values{0., geometry{size_type::POINT, 10}}},
+    {0, geometry_format_values{0, geometry{size_type::POINT, -10}}},
 };
 
 INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_no_offset_list));

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -17,28 +17,26 @@ vector<pair<unsigned int, geometry_format_values>> to_pixels_no_offset_list = {
     {0, geometry_format_values{0.}},
     {1000, geometry_format_values{150.}},
     {100, geometry_format_values{10.}},
-    {0, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 0}}},
-    {1234, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 1234}}},
-    {1, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 1}}},
+    {0, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 0}}},
+    {1234, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 1234}}},
+    {1, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 1}}},
 };
 
 vector<pair<unsigned int, geometry_format_values>> to_pixels_with_offset_list = {
-    {1000, geometry_format_values{100., ssize_with_unit{unit_type::PIXEL, 0}}},
-    {1010, geometry_format_values{100., ssize_with_unit{unit_type::PIXEL, 10}}},
-    {990, geometry_format_values{100., ssize_with_unit{unit_type::PIXEL, -10}}},
-    {10, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 10}}},
-    {1000, geometry_format_values{99., ssize_with_unit{unit_type::PIXEL, 10}}},
-    {0, geometry_format_values{1., ssize_with_unit{unit_type::PIXEL, -100}}},
+    {1000, geometry_format_values{100., ssize_with_unit{size_type::PIXEL, 0}}},
+    {1010, geometry_format_values{100., ssize_with_unit{size_type::PIXEL, 10}}},
+    {990, geometry_format_values{100., ssize_with_unit{size_type::PIXEL, -10}}},
+    {10, geometry_format_values{0., ssize_with_unit{size_type::PIXEL, 10}}},
+    {1000, geometry_format_values{99., ssize_with_unit{size_type::PIXEL, 10}}},
+    {0, geometry_format_values{1., ssize_with_unit{size_type::PIXEL, -100}}},
 };
 
 vector<pair<unsigned int, geometry_format_values>> to_pixels_with_units_list = {
-    {1013, geometry_format_values{100., ssize_with_unit{unit_type::POINT, 10}}},
-    {987, geometry_format_values{100., ssize_with_unit{unit_type::POINT, -10}}},
-    {1010, geometry_format_values{100., ssize_with_unit{unit_type::SPACE, 10}}},  // Should be interpreted as PIXEL
-    {990, geometry_format_values{100., ssize_with_unit{unit_type::SPACE, -10}}},  // Should be interpreted as PIXEL
-    {1003, geometry_format_values{99., ssize_with_unit{unit_type::POINT, 10}}},
-    {13, geometry_format_values{0., ssize_with_unit{unit_type::POINT, 10}}},
-    {0, geometry_format_values{0, ssize_with_unit{unit_type::POINT, -10}}},
+    {1013, geometry_format_values{100., ssize_with_unit{size_type::POINT, 10}}},
+    {987, geometry_format_values{100., ssize_with_unit{size_type::POINT, -10}}},
+    {1003, geometry_format_values{99., ssize_with_unit{size_type::POINT, 10}}},
+    {13, geometry_format_values{0., ssize_with_unit{size_type::POINT, 10}}},
+    {0, geometry_format_values{0, ssize_with_unit{size_type::POINT, -10}}},
 };
 
 INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_no_offset_list));

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -17,28 +17,28 @@ vector<pair<unsigned int, geometry_format_values>> to_pixels_no_offset_list = {
     {0, geometry_format_values{0.}},
     {1000, geometry_format_values{150.}},
     {100, geometry_format_values{10.}},
-    {0, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 0}}},
-    {1234, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 1234}}},
-    {1, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 1}}},
+    {0, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 0}}},
+    {1234, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 1234}}},
+    {1, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 1}}},
 };
 
 vector<pair<unsigned int, geometry_format_values>> to_pixels_with_offset_list = {
-    {1000, geometry_format_values{100., size_with_unit{unit_type::PIXEL, 0}}},
-    {1010, geometry_format_values{100., size_with_unit{unit_type::PIXEL, 10}}},
-    {990, geometry_format_values{100., size_with_unit{unit_type::PIXEL, -10}}},
-    {10, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 10}}},
-    {1000, geometry_format_values{99., size_with_unit{unit_type::PIXEL, 10}}},
-    {0, geometry_format_values{1., size_with_unit{unit_type::PIXEL, -100}}},
+    {1000, geometry_format_values{100., ssize_with_unit{unit_type::PIXEL, 0}}},
+    {1010, geometry_format_values{100., ssize_with_unit{unit_type::PIXEL, 10}}},
+    {990, geometry_format_values{100., ssize_with_unit{unit_type::PIXEL, -10}}},
+    {10, geometry_format_values{0., ssize_with_unit{unit_type::PIXEL, 10}}},
+    {1000, geometry_format_values{99., ssize_with_unit{unit_type::PIXEL, 10}}},
+    {0, geometry_format_values{1., ssize_with_unit{unit_type::PIXEL, -100}}},
 };
 
 vector<pair<unsigned int, geometry_format_values>> to_pixels_with_units_list = {
-    {1013, geometry_format_values{100., size_with_unit{unit_type::POINT, 10}}},
-    {987, geometry_format_values{100., size_with_unit{unit_type::POINT, -10}}},
-    {1010, geometry_format_values{100., size_with_unit{unit_type::SPACE, 10}}},  // Should be interpreted as PIXEL
-    {990, geometry_format_values{100., size_with_unit{unit_type::SPACE, -10}}},  // Should be interpreted as PIXEL
-    {1003, geometry_format_values{99., size_with_unit{unit_type::POINT, 10}}},
-    {13, geometry_format_values{0., size_with_unit{unit_type::POINT, 10}}},
-    {0, geometry_format_values{0, size_with_unit{unit_type::POINT, -10}}},
+    {1013, geometry_format_values{100., ssize_with_unit{unit_type::POINT, 10}}},
+    {987, geometry_format_values{100., ssize_with_unit{unit_type::POINT, -10}}},
+    {1010, geometry_format_values{100., ssize_with_unit{unit_type::SPACE, 10}}},  // Should be interpreted as PIXEL
+    {990, geometry_format_values{100., ssize_with_unit{unit_type::SPACE, -10}}},  // Should be interpreted as PIXEL
+    {1003, geometry_format_values{99., ssize_with_unit{unit_type::POINT, 10}}},
+    {13, geometry_format_values{0., ssize_with_unit{unit_type::POINT, 10}}},
+    {0, geometry_format_values{0, ssize_with_unit{unit_type::POINT, -10}}},
 };
 
 INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_no_offset_list));

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -1,9 +1,7 @@
-#include "common/test.hpp"
 #include "components/bar.hpp"
+#include "common/test.hpp"
 
 using namespace polybar;
-
-
 
 /**
  * \brief Class for parameterized tests on geom_format_to_pixels
@@ -11,38 +9,46 @@ using namespace polybar;
  * The first element in the tuple is the expected return value, the second
  * value is the format string. The max value is always 1000
  */
-class GeomFormatToPixelsTest :
-  public ::testing::Test,
-  public ::testing::WithParamInterface<pair<double, string>> {};
+class GeomFormatToPixelsTest : public ::testing::Test,
+                               public ::testing::WithParamInterface<pair<unsigned int, geometry_format_values>> {};
 
-vector<pair<double, string>> to_pixels_no_offset_list = {
-  {1000, "100%"},
-  {0, "0%"},
-  {1000, "150%"},
-  {100, "10%"},
-  {0, "0"},
-  {1234, "1234"},
-  {1.234, "1.234"},
+vector<pair<unsigned int, geometry_format_values>> to_pixels_no_offset_list = {
+    {1000, geometry_format_values{100.}},
+    {0, geometry_format_values{0.}},
+    {1000, geometry_format_values{150.}},
+    {100, geometry_format_values{10.}},
+    {0, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 0}}},
+    {1234, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 1234}}},
+    {1, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 1}}},
 };
 
-vector<pair<double, string>> to_pixels_with_offset_list = {
-  {1000, "100%:-0"},
-  {1000, "100%:+0"},
-  {1010, "100%:+10"},
-  {990, "100%:-10"},
-  {10, "0%:+10"},
-  {1000, "99%:+10"},
-  {0, "1%:-100"},
+vector<pair<unsigned int, geometry_format_values>> to_pixels_with_offset_list = {
+    {1000, geometry_format_values{100., size_with_unit{unit_type::PIXEL, 0}}},
+    {1010, geometry_format_values{100., size_with_unit{unit_type::PIXEL, 10}}},
+    {990, geometry_format_values{100., size_with_unit{unit_type::PIXEL, -10}}},
+    {10, geometry_format_values{0., size_with_unit{unit_type::PIXEL, 10}}},
+    {1000, geometry_format_values{99., size_with_unit{unit_type::PIXEL, 10}}},
+    {0, geometry_format_values{1., size_with_unit{unit_type::PIXEL, -100}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest,
-    ::testing::ValuesIn(to_pixels_no_offset_list));
+vector<pair<unsigned int, geometry_format_values>> to_pixels_with_units_list = {
+    {1013, geometry_format_values{100., size_with_unit{unit_type::POINT, 10}}},
+    {987, geometry_format_values{100., size_with_unit{unit_type::POINT, -10}}},
+    {1010, geometry_format_values{100., size_with_unit{unit_type::SPACE, 10}}},  // Should be interpreted as PIXEL
+    {990, geometry_format_values{100., size_with_unit{unit_type::SPACE, -10}}},  // Should be interpreted as PIXEL
+    {1003, geometry_format_values{99., size_with_unit{unit_type::POINT, 10}}},
+    {13, geometry_format_values{0., size_with_unit{unit_type::POINT, 10}}},
+    {0, geometry_format_values{0, size_with_unit{unit_type::POINT, -10}}},
+};
 
-INSTANTIATE_TEST_SUITE_P(WithOffset, GeomFormatToPixelsTest,
-    ::testing::ValuesIn(to_pixels_with_offset_list));
+INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_no_offset_list));
+
+INSTANTIATE_TEST_SUITE_P(WithOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_with_offset_list));
+
+INSTANTIATE_TEST_SUITE_P(WithUnits, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_with_units_list));
 
 TEST_P(GeomFormatToPixelsTest, correctness) {
-  double exp = GetParam().first;
-  std::string str = GetParam().second;
-  EXPECT_DOUBLE_EQ(exp, geom_format_to_pixels(str, 1000));
+  unsigned int exp = GetParam().first;
+  polybar::geometry_format_values geometry = GetParam().second;
+  EXPECT_DOUBLE_EQ(exp, geom_format_to_pixels(geometry, 1000, 96));
 }


### PR DESCRIPTION
Implement feature requested in #1651 and #951.
This pr add supports for `px` (pixel) and `pt` (point) for polybar.

I followed the advices given by @patrick96 in #1651, so I add a `size_with_unit` structure to store the value and the unit. Unlike the `size` definition, the value is signed to handle negative offset.

To handle the `width` and `height` problem, I added a `geometry_format_values` structure which contains a percentage and the offset (a `size_with_unit` structure).

`builder::space` now uses the `%{O}` formatting tag but this is handled by `size_with_unit_to_string` helper in the new header `"utils/unit.hpp"` to avoid duplicate code (this function is also used in `controller.cpp` since I can't use `builder::space` here).

DPI initialization is now in the constructor of the bar. However this initialization seems strange, the DPI are only computed if `dpi < 0` is explicitly specified in the configuration (see below). If the DPI isn't specified in the configuration, the default value is 96. Is it the correct behavior?

https://github.com/Lomadriel/polybar/blob/cc4e09edc41cfbd5f2f4bf7235470aa1c21bc59a/src/components/bar.cpp#L155-L178

The rest of the PR is just adapting the code to use these structures. I tried to find all keys that could uses units but I am not sure if I added units support for all the key that could benefit of this feature.

EDIT: Fixes #1700

TEAMEDIT:
Closes #1651 
Closes #951
Fixes #1265