### PR TITLE
feat(xworkspaces): add urgent hint cache.

### DIFF
--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -3,6 +3,7 @@
 #include <bitset>
 #include <mutex>
 #include <set>
+#include <unordered_map>
 
 #include "components/config.hpp"
 #include "components/types.hpp"
@@ -63,14 +64,14 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    void handle(const evt::property_notify& evt);
+    void handle(const evt::property_notify& evt) override;
 
     void rebuild_clientlist();
     void rebuild_desktops();
     void rebuild_desktop_states();
     void set_desktop_urgent(xcb_window_t window);
 
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     static vector<string> get_desktop_names();
@@ -94,6 +95,7 @@ namespace modules {
     bool m_monitorsupport{true};
 
     vector<string> m_desktop_names;
+    std::unordered_map<string, bool> m_urgent_desktops;
     unsigned int m_current_desktop;
     string m_current_desktop_name;
 

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -164,17 +164,17 @@ namespace modules {
     bounds.erase(std::unique(bounds.begin(), bounds.end(), [](auto& a, auto& b) { return a == b; }), bounds.end());
 
     unsigned int step;
-    if (bounds.size() > 0) {
+    if (!bounds.empty()) {
       step = m_desktop_names.size() / bounds.size();
     } else {
       step = 1;
     }
     unsigned int offset = 0;
-    for (unsigned int i = 0; i < bounds.size(); i++) {
-      if (!m_pinworkspaces || m_bar.monitor->match(bounds[i])) {
+    for (const auto& bound : bounds) {
+      if (!m_pinworkspaces || m_bar.monitor->match(bound)) {
         auto viewport = make_unique<struct viewport>();
         viewport->state = viewport_state::UNFOCUSED;
-        viewport->pos = bounds[i];
+        viewport->pos = bound;
 
         for (auto&& m : m_monitors) {
           if (m->match(viewport->pos)) {
@@ -216,6 +216,9 @@ namespace modules {
       for (auto&& d : v->desktops) {
         if (m_desktop_names[d->index] == m_current_desktop_name) {
           d->state = desktop_state::ACTIVE;
+          m_urgent_desktops.erase(m_current_desktop_name);
+        } else if (m_urgent_desktops[m_desktop_names[d->index]]) {
+          d->state = desktop_state::URGENT;
         } else if (occupied_desks.count(d->index) > 0) {
           d->state = desktop_state::OCCUPIED;
         } else {
@@ -258,6 +261,7 @@ namespace modules {
       for (auto&& d : v->desktops) {
         if (d->index == desk && d->state != desktop_state::URGENT) {
           d->state = desktop_state::URGENT;
+          m_urgent_desktops[m_desktop_names[d->index]] = true;
 
           d->label = m_labels.at(d->state)->clone();
           d->label->reset_tokens();


### PR DESCRIPTION
Fixes #1081.

Also fix a segfault when a i3-sticky window exists.
These windows are on a "magic" desktop and the returned desktop id is garbage so it must be ignored.

This PR includes all the changes from #882, applies the changes requested by @patrick96 and adds a cache for the urgent hint to prevent it from disappearing when the desktop is changed.

I also rebased the branch from @kronn onto master

