### PR TITLE
Improves date module (label for alternative and timezone support)

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -44,4 +44,6 @@ constexpr size_t operator"" _z(unsigned long long n) {
   return n;
 }
 
+[[deprecated("Use env_util::env_guard (thread safe version)")]] int setenv(const char*, const char*, int);
+
 POLYBAR_NS_END

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -4,9 +4,7 @@
 #include "modules/meta/timer_module.hpp"
 
 #include <atomic>
-#include <ctime>
-#include <iomanip>
-#include <iostream>
+#include <sstream>
 
 POLYBAR_NS
 
@@ -39,9 +37,6 @@ namespace modules {
 
     string m_date;
     string m_time;
-
-    static std::atomic_bool s_timezone_activated;
-    static mutex s_timezone_mutex;
 
     // Single stringstream to be used to gather the results of std::put_time
     std::stringstream datetime_stream;

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -15,18 +15,23 @@ namespace modules {
 
     bool update();
     bool build(builder* builder, const string& tag) const;
+    string get_format() const;
 
    protected:
     bool input(string&& cmd);
 
    private:
+    static constexpr auto FORMAT_ALT = "format-alt";
+
     static constexpr auto TAG_LABEL = "<label>";
+    static constexpr auto TAG_LABEL_ALT = "<label-alt>";
     static constexpr auto EVENT_TOGGLE = "datetoggle";
 
     // \deprecated: Use <label>
     static constexpr auto TAG_DATE = "<date>";
 
     label_t m_label;
+    label_t m_label_alt;
 
     string m_dateformat;
     string m_dateformat_alt;

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -3,9 +3,10 @@
 #include "modules/meta/input_handler.hpp"
 #include "modules/meta/timer_module.hpp"
 
-#include <iostream>
-#include <iomanip>
+#include <atomic>
 #include <ctime>
+#include <iomanip>
+#include <iostream>
 
 POLYBAR_NS
 
@@ -33,15 +34,20 @@ namespace modules {
     string m_dateformat_alt;
     string m_timeformat;
     string m_timeformat_alt;
+    string m_timezone;
+    string m_timezone_alt;
 
     string m_date;
     string m_time;
+
+    static std::atomic_bool s_timezone_activated;
+    static mutex s_timezone_mutex;
 
     // Single stringstream to be used to gather the results of std::put_time
     std::stringstream datetime_stream;
 
     std::atomic<bool> m_toggled{false};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/utils/env.hpp
+++ b/include/utils/env.hpp
@@ -1,12 +1,71 @@
 #pragma once
 
+#include <stdlib.h>
+#include <mutex>
+
 #include "common.hpp"
 
+#include <iostream>
 POLYBAR_NS
 
 namespace env_util {
   bool has(const string& var);
-  string get(const string& var, string fallback = "");
-}
+  string get(const string& var, const string& fallback = "");
+
+  namespace details {
+    class env_mutex_holder {
+     private:
+      static std::mutex s_env_mutex;
+      template <typename Fun>
+      friend class env_guard_impl;
+    };
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+    template <typename Fun>
+    class env_guard_impl : std::lock_guard<std::mutex> {
+     public:
+      env_guard_impl(string name, const string& value, Fun cleanup)
+          : std::lock_guard<std::mutex>(details::env_mutex_holder::s_env_mutex)
+          , m_name(move(name))
+          , m_value_empty(value.empty())
+          , m_original_env()
+          , cleanup(move(cleanup)) {
+        m_original_env = get(m_name);
+
+        if (!m_value_empty) {
+          ::setenv(m_name.c_str(), value.c_str(), true);
+        }
+      }
+
+      ~env_guard_impl() {
+        if (!m_value_empty) {
+          if (m_original_env.empty()) {
+            ::unsetenv(m_name.c_str());
+          } else {
+            ::setenv(m_name.c_str(), m_original_env.c_str(), true);
+          }
+        }
+
+        cleanup(m_value_empty);
+      }
+
+     private:
+      string m_name;
+      bool m_value_empty;
+      string m_original_env;
+      Fun cleanup;
+    };
+
+  }  // namespace details
+#pragma GCC diagnostic pop
+
+  template <typename Fun>
+  class env_guard : details::env_guard_impl<Fun> {
+   public:
+    using details::env_guard_impl<Fun>::env_guard_impl;
+  };
+}  // namespace env_util
 
 POLYBAR_NS_END

--- a/src/utils/env.cpp
+++ b/src/utils/env.cpp
@@ -10,13 +10,17 @@ POLYBAR_NS
 namespace env_util {
   bool has(const string& var) {
     const char* env{std::getenv(var.c_str())};
-    return env != nullptr && std::strlen(env) > 0;
+    return env != nullptr && env[0] != '\0';
   }
 
-  string get(const string& var, string fallback) {
+  string get(const string& var, const string& fallback) {
     const char* value{std::getenv(var.c_str())};
-    return value != nullptr ? value : move(fallback);
+    return value != nullptr ? value : fallback;
   }
-}
+
+  namespace details {
+      std::mutex env_mutex_holder::s_env_mutex;
+  }
+}  // namespace env_util
 
 POLYBAR_NS_END


### PR DESCRIPTION
Fix #596.

A new attempt to implement this feature. This PR fixes the concurrency problem in #1353 by using a static mutex in the date class. Since the date class is the only one to support timezone, this shouldn't be a problem. However if a global clock is wanted I can add an utility function/class that will do the job.

TEAM EDIT: Closes #1293