### PR TITLE
font: Draw red rectangle for unmatched charachters

### DIFF
--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -225,10 +225,11 @@ namespace cairo {
         save();
         cairo_set_operator(m_c, CAIRO_OPERATOR_SOURCE);
         cairo_set_source_rgb(m_c, 1, 0, 0);
-        cairo_rectangle(m_c, *t.x_advance, *t.y_advance, 10, 10);
-        cairo_fill(m_c);
-        restore();
+        cairo_rectangle(m_c, *t.x_advance, *t.y_advance, 10, 20);
         *t.x_advance += 10;
+        cairo_fill(m_c);
+        cairo_move_to(m_c, *t.x_advance, 0.0);
+        restore();
         position(&x, nullptr);
 
 

--- a/include/cairo/font.hpp
+++ b/include/cairo/font.hpp
@@ -250,6 +250,10 @@ namespace cairo {
         //   cairo_glyph_path(m_cairo, glyphs, nglyphs);
         // }
 
+        for (int i = 0; i < nglyphs; i++) {
+          glyphs[i].index = 0;
+        }
+
         cairo_text_extents_t extents{};
         cairo_scaled_font_glyph_extents(m_scaled, glyphs, nglyphs, &extents);
         cairo_show_text_glyphs(m_cairo, utf8.c_str(), utf8.size(), glyphs, nglyphs, clusters, nclusters, cf);


### PR DESCRIPTION
I think we need a visual indicator when characters are dropped because most people just think that the module doesn't show at all.

I thought about drawing a hollow rectangle, similar to what terminals do, but I found it easier to just draw a red rectangle.

This can probably be polished a bit more.

@NBonaparte thoughts?