### PR TITLE
fix: Fix #1758

### DIFF
--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -158,7 +158,7 @@ namespace cairo {
       while (!chars.empty()) {
         auto remaining = chars.size();
         for (auto&& f : fns) {
-          unsigned int matches;
+          unsigned int matches = 0;
 
           // Match as many glyphs as possible if the default/preferred font
           // is being tested. Otherwise test one glyph at a time against


### PR DESCRIPTION
* Initialize unsigned int matches to 0 for Fedora 30