### PR TITLE
fix(modules): move join in a new method

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -131,6 +131,7 @@ namespace modules {
     virtual bool input(const string& action, const string& data) = 0;
 
     virtual void start() = 0;
+    virtual void join() = 0;
     virtual void stop() = 0;
     virtual void halt(string error_message) = 0;
     virtual string contents() = 0;
@@ -157,6 +158,7 @@ namespace modules {
 
     bool visible() const override;
 
+    void join() final override;
     void stop() override;
     void halt(string error_message) override;
     void teardown();

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -65,6 +65,18 @@ namespace modules {
     return static_cast<bool>(m_enabled);
   }
 
+  template <class Impl>
+  void module<Impl>::join() {
+    for (auto&& thread_ : m_threads) {
+      if (thread_.joinable()) {
+        thread_.join();
+      }
+    }
+    if (m_mainthread.joinable()) {
+      m_mainthread.join();
+    }
+  }
+
   template <typename Impl>
   bool module<Impl>::visible() const {
     return static_cast<bool>(m_visible);
@@ -85,15 +97,6 @@ namespace modules {
     {
       CAST_MOD(Impl)->wakeup();
       CAST_MOD(Impl)->teardown();
-
-      for (auto&& thread_ : m_threads) {
-        if (thread_.joinable()) {
-          thread_.join();
-        }
-      }
-      if (m_mainthread.joinable()) {
-        m_mainthread.join();
-      }
 
       m_sig.emit(signals::eventqueue::check_state{});
     }

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -32,6 +32,7 @@ namespace modules {
     }                                                                                   \
     void start() override {}                                                            \
     void stop() override {}                                                             \
+    void join() override {}                                                             \
     void halt(string) override {}                                                       \
     string contents() override {                                                        \
       return "";                                                                        \

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -74,7 +74,11 @@ controller::~controller() {
   m_log.trace("controller: Stop modules");
   for (auto&& module : m_modules) {
     auto module_name = module->name();
-    auto cleanup_ms = time_util::measure([&module] { module->stop(); });
+    auto cleanup_ms = time_util::measure([&module] {
+      module->stop();
+      module->join();
+      module.reset();
+    });
     m_log.info("Deconstruction of %s took %lu ms.", module_name, cleanup_ms);
   }
 }


### PR DESCRIPTION
Addresses point 2 of #1732.

Since the joins are in the `stop` method, the vtable is no longer acceded during the destruction. This also solve the CRTP problem.