### PR TITLE
Use GNUInstallDirs instead of hardcoded paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(CMAKE_MODULE_PATH
   ${PROJECT_SOURCE_DIR}/cmake/common
   ${PROJECT_SOURCE_DIR}/cmake/modules)
 
+include(GNUInstallDirs)
 include(utils)
 include(01-core)
 include(02-opts)
@@ -160,8 +161,7 @@ configure_file(
   ESCAPE_QUOTES @ONLY)
 
 install(FILES config
-  DESTINATION share/doc/polybar
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}
   COMPONENT config)
 
 # }}}
-

--- a/cmake/01-core.cmake
+++ b/cmake/01-core.cmake
@@ -72,20 +72,6 @@ elseif(CXXLIB_GCC)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lstdc++")
 endif()
 
-# Install paths
-if(NOT DEFINED CMAKE_INSTALL_BINDIR)
-  set(CMAKE_INSTALL_BINDIR bin)
-endif()
-if(NOT DEFINED CMAKE_INSTALL_SBINDIR)
-  set(CMAKE_INSTALL_SBINDIR sbin)
-endif()
-if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-  set(CMAKE_INSTALL_LIBDIR lib)
-endif()
-if(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
-  set(CMAKE_INSTALL_INCLUDEDIR include)
-endif()
-
 # Custom build type ; SANITIZE
 SET(CMAKE_CXX_FLAGS_SANITIZE "-O0 -g -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls"
   CACHE STRING "Flags used by the C++ compiler during sanitize builds." FORCE)

--- a/cmake/05-summary.cmake
+++ b/cmake/05-summary.cmake
@@ -8,6 +8,13 @@ message_colored(STATUS "   Type: ${CMAKE_BUILD_TYPE}" "37;2")
 message_colored(STATUS "   CXX: ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}" "37;2")
 message_colored(STATUS "   LD: ${CMAKE_LINKER} ${CMAKE_EXE_LINKER_FLAGS} ${CMAKE_EXE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}" "37;2")
 
+message(STATUS " Install Paths:")
+message_colored(STATUS "   PREFIX:  ${CMAKE_INSTALL_PREFIX}" "32")
+message_colored(STATUS "   BINDIR:  ${CMAKE_INSTALL_FULL_BINDIR}" "32")
+message_colored(STATUS "   DATADIR: ${CMAKE_INSTALL_FULL_DATADIR}" "32")
+message_colored(STATUS "   DOCDIR:  ${CMAKE_INSTALL_FULL_DOCDIR}" "32")
+message_colored(STATUS "   MANDIR:  ${CMAKE_INSTALL_FULL_MANDIR}" "32")
+
 message(STATUS " Targets:")
 colored_option("   polybar-msg" BUILD_IPC_MSG)
 colored_option("   testsuite" BUILD_TESTS)

--- a/contrib/bash/CMakeLists.txt
+++ b/contrib/bash/CMakeLists.txt
@@ -2,5 +2,5 @@
 # Bash completion template
 #
 install(FILES polybar
-  DESTINATION share/bash-completion/completions
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/bash-completion/completions
   COMPONENT tools)

--- a/contrib/zsh/CMakeLists.txt
+++ b/contrib/zsh/CMakeLists.txt
@@ -2,5 +2,5 @@
 # Zsh completion template
 #
 install(FILES _polybar _polybar_msg
-  DESTINATION share/zsh/site-functions
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/zsh/site-functions
   COMPONENT tools)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,9 +48,9 @@ endforeach()
 add_custom_target(doc ALL DEPENDS ${doc_targets})
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
-  DESTINATION share/doc/polybar
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}/polybar
   COMPONENT doc)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar.1
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1
+  DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
   COMPONENT doc)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,7 +48,17 @@ endforeach()
 add_custom_target(doc ALL DEPENDS ${doc_targets})
 
 # This is needed for the case where only the doc target is built
-include(GNUInstallDirs)
+# CMAKE_INSTALL_DOCDIR uses PROJECT_NAME which is now polybar-doc, to be
+# consistent with a regular install we temporarily override it with "polybar"
+# before including GNUInstallDirs
+# Also since no language is set and GNUInstallDirs cannot set
+# CMAKE_INSTALL_LIBDIR, so we set it to a dummy value to suppress a warning
+if(${CMAKE_PROJECT_NAME} STREQUAL "polybar-doc")
+  set(PROJECT_NAME "polybar")
+  set(CMAKE_INSTALL_LIBDIR "")
+  include(GNUInstallDirs)
+  set(PROJECT_NAME "polybar-doc")
+endif()
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
   DESTINATION ${CMAKE_INSTALL_DOCDIR}

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,7 +48,7 @@ endforeach()
 add_custom_target(doc ALL DEPENDS ${doc_targets})
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
-  DESTINATION ${CMAKE_INSTALL_DOCDIR}/polybar
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}
   COMPONENT doc)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar.1

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -47,6 +47,9 @@ endforeach()
 # Dummy target that depends on all documentation targets
 add_custom_target(doc ALL DEPENDS ${doc_targets})
 
+# This is needed for the case where only the doc target is built
+include(GNUInstallDirs)
+
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
   DESTINATION ${CMAKE_INSTALL_DOCDIR}
   COMPONENT doc)


### PR DESCRIPTION
This change should be a no-op in the normal case and at the same time make it
easier to customise polybar builds on systems with special needs.