### PR TITLE
fix(i3): workspace name need to be surrounded by quotes to accept all strings

### DIFF
--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -56,6 +56,8 @@ namespace modules {
     bool input(string&& cmd);
 
    private:
+    static string make_workspace_command(const string& workspace);
+
     static constexpr const char* DEFAULT_TAGS{"<label-state> <label-mode>"};
     static constexpr const char* DEFAULT_MODE{"default"};
     static constexpr const char* DEFAULT_WS_ICON{"ws-icon-default"};
@@ -92,6 +94,6 @@ namespace modules {
 
     unique_ptr<i3_util::connection_t> m_ipc;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -231,7 +231,7 @@ namespace modules {
       if (cmd.compare(0, strlen(EVENT_CLICK), EVENT_CLICK) == 0) {
         cmd.erase(0, strlen(EVENT_CLICK));
         m_log.info("%s: Sending workspace focus command to ipc handler", name());
-        conn.send_command("workspace " + cmd);
+        conn.send_command(make_workspace_command(cmd));
         return true;
       }
 
@@ -257,14 +257,14 @@ namespace modules {
       if (scrolldir == "next" && (m_wrap || next(current_ws) != workspaces.end())) {
         if (!(*current_ws)->focused) {
           m_log.info("%s: Sending workspace focus command to ipc handler", name());
-          conn.send_command("workspace " + (*current_ws)->name);
+          conn.send_command(make_workspace_command((*current_ws)->name));
         }
         m_log.info("%s: Sending workspace next_on_output command to ipc handler", name());
         conn.send_command("workspace next_on_output");
       } else if (scrolldir == "prev" && (m_wrap || current_ws != workspaces.begin())) {
         if (!(*current_ws)->focused) {
           m_log.info("%s: Sending workspace focus command to ipc handler", name());
-          conn.send_command("workspace " + (*current_ws)->name);
+          conn.send_command(make_workspace_command((*current_ws)->name));
         }
         m_log.info("%s: Sending workspace prev_on_output command to ipc handler", name());
         conn.send_command("workspace prev_on_output");
@@ -276,6 +276,10 @@ namespace modules {
 
     return true;
   }
-}
+
+  string i3_module::make_workspace_command(const string& workspace) {
+    return "workspace \"" + workspace + "\"";
+  }
+}  // namespace modules
 
 POLYBAR_NS_END


### PR DESCRIPTION
Like when i3-msg is used (`i3-msg workspace '","'`), the name of the workspaces need to be surrounded by quotes to accept all strings.

Fixes #1797.