### PR TITLE
battery: add `%percentage_raw%` token, which is not forced to `100` when real percentage is above `full-at`

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -57,6 +57,7 @@ namespace modules {
    protected:
     state current_state();
     int current_percentage(state state);
+    int current_percentage_raw();
     string current_time();
     string current_consumption();
     void subthread();

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -57,7 +57,7 @@ namespace modules {
    protected:
     state current_state();
     int current_percentage();
-    int clamp_percentage(int percentage, state state);
+    int clamp_percentage(int percentage, state state) const;
     string current_time();
     string current_consumption();
     void subthread();

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -56,8 +56,8 @@ namespace modules {
 
    protected:
     state current_state();
-    int current_percentage(state state);
-    int current_percentage_raw();
+    int current_percentage();
+    int clamp_percentage(int percentage, state state);
     string current_time();
     string current_consumption();
     void subthread();

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -230,6 +230,7 @@ namespace modules {
     if (label) {
       label->reset_tokens();
       label->replace_token("%percentage%", to_string(m_percentage));
+      label->replace_token("%percentage_raw%", to_string(current_percentage_raw()));
       label->replace_token("%consumption%", current_consumption());
 
       if (m_state != battery_module::state::FULL && !m_timeformat.empty()) {
@@ -301,6 +302,12 @@ namespace modules {
     }
     return percentage;
   }
+
+  int battery_module::current_percentage_raw() {
+    int percentage{read(*m_capacity_reader)};
+    return percentage;
+  }
+  
 
   /**
   * Get the current power consumption

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -296,8 +296,7 @@ namespace modules {
    * Get the current capacity level
    */
   int battery_module::current_percentage() {
-    int percentage{read(*m_capacity_reader)};
-    return percentage;
+    return read(*m_capacity_reader);
   }
 
   int battery_module::clamp_percentage(int percentage, state state) const {

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -263,9 +263,9 @@ namespace modules {
     } else if (tag == TAG_ANIMATION_DISCHARGING) {
       builder->node(m_animation_discharging->get());
     } else if (tag == TAG_BAR_CAPACITY) {
-      builder->node(m_bar_capacity->output(m_percentage));
+      builder->node(m_bar_capacity->output(clamp_percentage(m_percentage, m_state)));
     } else if (tag == TAG_RAMP_CAPACITY) {
-      builder->node(m_ramp_capacity->get_by_percentage(m_percentage));
+      builder->node(m_ramp_capacity->get_by_percentage(clamp_percentage(m_percentage, m_state)));
     } else if (tag == TAG_LABEL_CHARGING) {
       builder->node(m_label_charging);
     } else if (tag == TAG_LABEL_DISCHARGING) {
@@ -300,7 +300,7 @@ namespace modules {
     return percentage;
   }
 
-  int battery_module::clamp_percentage(int percentage, state state) {
+  int battery_module::clamp_percentage(int percentage, state state) const {
     if (state == battery_module::state::FULL && percentage >= m_fullat) {
       return 100;
     }


### PR DESCRIPTION
Following the discussion on #1753, this PR adds `%percentage_raw%` to the battery module, which represent the real percentage reported by the kernel regardless of the value set in the `full-at` property by the user. This property still sets the state as *Full* when the percentage level goes above its value. The behavior of the `%percentage%` token has not been altered.

Since in the next major (breaking) release the plan is to bring this behavior to the `%percentage%` token, the code has been refactored towards this deprecation of this old behavior, storing the real percentage instead of the clamped one and adding a clamping function for that purpose.

Feedback and comments are welcome.