### PR TITLE
refactor(build): Remove version number namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,6 @@ else()
   set(APP_VERSION "${version_txt}")
 endif()
 
-STRING(REGEX REPLACE "[^a-zA-Z0-9_]" "_" APP_VERSION_NAMESPACE "v${APP_VERSION}")
-
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   ${PROJECT_SOURCE_DIR}/cmake

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -8,10 +8,8 @@
 #include "settings.hpp"
 
 #define POLYBAR_NS    \
-  namespace polybar { \
-    inline namespace APP_VERSION_NAMESPACE {
+  namespace polybar {
 #define POLYBAR_NS_END \
-  }                    \
   }
 
 #ifndef PIPE_READ

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -6,7 +6,6 @@
 
 #define APP_NAME "@PROJECT_NAME@"
 #cmakedefine APP_VERSION "@APP_VERSION@"
-#cmakedefine APP_VERSION_NAMESPACE @APP_VERSION_NAMESPACE@
 
 #cmakedefine01 ENABLE_ALSA
 #cmakedefine01 ENABLE_MPD


### PR DESCRIPTION
I don't know the original intention behind this but it clutters up debug
traces and basically makes ccache useless.

The only benefit it has, giving version info in stacktraces, is kind of
void since we already ask for version information on github issues.