### PR TITLE
fix(xbacklight): fix concurrent access

### DIFF
--- a/include/modules/meta/static_module.hpp
+++ b/include/modules/meta/static_module.hpp
@@ -13,7 +13,10 @@ namespace modules {
     void start() {
       this->m_mainthread = thread([&] {
         this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
-        CAST_MOD(Impl)->update();
+        {
+          std::lock_guard<std::mutex> lck(this->m_updatelock);
+          CAST_MOD(Impl)->update();
+        }
         CAST_MOD(Impl)->broadcast();
       });
     }

--- a/src/modules/xbacklight.cpp
+++ b/src/modules/xbacklight.cpp
@@ -91,6 +91,8 @@ namespace modules {
    * Query the RandR extension for the new values
    */
   void xbacklight_module::update() {
+    std::lock_guard<std::mutex> guard(m_buildlock);
+
     auto& bl = m_output->backlight;
     randr_util::get_backlight_value(m_connection, m_output, bl);
     m_percentage = math_util::nearest_5(math_util::percentage<double>(bl.val, bl.min, bl.max));
@@ -172,6 +174,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END


### PR DESCRIPTION
Closes #1776.
The `update` function wasn't protected.