### PR TITLE
feat(cmake): removing globs and using imported target

### DIFF
--- a/cmake/03-libs.cmake
+++ b/cmake/03-libs.cmake
@@ -3,28 +3,55 @@
 #
 
 find_package(Threads REQUIRED)
-list(APPEND libs ${CMAKE_THREAD_LIBS_INIT})
+find_package(CairoFC REQUIRED)
 
-querylib(TRUE "pkg-config" cairo-fc libs dirs)
-
-querylib(ENABLE_ALSA "pkg-config" alsa libs dirs)
-querylib(ENABLE_CURL "pkg-config" libcurl libs dirs)
-querylib(ENABLE_MPD "pkg-config" libmpdclient libs dirs)
-if(WITH_LIBNL)
-  querylib(ENABLE_NETWORK "pkg-config" libnl-genl-3.0 libs dirs)
-else()
-  querylib(ENABLE_NETWORK "cmake" Libiw libs dirs)
+if (ENABLE_ALSA)
+  find_package(ALSA REQUIRED)
 endif()
-querylib(ENABLE_PULSEAUDIO "pkg-config" libpulse libs dirs)
 
-querylib(WITH_XCOMPOSITE "pkg-config" xcb-composite libs dirs)
-querylib(WITH_XKB "pkg-config" xcb-xkb libs dirs)
-querylib(WITH_XRANDR "pkg-config" xcb-randr libs dirs)
-querylib(WITH_XRANDR_MONITORS "pkg-config" "xcb-randr>=1.12" libs dirs)
-querylib(WITH_XRM "pkg-config" xcb-xrm libs dirs)
-querylib(WITH_XCURSOR "pkg-config" xcb-cursor libs dirs)
+if (ENABLE_CURL)
+  find_package(CURL REQUIRED)
+endif()
+
+if (ENABLE_MPD)
+  find_package(LibMPDClient REQUIRED)
+endif()
+
+if (ENABLE_NETWORK)
+  if(WITH_LIBNL)
+    find_package(LibNlGenl3 REQUIRED)
+  else()
+    find_package(Libiw REQUIRED)
+  endif()
+endif()
+
+if (ENABLE_PULSEAUDIO)
+  find_package(LibPulse REQUIRED)
+endif()
+
+# Randr is required
+set(XORG_EXTENSIONS RANDR)
+if (WITH_XCOMPOSITE)
+  set(XORG_EXTENSIONS ${XORG_EXTENSIONS} COMPOSITE)
+endif()
+if (WITH_XKB)
+  set(XORG_EXTENSIONS ${XORG_EXTENSIONS} XKB)
+endif()
+if (WITH_XCURSOR)
+  set(XORG_EXTENSIONS ${XORG_EXTENSIONS} CURSOR)
+endif()
+if (WITH_XRM)
+  set(XORG_EXTENSIONS ${XORG_EXTENSIONS} XRM)
+endif()
+
+set(XCB_VERSION "")
+if (WITH_XRANDR_MONITOR)
+  set(XCB_VERSION "1.12")
+endif()
+
+find_package(Xcb ${XCB_VERSION} REQUIRED COMPONENTS ${XORG_EXTENSIONS})
 
 # FreeBSD Support
 if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-  querylib(TRUE "pkg-config" libinotify libs dirs)
+  find_package(LibInotify REQUIRED)
 endif()

--- a/cmake/common/utils.cmake
+++ b/cmake/common/utils.cmake
@@ -117,4 +117,17 @@ function(checklib flag type pkg)
   endif()
 endfunction()
 
+function(get_include_dirs output)
+  get_filename_component(generated_sources_dir  ${CMAKE_BINARY_DIR}/generated-sources   ABSOLUTE)
+  get_filename_component(include_dir            ${CMAKE_SOURCE_DIR}/include             ABSOLUTE)
+
+  set(${output} ${include_dir} ${generated_sources_dir} PARENT_SCOPE)
+endfunction()
+
+function(get_sources_dirs output)
+  get_filename_component(src_dir                ${CMAKE_SOURCE_DIR}/src                 ABSOLUTE)
+
+  set(${output} ${src_dir} PARENT_SCOPE)
+endfunction()
+
 # }}}

--- a/cmake/modules/FindCairoFC.cmake
+++ b/cmake/modules/FindCairoFC.cmake
@@ -1,0 +1,31 @@
+find_package(PkgConfig REQUIRED)
+include(CMakeFindDependencyMacro)
+
+pkg_check_modules(PC_CairoFC QUIET cairo-fc)
+
+set(CairoFC_INCLUDE_DIR ${PC_CairoFC_INCLUDE_DIRS})
+set(CairoFC_LIBRARY ${PC_CairoFC_LIBRARIES})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set CairoFC_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(CairoFC
+  REQUIRED_VARS
+  CairoFC_INCLUDE_DIR
+  CairoFC_LIBRARY
+  VERSION_VAR
+  PC_CairoFC_VERSION)
+message(STATUS "${CairoFC}")
+
+mark_as_advanced(CairoFC_INCLUDE_DIR CairoFC_LIBRARY)
+
+set(CairoFC_LIBRARIES ${CairoFC_LIBRARY})
+set(CairoFC_INCLUDE_DIRS ${CairoFC_INCLUDE_DIR})
+
+if(CairoFC_FOUND AND NOT TARGET Cairo::CairoFC)
+  add_library(Cairo::CairoFC INTERFACE IMPORTED)
+  set_target_properties(Cairo::CairoFC PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CairoFC_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${CairoFC_LIBRARIES}"
+  )
+endif()

--- a/cmake/modules/FindCairoFC.cmake
+++ b/cmake/modules/FindCairoFC.cmake
@@ -1,31 +1,5 @@
-find_package(PkgConfig REQUIRED)
-include(CMakeFindDependencyMacro)
-
-pkg_check_modules(PC_CairoFC QUIET cairo-fc)
-
-set(CairoFC_INCLUDE_DIR ${PC_CairoFC_INCLUDE_DIRS})
-set(CairoFC_LIBRARY ${PC_CairoFC_LIBRARIES})
-
-include(FindPackageHandleStandardArgs)
-# handle the QUIETLY and REQUIRED arguments and set CairoFC_FOUND to TRUE
-# if all listed variables are TRUE
-find_package_handle_standard_args(CairoFC
-  REQUIRED_VARS
-  CairoFC_INCLUDE_DIR
-  CairoFC_LIBRARY
-  VERSION_VAR
-  PC_CairoFC_VERSION)
-message(STATUS "${CairoFC}")
-
-mark_as_advanced(CairoFC_INCLUDE_DIR CairoFC_LIBRARY)
-
-set(CairoFC_LIBRARIES ${CairoFC_LIBRARY})
-set(CairoFC_INCLUDE_DIRS ${CairoFC_INCLUDE_DIR})
+find_package_impl("cairo-fc" "CairoFC" "")
 
 if(CairoFC_FOUND AND NOT TARGET Cairo::CairoFC)
-  add_library(Cairo::CairoFC INTERFACE IMPORTED)
-  set_target_properties(Cairo::CairoFC PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CairoFC_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES "${CairoFC_LIBRARIES}"
-  )
+  create_imported_target("Cairo::CairoFC" "${CairoFC_INCLUDE_DIR}" "${CairoFC_LIBRARY}")
 endif()

--- a/cmake/modules/FindLibInotify.cmake
+++ b/cmake/modules/FindLibInotify.cmake
@@ -1,0 +1,26 @@
+function(libinotify)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(PC_LibInotify QUIET libinotify)
+
+  include(FindPackageHandleStandardArgs)
+
+  find_path(LibInotify_INCLUDES
+    NAMES netlink/version.h
+    HINTS ${PC_LibInotify_INCLUDEDIR} ${PC_LibInotify_INCLUDE_DIRS}
+    )
+
+  find_package_handle_standard_args(LibInotify
+    REQUIRED_VARS PC_LibInotify_INCLUDE_DIRS
+    VERSION_VAR PC_LibInotify_VERSION
+    )
+
+  if(LibInotify_FOUND AND NOT TARGET LibInotify::LibInotify)
+    add_library(LibInotify::LibInotify INTERFACE IMPORTED)
+    set_target_properties(LibInotify::LibInotify PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${PC_LibInotify_LIBRARIES}")
+
+    target_include_directories(LibInotify::LibInotify SYSTEM INTERFACE ${LibInotify_INCLUDES})
+  endif()
+endfunction()
+
+libinotify()

--- a/cmake/modules/FindLibInotify.cmake
+++ b/cmake/modules/FindLibInotify.cmake
@@ -1,26 +1,5 @@
-function(libinotify)
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(PC_LibInotify QUIET libinotify)
+find_package_impl("libinotify" "LibInotify" "")
 
-  include(FindPackageHandleStandardArgs)
-
-  find_path(LibInotify_INCLUDES
-    NAMES netlink/version.h
-    HINTS ${PC_LibInotify_INCLUDEDIR} ${PC_LibInotify_INCLUDE_DIRS}
-    )
-
-  find_package_handle_standard_args(LibInotify
-    REQUIRED_VARS PC_LibInotify_INCLUDE_DIRS
-    VERSION_VAR PC_LibInotify_VERSION
-    )
-
-  if(LibInotify_FOUND AND NOT TARGET LibInotify::LibInotify)
-    add_library(LibInotify::LibInotify INTERFACE IMPORTED)
-    set_target_properties(LibInotify::LibInotify PROPERTIES
-      INTERFACE_LINK_LIBRARIES "${PC_LibInotify_LIBRARIES}")
-
-    target_include_directories(LibInotify::LibInotify SYSTEM INTERFACE ${LibInotify_INCLUDES})
-  endif()
-endfunction()
-
-libinotify()
+if(LibInotify_FOUND AND NOT TARGET LibInotify::LibInotify)
+  create_imported_target("LibInotify::LibInotify" "${LibInotify_INCLUDE_DIR}" "${LibInotify_LIBRARY}")
+endif()

--- a/cmake/modules/FindLibMPDClient.cmake
+++ b/cmake/modules/FindLibMPDClient.cmake
@@ -1,0 +1,22 @@
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_LibMPDClient QUIET libmpdclient)
+
+include(FindPackageHandleStandardArgs)
+
+find_path(LibMPDClient_INCLUDES
+  NAMES mpd/player.h
+  HINTS ${PC_LibMPDClient_INCLUDEDIR} ${PC_LibMPDClient_INCLUDE_DIRS}
+  )
+
+find_package_handle_standard_args(LibMPDClient
+  REQUIRED_VARS LibMPDClient_INCLUDES
+  VERSION_VAR PC_LibMPDClient_VERSION
+  )
+
+if(LibMPDClient_FOUND AND NOT TARGET LibMPDClient::LibMPDClient)
+  add_library(LibMPDClient::LibMPDClient INTERFACE IMPORTED)
+  set_target_properties(LibMPDClient::LibMPDClient PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${PC_LibMPDClient_LIBRARIES}")
+
+  target_include_directories(LibMPDClient::LibMPDClient SYSTEM INTERFACE ${LibMPDClient_INCLUDES})
+endif()

--- a/cmake/modules/FindLibMPDClient.cmake
+++ b/cmake/modules/FindLibMPDClient.cmake
@@ -1,22 +1,5 @@
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(PC_LibMPDClient QUIET libmpdclient)
-
-include(FindPackageHandleStandardArgs)
-
-find_path(LibMPDClient_INCLUDES
-  NAMES mpd/player.h
-  HINTS ${PC_LibMPDClient_INCLUDEDIR} ${PC_LibMPDClient_INCLUDE_DIRS}
-  )
-
-find_package_handle_standard_args(LibMPDClient
-  REQUIRED_VARS LibMPDClient_INCLUDES
-  VERSION_VAR PC_LibMPDClient_VERSION
-  )
+find_package_impl("libmpdclient" "LibMPDClient" "mpd/player.h")
 
 if(LibMPDClient_FOUND AND NOT TARGET LibMPDClient::LibMPDClient)
-  add_library(LibMPDClient::LibMPDClient INTERFACE IMPORTED)
-  set_target_properties(LibMPDClient::LibMPDClient PROPERTIES
-    INTERFACE_LINK_LIBRARIES "${PC_LibMPDClient_LIBRARIES}")
-
-  target_include_directories(LibMPDClient::LibMPDClient SYSTEM INTERFACE ${LibMPDClient_INCLUDES})
+  create_imported_target("LibMPDClient::LibMPDClient" "${LibMPDClient_INCLUDE_DIR}" "${LibMPDClient_LIBRARY}")
 endif()

--- a/cmake/modules/FindLibNlGenl3.cmake
+++ b/cmake/modules/FindLibNlGenl3.cmake
@@ -1,17 +1,5 @@
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(PC_LibNlGenl3 QUIET libnl-genl-3.0)
-
-include(FindPackageHandleStandardArgs)
-
-find_package_handle_standard_args(LibNlGenl3
-  REQUIRED_VARS PC_LibNlGenl3_INCLUDE_DIRS
-  VERSION_VAR PC_LibNlGenl3_VERSION
-)
+find_package_impl("libnl-genl-3.0" "LibNlGenl3" "")
 
 if(LibNlGenl3_FOUND AND NOT TARGET LibNlGenl3::LibNlGenl3)
-  add_library(LibNlGenl3::LibNlGenl3 INTERFACE IMPORTED)
-
-  set_target_properties(LibNlGenl3::LibNlGenl3 PROPERTIES
-    INTERFACE_LINK_LIBRARIES "${PC_LibNlGenl3_LIBRARIES}")
-  target_include_directories(LibNlGenl3::LibNlGenl3 SYSTEM INTERFACE ${PC_LibNlGenl3_INCLUDE_DIRS})
+  create_imported_target("LibNlGenl3::LibNlGenl3" "${LibNlGenl3_INCLUDE_DIR}" "${LibNlGenl3_LIBRARY}")
 endif()

--- a/cmake/modules/FindLibNlGenl3.cmake
+++ b/cmake/modules/FindLibNlGenl3.cmake
@@ -1,0 +1,17 @@
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_LibNlGenl3 QUIET libnl-genl-3.0)
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(LibNlGenl3
+  REQUIRED_VARS PC_LibNlGenl3_INCLUDE_DIRS
+  VERSION_VAR PC_LibNlGenl3_VERSION
+)
+
+if(LibNlGenl3_FOUND AND NOT TARGET LibNlGenl3::LibNlGenl3)
+  add_library(LibNlGenl3::LibNlGenl3 INTERFACE IMPORTED)
+
+  set_target_properties(LibNlGenl3::LibNlGenl3 PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${PC_LibNlGenl3_LIBRARIES}")
+  target_include_directories(LibNlGenl3::LibNlGenl3 SYSTEM INTERFACE ${PC_LibNlGenl3_INCLUDE_DIRS})
+endif()

--- a/cmake/modules/FindLibPulse.cmake
+++ b/cmake/modules/FindLibPulse.cmake
@@ -1,23 +1,5 @@
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(PC_LibPulse QUIET libpulse)
-
-include(FindPackageHandleStandardArgs)
-
-find_path(LibPulse_INCLUDES
-  NAMES pulse/version.h
-  HINTS ${PC_LibPulse_INCLUDEDIR} ${PC_LibPulse_INCLUDE_DIRS}
-)
-
-find_package_handle_standard_args(LibPulse
-  REQUIRED_VARS LibPulse_INCLUDES
-  VERSION_VAR PC_LibPulse_VERSION
-)
+find_package_impl("libpulse" "LibPulse" "pulse/version.h")
 
 if(LibPulse_FOUND AND NOT TARGET LibPulse::LibPulse)
-  add_library(LibPulse::LibPulse INTERFACE IMPORTED)
-  set_target_properties(LibPulse::LibPulse PROPERTIES
-    INTERFACE_LINK_LIBRARIES "${PC_LibPulse_LIBRARIES}")
-
-  target_include_directories(LibPulse::LibPulse SYSTEM INTERFACE ${LibPulse_INCLUDES})
+  create_imported_target("LibPulse::LibPulse" "${LibPulse_INCLUDE_DIR}" "${LibPulse_LIBRARY}")
 endif()

--- a/cmake/modules/FindLibPulse.cmake
+++ b/cmake/modules/FindLibPulse.cmake
@@ -1,0 +1,23 @@
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_LibPulse QUIET libpulse)
+
+include(FindPackageHandleStandardArgs)
+
+find_path(LibPulse_INCLUDES
+  NAMES pulse/version.h
+  HINTS ${PC_LibPulse_INCLUDEDIR} ${PC_LibPulse_INCLUDE_DIRS}
+)
+
+find_package_handle_standard_args(LibPulse
+  REQUIRED_VARS LibPulse_INCLUDES
+  VERSION_VAR PC_LibPulse_VERSION
+)
+
+if(LibPulse_FOUND AND NOT TARGET LibPulse::LibPulse)
+  add_library(LibPulse::LibPulse INTERFACE IMPORTED)
+  set_target_properties(LibPulse::LibPulse PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${PC_LibPulse_LIBRARIES}")
+
+  target_include_directories(LibPulse::LibPulse SYSTEM INTERFACE ${LibPulse_INCLUDES})
+endif()

--- a/cmake/modules/FindLibiw.cmake
+++ b/cmake/modules/FindLibiw.cmake
@@ -17,8 +17,5 @@ find_package_handle_standard_args(Libiw DEFAULT_MSG LIBIW_LIBRARY LIBIW_INCLUDE_
 mark_as_advanced(LIBIW_INCLUDE_DIR LIBIW_LIBRARY)
 
 if(Libiw_FOUND AND NOT TARGET Libiw::Libiw)
-  add_library(Libiw::Libiw INTERFACE IMPORTED)
-  set_target_properties(Libiw::Libiw PROPERTIES
-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${LIBIW_INCLUDE_DIR}"
-    INTERFACE_LINK_LIBRARIES "${LIBIW_LIBRARY}")
+  create_imported_target("Libiw::Libiw" "${LIBIW_INCLUDE_DIR}" "${LIBIW_LIBRARIES}")
 endif()

--- a/cmake/modules/FindLibiw.cmake
+++ b/cmake/modules/FindLibiw.cmake
@@ -6,7 +6,7 @@
 find_library(LIBIW_LIBRARY iw)
 
 if(LIBIW_LIBRARY)
-    set(LIBIW_LIBRARIES ${LIBIW_LIBRARY})
+  set(LIBIW_LIBRARIES ${LIBIW_LIBRARY})
 endif(LIBIW_LIBRARY)
 
 find_path(LIBIW_INCLUDE_DIR NAMES iwlib.h)
@@ -15,3 +15,10 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libiw DEFAULT_MSG LIBIW_LIBRARY LIBIW_INCLUDE_DIR)
 
 mark_as_advanced(LIBIW_INCLUDE_DIR LIBIW_LIBRARY)
+
+if(Libiw_FOUND AND NOT TARGET Libiw::Libiw)
+  add_library(Libiw::Libiw INTERFACE IMPORTED)
+  set_target_properties(Libiw::Libiw PROPERTIES
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${LIBIW_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${LIBIW_LIBRARY}")
+endif()

--- a/cmake/modules/FindXcb.cmake
+++ b/cmake/modules/FindXcb.cmake
@@ -1,6 +1,4 @@
-cmake_policy(PUSH)
-cmake_policy(SET CMP0057 NEW)
-
+# This script only supports the following components of XCB
 set(XCB_known_components
   XCB
   RANDR
@@ -9,44 +7,32 @@ set(XCB_known_components
   XRM
   CURSOR)
 
+# Deducing header from the name of the component
 foreach(_comp ${XCB_known_components})
   string(TOLOWER "${_comp}" _lc_comp)
   set(XCB_${_comp}_pkg_config "xcb-${_lc_comp}")
   set(XCB_${_comp}_header "xcb/${_lc_comp}.h")
 endforeach()
+# Exception cases
 set(XCB_XRM_header "xcb/xcb_xrm.h")
 set(XCB_CURSOR_header "xcb/xcb_cursor.h")
 
-find_package(PkgConfig REQUIRED)
-include(FindPackageHandleStandardArgs)
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW)
 
 foreach(_comp ${Xcb_FIND_COMPONENTS})
   if (NOT ${_comp} IN_LIST XCB_known_components)
     cmake_policy(POP)
-    message(FATAL_ERROR "Unknow component ${_comp} for XCB")
+    message(FATAL_ERROR "Unknow component \"${_comp}\" of XCB")
   endif()
 
-  pkg_check_modules(PC_${_comp} QUIET ${XCB_${_comp}_pkg_config})
-
-  find_path(${_comp}_INCLUDES_DIRS
-    NAMES "${XCB_${_comp}_header}"
-    HINTS ${PC_${_comp}_INCLUDEDIR} ${PC_${_comp}_INCLUDE_DIRS}
-  )
-
-  find_package_handle_standard_args(Xcb_${_comp}
-    REQUIRED_VARS ${_comp}_INCLUDES_DIRS
-    VERSION_VAR PC_${_comp}_VERSION
-    HANDLE_COMPONENTS
-  )
+  find_package_impl(${XCB_${_comp}_pkg_config} "Xcb_${_comp}" "${XCB_${_comp}_header}")
 
   if(Xcb_${_comp}_FOUND AND NOT TARGET Xcb::${_comp})
-    add_library(Xcb::${_comp} INTERFACE IMPORTED)
-    set_target_properties(Xcb::${_comp} PROPERTIES
-      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_comp}_INCLUDES"
-      INTERFACE_LINK_LIBRARIES "${PC_${_comp}_LIBRARIES}"
-    )
+    create_imported_target("Xcb::${_comp}" "${Xcb_${_comp}_INCLUDE_DIRS}" "${Xcb_${_comp}_LIBRARIES}")
   elseif(NOT Xcb_${_comp}_FOUND AND Xcb_FIND_REQUIRED)
-      message(FATAL_ERROR "Xcb: Required component \"${component}\" is not found")
+    cmake_policy(POP)
+    message(FATAL_ERROR "Xcb: Required component \"${_comp}\" is not found")
   endif()
 endforeach()
 

--- a/cmake/modules/FindXcb.cmake
+++ b/cmake/modules/FindXcb.cmake
@@ -1,0 +1,53 @@
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW)
+
+set(XCB_known_components
+  XCB
+  RANDR
+  COMPOSITE
+  XKB
+  XRM
+  CURSOR)
+
+foreach(_comp ${XCB_known_components})
+  string(TOLOWER "${_comp}" _lc_comp)
+  set(XCB_${_comp}_pkg_config "xcb-${_lc_comp}")
+  set(XCB_${_comp}_header "xcb/${_lc_comp}.h")
+endforeach()
+set(XCB_XRM_header "xcb/xcb_xrm.h")
+set(XCB_CURSOR_header "xcb/xcb_cursor.h")
+
+find_package(PkgConfig REQUIRED)
+include(FindPackageHandleStandardArgs)
+
+foreach(_comp ${Xcb_FIND_COMPONENTS})
+  if (NOT ${_comp} IN_LIST XCB_known_components)
+    cmake_policy(POP)
+    message(FATAL_ERROR "Unknow component ${_comp} for XCB")
+  endif()
+
+  pkg_check_modules(PC_${_comp} QUIET ${XCB_${_comp}_pkg_config})
+
+  find_path(${_comp}_INCLUDES_DIRS
+    NAMES "${XCB_${_comp}_header}"
+    HINTS ${PC_${_comp}_INCLUDEDIR} ${PC_${_comp}_INCLUDE_DIRS}
+  )
+
+  find_package_handle_standard_args(Xcb_${_comp}
+    REQUIRED_VARS ${_comp}_INCLUDES_DIRS
+    VERSION_VAR PC_${_comp}_VERSION
+    HANDLE_COMPONENTS
+  )
+
+  if(Xcb_${_comp}_FOUND AND NOT TARGET Xcb::${_comp})
+    add_library(Xcb::${_comp} INTERFACE IMPORTED)
+    set_target_properties(Xcb::${_comp} PROPERTIES
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_comp}_INCLUDES"
+      INTERFACE_LINK_LIBRARIES "${PC_${_comp}_LIBRARIES}"
+    )
+  elseif(NOT Xcb_${_comp}_FOUND AND Xcb_FIND_REQUIRED)
+      message(FATAL_ERROR "Xcb: Required component \"${component}\" is not found")
+  endif()
+endforeach()
+
+cmake_policy(POP)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Generate settings.hpp
 #
 
-list(APPEND dirs ${CMAKE_CURRENT_LIST_DIR})
-
 if(WITH_XRANDR)
   list(APPEND XPP_EXTENSION_LIST xpp::randr::extension)
 endif()
@@ -20,6 +18,4 @@ configure_file(
   ${CMAKE_BINARY_DIR}/generated-sources/settings.hpp
   ESCAPE_QUOTES)
 
-list(APPEND dirs ${CMAKE_BINARY_DIR}/generated-sources/)
 set(APP_VERSION ${APP_VERSION} PARENT_SCOPE)
-set(dirs ${dirs} PARENT_SCOPE)

--- a/include/x11/extensions/all.hpp
+++ b/include/x11/extensions/all.hpp
@@ -5,7 +5,9 @@
 #if WITH_XRANDR
 #include "x11/extensions/randr.hpp"
 #endif
+#if WITH_XCOMPOSITE
 #include "x11/extensions/composite.hpp"
+#endif
 #if WITH_XKB
 #include "x11/extensions/xkb.hpp"
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,13 +23,26 @@ if(WITH_XKB)
 endif()
 
 add_subdirectory(xpp)
+if (NOT TARGET xpp)
+  message(FATAL_ERROR "Target xpp not generated")
+else()
+  get_target_property(_xpp_includes xpp INCLUDE_DIRECTORIES)
+  set_target_properties(xpp PROPERTIES INCLUDE_DIRECTORIES "")
+  target_include_directories(xpp SYSTEM PUBLIC ${_xpp_includes})
+endif()
 
 # }}}
 # Library: i3ipcpp {{{
 
 if(ENABLE_I3)
   add_subdirectory(i3ipcpp)
-  list(APPEND libs ${I3IPCPP_LIBRARIES})
+  if (NOT TARGET i3ipc++)
+    message(FATAL_ERROR "Target i3ipcpp not generated")
+  else()
+    get_target_property(_i3ipcpp_includes i3ipc++ INCLUDE_DIRECTORIES)
+    set_target_properties(i3ipc++ PROPERTIES INCLUDE_DIRECTORIES "")
+    target_include_directories(i3ipc++ SYSTEM PUBLIC ${_i3ipcpp_includes})
+  endif()
 endif()
 
 # }}}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,10 +4,8 @@
 
 # Library: concurrentqueue {{{
 
-add_library(concurrentqueue INTERFACE)
-target_include_directories(concurrentqueue INTERFACE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/concurrentqueue/include>)
-list(APPEND libs concurrentqueue)
+add_library(moodycamel INTERFACE)
+target_include_directories(moodycamel SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/concurrentqueue/include)
 
 # }}}
 # Library: xpp {{{
@@ -25,7 +23,6 @@ if(WITH_XKB)
 endif()
 
 add_subdirectory(xpp)
-list(APPEND libs xpp)
 
 # }}}
 # Library: i3ipcpp {{{

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,9 +151,11 @@ target_link_libraries(poly PUBLIC
 )
 
 target_compile_options(poly PUBLIC $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:MinSizeRel>:-flto>>)
+set_target_properties(poly PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/libs)
 
 add_executable(polybar main.cpp)
 target_link_libraries(polybar poly)
+set_target_properties(poly PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 install(TARGETS polybar
   DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,8 @@
 
 # Source tree {{{
 
-get_filename_component(generated_sources_dir  ${CMAKE_BINARY_DIR}/generated-sources   ABSOLUTE)
-get_filename_component(include_dir            ${CMAKE_SOURCE_DIR}/include             ABSOLUTE)
-get_filename_component(src_dir                ${CMAKE_CURRENT_SOURCE_DIR}             ABSOLUTE)
+get_include_dirs(includes_dir)
+get_sources_dirs(src_dir)
 
 set(ALSA_SOURCES
   ${src_dir}/adapters/alsa/control.cpp
@@ -129,7 +128,7 @@ set(POLY_SOURCES
 # Target: polybar {{{
 
 add_library(poly STATIC ${POLY_SOURCES})
-target_include_directories(poly PUBLIC ${include_dir} ${generated_sources_dir})
+target_include_directories(poly PUBLIC ${includes_dir})
 target_link_libraries(poly PUBLIC
   Threads::Threads
   Cairo::CairoFC
@@ -170,7 +169,7 @@ if(BUILD_IPC_MSG)
     utils/env.cpp
     utils/file.cpp
     utils/string.cpp)
-  target_include_directories(polybar-msg PRIVATE ${dirs})
+  target_include_directories(polybar-msg PRIVATE ${includes_dir})
   target_compile_options(polybar-msg PUBLIC $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:MinSizeRel>:-flto>>)
 
   install(TARGETS polybar-msg

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,65 +4,152 @@
 
 # Source tree {{{
 
-file(GLOB_RECURSE files RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.c[p]*)
-list(REMOVE_ITEM files main.cpp ipc.cpp)
+get_filename_component(generated_sources_dir  ${CMAKE_BINARY_DIR}/generated-sources   ABSOLUTE)
+get_filename_component(include_dir            ${CMAKE_SOURCE_DIR}/include             ABSOLUTE)
+get_filename_component(src_dir                ${CMAKE_CURRENT_SOURCE_DIR}             ABSOLUTE)
 
-if(NOT ENABLE_ALSA)
-  list(REMOVE_ITEM files modules/alsa.cpp)
-  list(REMOVE_ITEM files adapters/alsa/control.cpp)
-  list(REMOVE_ITEM files adapters/alsa/mixer.cpp)
-endif()
-if(NOT ENABLE_CURL)
-  list(REMOVE_ITEM files modules/github.cpp)
-  list(REMOVE_ITEM files utils/http.cpp)
-endif()
-if(NOT ENABLE_MPD)
-  list(REMOVE_ITEM files modules/mpd.cpp)
-  list(REMOVE_ITEM files adapters/mpd.cpp)
-endif()
-if(NOT ENABLE_NETWORK)
-  list(REMOVE_ITEM files modules/network.cpp)
-  list(REMOVE_ITEM files adapters/net.cpp)
-  list(REMOVE_ITEM files adapters/net_iw.cpp)
-  list(REMOVE_ITEM files adapters/net_nl.cpp)
-endif()
-if(WITH_LIBNL)
-  list(REMOVE_ITEM files adapters/net_iw.cpp)
-else()
-  list(REMOVE_ITEM files adapters/net_nl.cpp)
-endif()
-if(NOT ENABLE_I3)
-  list(REMOVE_ITEM files modules/i3.cpp)
-  list(REMOVE_ITEM files utils/i3.cpp)
-endif()
-if(NOT ENABLE_PULSEAUDIO)
-  list(REMOVE_ITEM files modules/pulseaudio.cpp)
-  list(REMOVE_ITEM files adapters/pulseaudio.cpp)
-endif()
-if(NOT WITH_XRANDR)
-  list(REMOVE_ITEM files x11/extensions/randr.cpp)
-endif()
-if(NOT WITH_XCOMPOSITE)
-  list(REMOVE_ITEM files x11/extensions/composite.cpp)
-endif()
-if(NOT WITH_XKB)
-  list(REMOVE_ITEM files x11/extensions/xkb.cpp)
-  list(REMOVE_ITEM files modules/xkeyboard.cpp)
-endif()
-if(NOT WITH_XRM)
-  list(REMOVE_ITEM files x11/xresources.cpp)
-endif()
-if(NOT WITH_XCURSOR)
-  list(REMOVE_ITEM files x11/cursor.cpp)
-endif()
+set(ALSA_SOURCES
+  ${src_dir}/adapters/alsa/control.cpp
+  ${src_dir}/adapters/alsa/mixer.cpp
+  ${src_dir}/modules/alsa.cpp
+)
+
+set(GITHUB_SOURCES ${src_dir}/modules/github.cpp ${src_dir}/utils/http.cpp)
+
+set(I3_SOURCES
+  ${src_dir}/modules/i3.cpp
+  ${src_dir}/utils/i3.cpp
+)
+
+set(MPD_SOURCES
+  ${src_dir}/adapters/mpd.cpp
+  ${src_dir}/modules/mpd.cpp
+)
+
+set(NETWORK_SOURCES
+  ${src_dir}/adapters/net.cpp
+  ${src_dir}/modules/network.cpp
+  $<IF:$<BOOL:${WITH_LIBNL}>,${src_dir}/adapters/net_nl.cpp,${src_dir}/adapters/net_iw.cpp>
+)
+
+
+set(PULSEAUDIO_SOURCES
+  ${src_dir}/adapters/pulseaudio.cpp
+  ${src_dir}/modules/pulseaudio.cpp
+)
+
+set(XCOMPOSITE_SOURCES ${src_dir}/x11/extensions/composite.cpp)
+
+set(XCURSOR_SOURCES ${src_dir}/x11/cursor.cpp)
+
+set(XKB_SOURCES
+  ${src_dir}/modules/xkeyboard.cpp
+  ${src_dir}/x11/extensions/xkb.cpp
+)
+
+set(XRM_SOURCES ${src_dir}/x11/xresources.cpp)
+
+set(POLY_SOURCES
+  ${src_dir}/cairo/utils.cpp
+  ${src_dir}/components/bar.cpp
+  ${src_dir}/components/builder.cpp
+  ${src_dir}/components/command_line.cpp
+  ${src_dir}/components/config.cpp
+  ${src_dir}/components/controller.cpp
+  ${src_dir}/components/ipc.cpp
+  ${src_dir}/components/logger.cpp
+  ${src_dir}/components/parser.cpp
+  ${src_dir}/components/renderer.cpp
+  ${src_dir}/components/screen.cpp
+  ${src_dir}/components/taskqueue.cpp
+  ${src_dir}/drawtypes/animation.cpp
+  ${src_dir}/drawtypes/iconset.cpp
+  ${src_dir}/drawtypes/label.cpp
+  ${src_dir}/drawtypes/progressbar.cpp
+  ${src_dir}/drawtypes/ramp.cpp
+  ${src_dir}/events/signal_emitter.cpp
+  ${src_dir}/events/signal_receiver.cpp
+  ${src_dir}/modules/backlight.cpp
+  ${src_dir}/modules/battery.cpp
+  ${src_dir}/modules/bspwm.cpp
+  ${src_dir}/modules/counter.cpp
+  ${src_dir}/modules/cpu.cpp
+  ${src_dir}/modules/date.cpp
+  ${src_dir}/modules/fs.cpp
+  ${src_dir}/modules/ipc.cpp
+  ${src_dir}/modules/memory.cpp
+  ${src_dir}/modules/menu.cpp
+  ${src_dir}/modules/meta/base.cpp
+  ${src_dir}/modules/script.cpp
+  ${src_dir}/modules/systray.cpp
+  ${src_dir}/modules/temperature.cpp
+  ${src_dir}/modules/text.cpp
+  ${src_dir}/modules/xbacklight.cpp
+  ${src_dir}/modules/xwindow.cpp
+  ${src_dir}/modules/xworkspaces.cpp
+  ${src_dir}/utils/bspwm.cpp
+  ${src_dir}/utils/command.cpp
+  ${src_dir}/utils/concurrency.cpp
+  ${src_dir}/utils/env.cpp
+  ${src_dir}/utils/factory.cpp
+  ${src_dir}/utils/file.cpp
+  ${src_dir}/utils/inotify.cpp
+  ${src_dir}/utils/io.cpp
+  ${src_dir}/utils/process.cpp
+  ${src_dir}/utils/socket.cpp
+  ${src_dir}/utils/string.cpp
+  ${src_dir}/utils/throttle.cpp
+  ${src_dir}/x11/atoms.cpp
+  ${src_dir}/x11/background_manager.cpp
+  ${src_dir}/x11/connection.cpp
+  ${src_dir}/x11/ewmh.cpp
+  ${src_dir}/x11/extensions/randr.cpp
+  ${src_dir}/x11/icccm.cpp
+  ${src_dir}/x11/registry.cpp
+  ${src_dir}/x11/tray_client.cpp
+  ${src_dir}/x11/tray_manager.cpp
+  ${src_dir}/x11/window.cpp
+  ${src_dir}/x11/winspec.cpp
+  ${src_dir}/x11/xembed.cpp
+
+  $<$<BOOL:${ENABLE_ALSA}>:${ALSA_SOURCES}>
+  $<$<BOOL:${ENABLE_CURL}>:${GITHUB_SOURCES}>
+  $<$<BOOL:${ENABLE_I3}>:${I3_SOURCES}>
+  $<$<BOOL:${ENABLE_MPD}>:${MPD_SOURCES}>
+  $<$<BOOL:${ENABLE_NETWORK}>:${NETWORK_SOURCES}>
+  $<$<BOOL:${ENABLE_PULSEAUDIO}>:${PULSEAUDIO_SOURCES}>
+  $<$<BOOL:${WITH_XCOMPOSITE}>:${XCOMPOSITE_SOURCES}>
+  $<$<BOOL:${WITH_XCURSOR}>:${XCURSOR_SOURCES}>
+  $<$<BOOL:${WITH_XKB}>:${XKB_SOURCES}>
+  $<$<BOOL:${WITH_XRM}>:${XRM_SOURCES}>
+)
 
 # }}}
 
 # Target: polybar {{{
 
-add_library(poly STATIC ${files})
-target_include_directories(poly PUBLIC ${dirs})
-target_link_libraries(poly ${libs} Threads::Threads)
+add_library(poly STATIC ${POLY_SOURCES})
+target_include_directories(poly PUBLIC ${include_dir} ${generated_sources_dir})
+target_link_libraries(poly PUBLIC
+  Threads::Threads
+  Cairo::CairoFC
+  moodycamel
+  xpp
+  $<$<TARGET_EXISTS:i3ipc++>:i3ipc++>
+  $<$<TARGET_EXISTS:ALSA::ALSA>:ALSA::ALSA>
+  $<$<TARGET_EXISTS:CURL::libcurl>:CURL::libcurl>
+  $<$<TARGET_EXISTS:LibMPDClient::LibMPDClient>:LibMPDClient::LibMPDClient>
+  $<$<TARGET_EXISTS:LibNlGenl3::LibNlGenl3>:LibNlGenl3::LibNlGenl3>
+  $<$<TARGET_EXISTS:Libiw::Libiw>:Libiw::Libiw>
+  $<$<TARGET_EXISTS:LibPulse::LibPulse>:LibPulse::LibPulse>
+  $<$<TARGET_EXISTS:Xcb::RANDR>:Xcb::RANDR>
+  $<$<TARGET_EXISTS:Xcb::COMPOSITE>:Xcb::COMPOSITE>
+  $<$<TARGET_EXISTS:Xcb::XKB>:Xcb::XKB>
+  $<$<TARGET_EXISTS:Xcb::CURSOR>:Xcb::CURSOR>
+  $<$<TARGET_EXISTS:Xcb::XRM>:Xcb::XRM>
+  $<$<TARGET_EXISTS:LibInotify::LibInotify>:LibInotify::LibInotify>
+)
+
 target_compile_options(poly PUBLIC $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:MinSizeRel>:-flto>>)
 
 add_executable(polybar main.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,3 @@
-include_directories(${dirs})
-include_directories(${CMAKE_CURRENT_LIST_DIR})
-
 # Download and unpack googletest at configure time {{{
 configure_file(
   CMakeLists.txt.in
@@ -39,6 +36,8 @@ function(add_unit_test source_file)
   set(name "unit_test.${testname}")
 
   add_executable(${name} unit_tests/${source_file}.cpp)
+  get_include_dirs(includes_dir)
+  target_include_directories(${name} PRIVATE ${includes_dir} ${CMAKE_CURRENT_LIST_DIR})
 
   # Link against gmock (this automatically links against gtest)
   target_link_libraries(${name} poly gmock_main)


### PR DESCRIPTION
This is the first of many PRs aiming at splitting polybar modules into separate shared objects.

In this PR, I removed all the globs in the cmake.
Moreover I also modernized the cmake by using imported targets rather than using `dirs` and `libs` variables.

EDIT:
Closes #1536.