### PR TITLE
fix(msg): use stdout when exiting with code 0

### DIFF
--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -15,8 +15,8 @@ using namespace std;
 #define IPC_CHANNEL_PREFIX "/tmp/polybar_mqueue."
 #endif
 
-void log(const string& msg) {
-  fprintf(stderr, "polybar-msg: %s\n", msg.c_str());
+void display(const string& msg) {
+  fprintf(stdout, "%s\n", msg.c_str());
 }
 
 void log(int exit_code, const string& msg) {
@@ -33,7 +33,7 @@ void remove_pipe(const string& handle) {
   if (unlink(handle.c_str()) == -1) {
     log(1, "Could not remove stale ipc channel: "s + strerror(errno));
   } else {
-    log("Removed stale ipc channel: " + handle);
+    display("Removed stale ipc channel: " + handle);
   }
 }
 
@@ -120,7 +120,7 @@ int main(int argc, char** argv) {
       file_descriptor fd(channel, O_WRONLY | O_NONBLOCK);
       string payload{ipc_type + ':' + ipc_payload};
       if (write(fd, payload.c_str(), payload.size()) != -1) {
-        log("Successfully wrote \"" + payload + "\" to \"" + channel + "\"");
+        display("Successfully wrote \"" + payload + "\" to \"" + channel + "\"");
         exit_status = 0;
       } else {
         log(E_WRITE, "Failed to write \"" + payload + "\" to \"" + channel + "\" (err: " + strerror(errno) + ")");


### PR DESCRIPTION
This PR change `polybar-msg` to output messages to stdout when the exit code is 0.

Currently wanting to only log errors coming from `polybar-msg` is very akward and non-unixy, to do so one is forced to write something like the following:
``` sh
err=$(polybar-msg hook module 1 2>&1) || echo "$err"`
# or
polybar-msg hook module 1 2>&1 | awk '!/Successfully wrote/ {print $0}'
```
With this change you can apply the conventional redirection pattern:
```sh
polybar-msg hook module 1 1>/dev/null
```

In my case not redirecting successful output result in a flood of the logs of ~10k message a day.