### PR TITLE
cleanup(logger): use universal references to avoid useless copies

### DIFF
--- a/include/components/logger.hpp
+++ b/include/components/logger.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "common.hpp"
 #include "settings.hpp"
@@ -34,51 +35,51 @@ class logger {
 
   static loglevel parse_verbosity(const string& name, loglevel fallback = loglevel::NONE);
 
-  void verbosity(loglevel&& level);
+  void verbosity(loglevel level);
 
 #ifdef DEBUG_LOGGER  // {{{
   template <typename... Args>
-  void trace(string message, Args... args) const {
-    output(loglevel::TRACE, message, args...);
+  void trace(const string& message, Args&&... args) const {
+    output(loglevel::TRACE, message, std::forward<Args>(args)...);
   }
 #ifdef DEBUG_LOGGER_VERBOSE
   template <typename... Args>
-  void trace_x(string message, Args... args) const {
-    output(loglevel::TRACE, message, args...);
+  void trace_x(const string& message, Args&&... args) const {
+    output(loglevel::TRACE, message, std::forward<Args>(args)...);
   }
 #else
   template <typename... Args>
-  void trace_x(Args...) const {}
+  void trace_x(Args&&...) const {}
 #endif
 #else
   template <typename... Args>
-  void trace(Args...) const {}
+  void trace(Args&&...) const {}
   template <typename... Args>
-  void trace_x(Args...) const {}
+  void trace_x(Args&&...) const {}
 #endif  // }}}
 
   /**
    * Output an info message
    */
   template <typename... Args>
-  void info(string message, Args... args) const {
-    output(loglevel::INFO, message, args...);
+  void info(const string& message, Args&&... args) const {
+    output(loglevel::INFO, message, std::forward<Args>(args)...);
   }
 
   /**
    * Output a warning message
    */
   template <typename... Args>
-  void warn(string message, Args... args) const {
-    output(loglevel::WARNING, message, args...);
+  void warn(const string& message, Args&&... args) const {
+    output(loglevel::WARNING, message, std::forward<Args>(args)...);
   }
 
   /**
    * Output an error message
    */
   template <typename... Args>
-  void err(string message, Args... args) const {
-    output(loglevel::ERROR, message, args...);
+  void err(const string& message, Args&&... args) const {
+    output(loglevel::ERROR, message, std::forward<Args>(args)...);
   }
 
  protected:
@@ -95,14 +96,14 @@ class logger {
   /**
    * Convert thread id
    */
-  size_t convert(const std::thread::id arg) const;
+  size_t convert(std::thread::id arg) const;
 
   /**
    * Write the log message to the output channel
    * if the defined verbosity level allows it
    */
   template <typename... Args>
-  void output(loglevel level, string format, Args... values) const {
+  void output(loglevel level, const string& format, Args&&... values) const {
     if (level > m_level) {
       return;
     }

--- a/src/components/logger.cpp
+++ b/src/components/logger.cpp
@@ -60,13 +60,13 @@ logger::logger(loglevel level) : m_level(level) {
 /**
  * Set output verbosity
  */
-void logger::verbosity(loglevel&& level) {
+void logger::verbosity(loglevel level) {
 #ifndef DEBUG_LOGGER
   if (level == loglevel::TRACE) {
     throw application_error("Trace logging is not enabled...");
   }
 #endif
-  m_level = forward<decltype(level)>(level);
+  m_level = level;
 }
 
 /**

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -56,7 +56,7 @@ namespace modules {
     // Warn about "unreachable" format tag
     if (m_formatter->has(TAG_LABEL_UNMOUNTED) && m_remove_unmounted) {
       m_log.warn("%s: Defined format tag \"%s\" will never be used (reason: `remove-unmounted = true`)", name(),
-          TAG_LABEL_UNMOUNTED);
+          string{TAG_LABEL_UNMOUNTED});
     }
   }
 


### PR DESCRIPTION
Use const ref and universal references to avoid to copy a lot of strings especially when the function is "disabled" (like `trace_x`).