### PR TITLE
feat(menu): Add option to keep menu open after executing command 

### DIFF
--- a/include/modules/menu.hpp
+++ b/include/modules/menu.hpp
@@ -34,6 +34,8 @@ namespace modules {
     static constexpr auto EVENT_MENU_CLOSE = "menu-close";
 
     bool m_expand_right{true};
+    /* TODO: add in boolean variable to configure whether menu changes levels
+       (closes) after menu option execution */
 
     label_t m_labelopen;
     label_t m_labelclose;

--- a/include/modules/menu.hpp
+++ b/include/modules/menu.hpp
@@ -34,8 +34,7 @@ namespace modules {
     static constexpr auto EVENT_MENU_CLOSE = "menu-close";
 
     bool m_expand_right{true};
-    /* TODO: add in boolean variable to configure whether menu changes levels
-       (closes) after menu option execution */
+    bool m_stay_open_after_exec{false};
 
     label_t m_labelopen;
     label_t m_labelclose;

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -13,7 +13,7 @@ namespace modules {
 
   menu_module::menu_module(const bar_settings& bar, string name_) : static_module<menu_module>(bar, move(name_)) {
     m_expand_right = m_conf.get(name(), "expand-right", m_expand_right);
-    /* TODO: read config to get user setting for whether level should change after a menu option executes */
+    m_stay_open_after_exec = m_conf.get(name(), "stay-open-after-exec", m_stay_open_after_exec);
 
     string default_format;
     if(m_expand_right) {
@@ -119,8 +119,9 @@ namespace modules {
     if (cmd.compare(0, 4, "menu") != 0 && m_level > -1) {
       for (auto&& item : m_levels[m_level]->items) {
         if (item->exec == cmd) {
-          /* TODO: add conditional logic to this - should only change level (close menu) if user chooses */
-          m_level = -1;
+          if (!m_stay_open_after_exec) {
+            m_level = -1;
+          }
           break;
         }
       }

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -13,6 +13,7 @@ namespace modules {
 
   menu_module::menu_module(const bar_settings& bar, string name_) : static_module<menu_module>(bar, move(name_)) {
     m_expand_right = m_conf.get(name(), "expand-right", m_expand_right);
+    /* TODO: read config to get user setting for whether level should change after a menu option executes */
 
     string default_format;
     if(m_expand_right) {
@@ -118,6 +119,7 @@ namespace modules {
     if (cmd.compare(0, 4, "menu") != 0 && m_level > -1) {
       for (auto&& item : m_levels[m_level]->items) {
         if (item->exec == cmd) {
+          /* TODO: add conditional logic to this - should only change level (close menu) if user chooses */
           m_level = -1;
           break;
         }


### PR DESCRIPTION
This feature adds a `stay-open-after-exec` option that can be set for menus in modules.conf that prevents the menu from closing after a menu item is chosen if set to `true`, otherwise the menu closes after choosing a menu item (as it currently does) if set to `false`.

Feature requested in issues [#845](https://github.com/polybar/polybar/issues/845) and [#1326](https://github.com/polybar/polybar/issues/1326).

I would be happy to document this option if desired, but am unsure where to do that.