### PR TITLE
feat(restacker): add a generic restacker

### DIFF
--- a/include/utils/restack.hpp
+++ b/include/utils/restack.hpp
@@ -17,9 +17,6 @@ namespace restack {
     virtual void operator()(connection& connection, const bar_settings& settings, const logger& logger) const = 0;
   };
 
-  using restacker_map_t = std::unordered_map<std::string, wm_restacker&>;
-
-  restacker_map_t& get_restacker_map();
   wm_restacker* get_restacker(const std::string& wm_name);
 
 

--- a/include/utils/restack.hpp
+++ b/include/utils/restack.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "common.hpp"
+#include "components/logger.hpp"
+#include "components/types.hpp"
+#include "x11/extensions/randr.hpp"
+
+POLYBAR_NS
+
+namespace restack {
+  struct wm_restacker {
+    explicit wm_restacker(std::string&& name);
+
+    virtual ~wm_restacker() = default;
+    virtual void operator()(connection& connection, const bar_settings& settings, const logger& logger) const = 0;
+  };
+
+  using restacker_map_t = std::unordered_map<std::string, wm_restacker&>;
+
+  restacker_map_t& get_restacker_map();
+  wm_restacker* get_restacker(const std::string& wm_name);
+
+
+}  // namespace restack
+
+POLYBAR_NS_END

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -9,10 +9,10 @@
 #include "components/types.hpp"
 #include "events/signal.hpp"
 #include "events/signal_emitter.hpp"
-#include "utils/bspwm.hpp"
 #include "utils/color.hpp"
 #include "utils/factory.hpp"
 #include "utils/math.hpp"
+#include "utils/restack.hpp"
 #include "utils/string.hpp"
 #include "x11/atoms.hpp"
 #include "x11/connection.hpp"
@@ -23,10 +23,6 @@
 
 #if WITH_XCURSOR
 #include "x11/cursor.hpp"
-#endif
-
-#if ENABLE_I3
-#include "utils/i3.hpp"
 #endif
 
 POLYBAR_NS
@@ -438,15 +434,8 @@ void bar::restack_window() {
 
   auto restacked = false;
 
-  if (wm_restack == "bspwm") {
-    restacked = bspwm_util::restack_to_root(m_connection, m_opts.monitor, m_opts.window);
-#if ENABLE_I3
-  } else if (wm_restack == "i3" && m_opts.override_redirect) {
-    restacked = i3_util::restack_to_root(m_connection, m_opts.window);
-  } else if (wm_restack == "i3" && !m_opts.override_redirect) {
-    m_log.warn("Ignoring restack of i3 window (not needed when `override-redirect = false`)");
-    wm_restack.clear();
-#endif
+  if (auto restacker = restack::get_restacker(wm_restack)) {
+    (*restacker)(m_connection, m_opts, m_log);
   } else {
     m_log.warn("Ignoring unsupported wm-restack option '%s'", wm_restack);
     wm_restack.clear();

--- a/src/utils/bspwm.cpp
+++ b/src/utils/bspwm.cpp
@@ -3,6 +3,7 @@
 #include "errors.hpp"
 #include "utils/bspwm.hpp"
 #include "utils/env.hpp"
+#include "utils/restack.hpp"
 #include "x11/connection.hpp"
 
 POLYBAR_NS
@@ -146,6 +147,23 @@ namespace bspwm_util {
     }
     return conn;
   }
-}
+}  // namespace bspwm_util
+
+namespace {
+  struct bspwm_restacker : public restack::wm_restacker {
+    bspwm_restacker() : restack::wm_restacker("bspwm") {}
+
+    void operator()(connection& conn, const bar_settings& opts, const logger& log) const override {
+      auto restacked = bspwm_util::restack_to_root(conn, opts.monitor, opts.window);
+      if (restacked) {
+        log.info("Successfully restacked bar window");
+      } else {
+        log.err("Failed to restack bar window");
+      }
+    }
+  };
+
+  bspwm_restacker restacker;
+}  // namespace
 
 POLYBAR_NS_END

--- a/src/utils/restack.cpp
+++ b/src/utils/restack.cpp
@@ -1,0 +1,28 @@
+#include "utils/restack.hpp"
+
+#include <algorithm>
+
+POLYBAR_NS
+
+namespace restack {
+  wm_restacker::wm_restacker(std::string&& name) {
+    get_restacker_map().emplace(move(name), *this);
+  }
+
+  restacker_map_t& get_restacker_map() {
+    static restacker_map_t restacker_map;
+    return restacker_map;
+  }
+
+  wm_restacker* get_restacker(const std::string& wm_name) {
+    auto it = get_restacker_map().find(wm_name);
+
+    if (it == get_restacker_map().end()) {
+      return nullptr;
+    }
+
+    return &(it->second);
+  }
+}  // namespace restack
+
+POLYBAR_NS_END

--- a/src/utils/restack.cpp
+++ b/src/utils/restack.cpp
@@ -5,19 +5,24 @@
 POLYBAR_NS
 
 namespace restack {
+  namespace {
+    using restacker_map_t = std::unordered_map<std::string, wm_restacker&>;
+
+    restacker_map_t& get_restacker_map() {
+      static restacker_map_t restacker_map;
+      return restacker_map;
+    }
+  }
+
   wm_restacker::wm_restacker(std::string&& name) {
     get_restacker_map().emplace(move(name), *this);
   }
 
-  restacker_map_t& get_restacker_map() {
-    static restacker_map_t restacker_map;
-    return restacker_map;
-  }
-
   wm_restacker* get_restacker(const std::string& wm_name) {
-    auto it = get_restacker_map().find(wm_name);
+    const auto& map = get_restacker_map();
+    auto it = map.find(wm_name);
 
-    if (it == get_restacker_map().end()) {
+    if (it == map.end()) {
       return nullptr;
     }
 


### PR DESCRIPTION
This PR is the second aiming at splitting polybar into separate modules.
In order to split polybar in modules, it is needed to introduce a generic restacker since we can't use define anymore.

I took the inspiration in #1409 but I removed the macro.
The registration is done in the constructor of the restacker.