### PR TITLE
Fix animation framerate

### DIFF
--- a/include/drawtypes/animation.hpp
+++ b/include/drawtypes/animation.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 
 #include "common.hpp"
@@ -14,32 +15,33 @@ namespace chrono = std::chrono;
 namespace drawtypes {
   class animation : public non_copyable_mixin<animation> {
    public:
-    explicit animation(int framerate_ms) : m_framerate_ms(framerate_ms) {}
+    explicit animation(unsigned int framerate_ms) : m_framerate_ms(framerate_ms) {}
     explicit animation(vector<label_t>&& frames, int framerate_ms)
-        : m_frames(forward<decltype(frames)>(frames))
+        : m_frames(move(frames))
         , m_framerate_ms(framerate_ms)
         , m_framecount(m_frames.size())
-        , m_lastupdate(chrono::system_clock::now()) {}
+        , m_frame(m_frames.size() - 1) {}
 
     void add(label_t&& frame);
-    label_t get();
-    int framerate();
-    operator bool();
+    void increment();
+
+    label_t get() const;
+    unsigned int framerate() const;
+
+    explicit operator bool() const;
 
    protected:
-    void tick();
-
     vector<label_t> m_frames;
-    int m_framerate_ms = 1000;
-    int m_frame = 0;
-    int m_framecount = 0;
-    chrono::system_clock::time_point m_lastupdate;
+
+    unsigned int m_framerate_ms = 1000;
+    size_t m_framecount = 0;
+    std::atomic_size_t m_frame{0_z};
   };
 
   using animation_t = shared_ptr<animation>;
 
   animation_t load_animation(
       const config& conf, const string& section, string name = "animation", bool required = true);
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/drawtypes/animation.cpp
+++ b/src/drawtypes/animation.cpp
@@ -8,33 +8,27 @@ namespace drawtypes {
   void animation::add(label_t&& frame) {
     m_frames.emplace_back(forward<decltype(frame)>(frame));
     m_framecount = m_frames.size();
+    m_frame = m_framecount - 1;
   }
 
-  label_t animation::get() {
-    tick();
+  label_t animation::get() const {
     return m_frames[m_frame];
   }
 
-  int animation::framerate() {
+  unsigned int animation::framerate() const {
     return m_framerate_ms;
   }
 
-  animation::operator bool() {
+  animation::operator bool() const {
     return !m_frames.empty();
   }
 
-  void animation::tick() {
-    auto now = chrono::system_clock::now();
-    auto diff = chrono::duration_cast<chrono::milliseconds>(now - m_lastupdate);
+  void animation::increment() {
+    auto tmp = m_frame.load();
+    ++tmp;
+    tmp %= m_framecount;
 
-    if (diff.count() < m_framerate_ms) {
-      return;
-    }
-    if (++m_frame >= m_framecount) {
-      m_frame = 0;
-    }
-
-    m_lastupdate = now;
+    m_frame = tmp;
   }
 
   /**
@@ -64,6 +58,6 @@ namespace drawtypes {
 
     return factory_util::shared<animation>(move(vec), framerate);
   }
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -342,24 +342,18 @@ namespace modules {
    * same time.
    */
   void battery_module::subthread() {
-    chrono::duration<double> dur{0.0};
-
-    if (battery_module::state::CHARGING == m_state && m_animation_charging) {
-      dur += chrono::milliseconds{m_animation_charging->framerate()};
-    } else if (battery_module::state::DISCHARGING == m_state && m_animation_discharging) {
-      dur += chrono::milliseconds{m_animation_discharging->framerate()};
-    } else {
-      dur += 1s;
-    }
+    m_log.trace("%s: Start of subthread", name());
 
     while (running()) {
-      for (int i = 0; running() && i < dur.count(); ++i) {
-        if (m_state == battery_module::state::CHARGING ||
-            m_state == battery_module::state::DISCHARGING) {
-          broadcast();
-        }
-        sleep(dur);
+      int framerate = 1000; // milliseconds
+      if (m_state == battery_module::state::CHARGING) {
+        broadcast();
+        framerate = m_animation_charging->framerate();
+      } else if (m_state == battery_module::state::DISCHARGING) {
+        broadcast();
+        framerate = m_animation_discharging->framerate();
       }
+      this_thread::sleep_for(std::chrono::milliseconds(framerate));
     }
 
     m_log.trace("%s: End of subthread", name());

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -345,19 +345,25 @@ namespace modules {
     m_log.trace("%s: Start of subthread", name());
 
     while (running()) {
-      int framerate = 1000; // milliseconds
+      auto now = chrono::system_clock::now();
+      auto framerate = 1000U;  // milliseconds
       if (m_state == battery_module::state::CHARGING) {
+        m_animation_charging->increment();
         broadcast();
         framerate = m_animation_charging->framerate();
       } else if (m_state == battery_module::state::DISCHARGING) {
+        m_animation_discharging->increment();
         broadcast();
         framerate = m_animation_discharging->framerate();
       }
-      this_thread::sleep_for(std::chrono::milliseconds(framerate));
+
+      // We don't count the the first part of the loop to be as close as possible to the framerate.
+      now += chrono::milliseconds(framerate);
+      this_thread::sleep_until(now);
     }
 
     m_log.trace("%s: End of subthread", name());
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -176,7 +176,7 @@ namespace modules {
     const chrono::milliseconds framerate{m_animation_packetloss->framerate()};
 
     while (running()) {
-      auto now = chrono::system_clock::now();
+      auto now = chrono::steady_clock::now();
       if (m_connected && m_packetloss) {
         m_animation_packetloss->increment();
         broadcast();

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -174,13 +174,16 @@ namespace modules {
 
   void network_module::subthread_routine() {
     const chrono::milliseconds framerate{m_animation_packetloss->framerate()};
-    const auto dur = chrono::duration<double>(framerate);
 
     while (running()) {
+      auto now = chrono::system_clock::now();
       if (m_connected && m_packetloss) {
+        m_animation_packetloss->increment();
         broadcast();
       }
-      sleep(dur);
+
+      now += framerate;
+      this_thread::sleep_until(now);
     }
 
     m_log.trace("%s: Reached end of network subthread", name());


### PR DESCRIPTION
Fix #568.

As it may be seen in the code, the animation need to be synchronized with the thread that calls the `broadcast` function in order to keep a stable framerate.
To synchronize the thread and the animation, I moved the "animation update" in the `subthread` method.
Although this fix the bug, I don't like to move the "animation update" responsibility to another class. The modules should not have to update the animation. Moreover it could be easy to forget the call to `increment` that updates the animation. (when the code is refactored or simply when a new module will need this class).

This is why I also implemented a version with an `animation_manager`, but since this is a big refactor, I put this version in another branch.
=> https://github.com/Lomadriel/polybar/tree/refactor/animation
This commit (https://github.com/Lomadriel/polybar/commit/1dc8949bf53389143c757aaa63753c42ad501a2e) is the diff between this PR and the branch `refactor/animation`

In this version a module only store an `animation_manager`, that manages the animations. Once launched the `animation_manager` will process as follow:

1. Call a functor to let the module choose the current animation.
2. Sleep if no animation has been chosen.
3. Otherwise, increments the animation
4. Call a callback to let the module do whatever needs to be done (mostly call `broadcast`)
5. Sleep until the remaining time between two steps of the animation is passed.

As it really changes the way animations work, I let you choose which version you want.

TEAM EDIT: Closes #1213
