### PR TITLE
Remove warnings in cmake

### DIFF
--- a/cmake/02-opts.cmake
+++ b/cmake/02-opts.cmake
@@ -87,6 +87,14 @@ set(SETTING_PATH_TEMPERATURE_INFO "/sys/class/thermal/thermal_zone%zone%/temp"
   CACHE STRING "Path to file containing the current temperature")
 
 if(CMAKE_BUILD_TYPE_UPPER MATCHES DEBUG)
-  set(DEBUG_HINTS_OFFSET_X 0 CACHE INTEGER "Debug hint offset x")
-  set(DEBUG_HINTS_OFFSET_Y 0 CACHE INTEGER "Debug hint offset y")
+  set(DEBUG_HINTS_OFFSET_X 0 CACHE STRING "Debug hint offset x")
+  set(DEBUG_HINTS_OFFSET_Y 0 CACHE STRING "Debug hint offset y")
+
+  if (NOT DEBUG_HINTS_OFFSET_X MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "DEBUG_HINTS_OFFSET_X must be an integer")
+  endif()
+
+  if (NOT DEBUG_HINTS_OFFSET_Y MATCHES "^[0-9]+$")
+    message(FATAL_ERROR "DEBUG_HINTS_OFFSET_Y must be an integer")
+  endif()
 endif()

--- a/cmake/02-opts.cmake
+++ b/cmake/02-opts.cmake
@@ -85,16 +85,3 @@ set(SETTING_PATH_MESSAGING_FIFO "/tmp/polybar_mqueue.%pid%"
   CACHE STRING "Path to file containing the current temperature")
 set(SETTING_PATH_TEMPERATURE_INFO "/sys/class/thermal/thermal_zone%zone%/temp"
   CACHE STRING "Path to file containing the current temperature")
-
-if(CMAKE_BUILD_TYPE_UPPER MATCHES DEBUG)
-  set(DEBUG_HINTS_OFFSET_X 0 CACHE STRING "Debug hint offset x")
-  set(DEBUG_HINTS_OFFSET_Y 0 CACHE STRING "Debug hint offset y")
-
-  if (NOT DEBUG_HINTS_OFFSET_X MATCHES "^[0-9]+$")
-    message(FATAL_ERROR "DEBUG_HINTS_OFFSET_X must be an integer")
-  endif()
-
-  if (NOT DEBUG_HINTS_OFFSET_Y MATCHES "^[0-9]+$")
-    message(FATAL_ERROR "DEBUG_HINTS_OFFSET_Y must be an integer")
-  endif()
-endif()

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -63,11 +63,6 @@ static const int SINK_PRIORITY_SCREEN{2};
 static const int SINK_PRIORITY_TRAY{3};
 static const int SINK_PRIORITY_MODULE{4};
 
-#ifdef DEBUG_HINTS
-static const int DEBUG_HINTS_OFFSET_X{@DEBUG_HINTS_OFFSET_X@};
-static const int DEBUG_HINTS_OFFSET_Y{@DEBUG_HINTS_OFFSET_Y@};
-#endif
-
 static constexpr const char* ALSA_SOUNDCARD{"@SETTING_ALSA_SOUNDCARD@"};
 static constexpr const char* BSPWM_SOCKET_PATH{"@SETTING_BSPWM_SOCKET_PATH@"};
 static constexpr const char* BSPWM_STATUS_PREFIX{"@SETTING_BSPWM_STATUS_PREFIX@"};


### PR DESCRIPTION
As stated in the documentation of set (https://cmake.org/cmake/help/latest/command/set.html), `INTEGER` type doesn't exist.
`STRING` type is now used and a check has been added.

This PR removes the following warnings:
```
CMake Warning (dev) at cmake/02-opts.cmake:90 (set):
  implicitly converting 'INTEGER' to 'STRING' type.
CMake Warning (dev) at cmake/02-opts.cmake:91 (set):
  implicitly converting 'INTEGER' to 'STRING' type.
```
CMake version: 3.14.3