### PR TITLE
fix: Only remove cloned monitors when necessary

### DIFF
--- a/contrib/bash/polybar
+++ b/contrib/bash/polybar
@@ -31,10 +31,11 @@ _polybar() {
 	               -v --version
 	               -l --log=
 	               -q --quiet
-	               -c --config=
+                 -c --config=
 	               -r --reload
 	               -d --dump=
 	               -m --list-monitors
+	               -M --list-all-monitors
 	               -w --print-wmname
 	               -s --stdout
 	               -p --png='

--- a/contrib/bash/polybar
+++ b/contrib/bash/polybar
@@ -1,94 +1,94 @@
 _polybar_config_file() {
-	local config_path=${XDG_CONFIG_HOME:-$HOME/.config}/polybar/config
+  local config_path=${XDG_CONFIG_HOME:-$HOME/.config}/polybar/config
 
-	for ((i = 0; i < COMP_CWORD; i++)); do
-		case ${COMP_WORDS[i]} in
-		--config)
-			config_path=${COMP_WORDS[i + 2]}
-			break
-			;;
-		-c)
-			config_path=${COMP_WORDS[i + 1]}
-			break
-			;;
-		esac
-	done
+  for ((i = 0; i < COMP_CWORD; i++)); do
+    case ${COMP_WORDS[i]} in
+    --config)
+      config_path=${COMP_WORDS[i + 2]}
+      break
+      ;;
+    -c)
+      config_path=${COMP_WORDS[i + 1]}
+      break
+      ;;
+    esac
+  done
 
-	# Use eval + cd for to get bash's parameter/tilde expansion etc
-	(eval cd $(dirname "$config_path"); echo $PWD/$(basename "$config_path"))
+  # Use eval + cd for to get bash's parameter/tilde expansion etc
+  (eval cd $(dirname "$config_path"); echo $PWD/$(basename "$config_path"))
 }
 
 _polybar_bars() {
-	local config_file=$(_polybar_config_file)
+  local config_file=$(_polybar_config_file)
 
-	if [ -r "$config_file" ]; then
-		grep -Po '\[bar/\K(.*)(?=\])' "$config_file"
-	fi
+  if [ -r "$config_file" ]; then
+    grep -Po '\[bar/\K(.*)(?=\])' "$config_file"
+  fi
 }
 
 _polybar() {
-	local options='-h --help
-	               -v --version
-	               -l --log=
-	               -q --quiet
+  local options='-h --help
+                 -v --version
+                 -l --log=
+                 -q --quiet
                  -c --config=
-	               -r --reload
-	               -d --dump=
-	               -m --list-monitors
-	               -M --list-all-monitors
-	               -w --print-wmname
-	               -s --stdout
-	               -p --png='
+                 -r --reload
+                 -d --dump=
+                 -m --list-monitors
+                 -M --list-all-monitors
+                 -w --print-wmname
+                 -s --stdout
+                 -p --png='
 
-	local log_levels='error
-	                  warning
-	                  info
-	                  trace'
+  local log_levels='error
+                    warning
+                    info
+                    trace'
 
-	COMPREPLY=()
+  COMPREPLY=()
 
-	local cur=${COMP_WORDS[COMP_CWORD]}
-	case "$cur" in
-	-*)
-		COMPREPLY=( $(compgen -W "$options" -- "$cur") )
-		;;
-	*)
-		local prev=${COMP_WORDS[COMP_CWORD - 1]}
-		if [ "$prev" = "=" ]; then
-			prev=${COMP_WORDS[COMP_CWORD - 2]}
-		fi
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  case "$cur" in
+  -*)
+    COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+    ;;
+  *)
+    local prev=${COMP_WORDS[COMP_CWORD - 1]}
+    if [ "$prev" = "=" ]; then
+      prev=${COMP_WORDS[COMP_CWORD - 2]}
+    fi
 
-		case "$prev" in
-		-l|--log)
-			COMPREPLY=( $(compgen -W "$log_levels" -- "$cur") )
-			return 0
-			;;
-		-c|--config)
-			COMPREPLY=( $(compgen -f "$cur") )
-			return 0
-			;;
-		-p|--png)
-			COMPREPLY=( $(compgen -f -X "!*.png" "$cur") )
-			return 0
-			;;
-		# TODO: read properties of the selected bar from config
-		-d|--dump)
-			return 0
-			;;
-		*)
-			COMPREPLY=( $(compgen -W "$options $(_polybar_bars)" -- "$cur") )
-			;;
-		esac
-	esac
+    case "$prev" in
+    -l|--log)
+      COMPREPLY=( $(compgen -W "$log_levels" -- "$cur") )
+      return 0
+      ;;
+    -c|--config)
+      COMPREPLY=( $(compgen -f "$cur") )
+      return 0
+      ;;
+    -p|--png)
+      COMPREPLY=( $(compgen -f -X "!*.png" "$cur") )
+      return 0
+      ;;
+    # TODO: read properties of the selected bar from config
+    -d|--dump)
+      return 0
+      ;;
+    *)
+      COMPREPLY=( $(compgen -W "$options $(_polybar_bars)" -- "$cur") )
+      ;;
+    esac
+  esac
 
-	for ((i = 0; i < ${#COMPREPLY[@]}; i++)); do
-		case ${COMPREPLY[i]} in
-		--*=) ;;
-		-*) COMPREPLY[i]+=" "
-		esac
-	done
+  for ((i = 0; i < ${#COMPREPLY[@]}; i++)); do
+    case ${COMPREPLY[i]} in
+    --*=) ;;
+    -*) COMPREPLY[i]+=" "
+    esac
+  done
 
-	return 0
+  return 0
 }
 
 complete -o filenames -o noquote -o nospace -F _polybar polybar

--- a/contrib/zsh/_polybar
+++ b/contrib/zsh/_polybar
@@ -22,7 +22,7 @@ _polybar() {
     "($C)"{-c,--config=}'[Path to the configuration file]:configuration file:_files' \
     "($R)"{-r,--reload}'[Reload when the configuration has been modified]' \
     "($D $R $M $W $S)"{-d,--dump=}'[Print parameter value in bar section and exit]:parameter name' \
-    "($MM $M $D $R $W $S)"{-m,--list-monitors}'[Print list of available monitors and exit (Removes cloned monitors)]' \
+    "($MM $M $D $R $W $S)"{-m,--list-monitors}'[Print list of available monitors (Excluding cloned monitors) and exit]' \
     "($MM $M $D $R $W $S)"{-M,--list-all-monitors}'[Print list of all available monitors (Including cloned monitors) and exit]' \
     "($W $R $D $M $S)"{-w,--print-wmname}'[Print the generated WM_NAME and exit]' \
     "($S)"{-s,--stdout}'[Output data to stdout instead of drawing the X window]' \

--- a/contrib/zsh/_polybar
+++ b/contrib/zsh/_polybar
@@ -10,6 +10,7 @@ _polybar() {
   local R='-r --reload'
   local D='-d --dump'
   local M='-m --list-monitors'
+  local MM='-M --list-all-monitors'
   local W='-w --print-wmname'
   local S='-s --stdout'
 
@@ -21,7 +22,8 @@ _polybar() {
     "($C)"{-c,--config=}'[Path to the configuration file]:configuration file:_files' \
     "($R)"{-r,--reload}'[Reload when the configuration has been modified]' \
     "($D $R $M $W $S)"{-d,--dump=}'[Print parameter value in bar section and exit]:parameter name' \
-    "($M $D $R $W $S)"{-m,--list-monitors}'[Print list of available monitors and exit]' \
+    "($MM $M $D $R $W $S)"{-m,--list-monitors}'[Print list of available monitors and exit (Removes cloned monitors)]' \
+    "($MM $M $D $R $W $S)"{-M,--list-all-monitors}'[Print list of all available monitors (Including cloned monitors) and exit]' \
     "($W $R $D $M $S)"{-w,--print-wmname}'[Print the generated WM_NAME and exit]' \
     "($S)"{-s,--stdout}'[Output data to stdout instead of drawing the X window]' \
     '::bar name:_polybar_list_names'

--- a/doc/man/polybar.1.rst
+++ b/doc/man/polybar.1.rst
@@ -45,7 +45,7 @@ OPTIONS
 
    Print list of available monitors and exit
 
-   If some monitors are cloned, this will remove all but one of them
+   If some monitors are cloned, this will exclude all but one of them
 .. option:: -M, --list-all-monitors
 
    Print list of available monitors and exit

--- a/doc/man/polybar.1.rst
+++ b/doc/man/polybar.1.rst
@@ -44,6 +44,13 @@ OPTIONS
 .. option:: -m, --list-monitors
 
    Print list of available monitors and exit
+
+   If some monitors are cloned, this will remove all but one of them
+.. option:: -M, --list-all-monitors
+
+   Print list of available monitors and exit
+
+   This will also include all cloned monitors.
 .. option:: -w, --print-wmname
 
    Print the generated *WM_NAME* and exit

--- a/include/components/screen.hpp
+++ b/include/components/screen.hpp
@@ -47,6 +47,8 @@ class screen : public xpp::event::sink<evt::randr_screen_change_notify> {
   vector<monitor_t> m_monitors;
   struct size m_size {0U, 0U};
   bool m_sigraised{false};
+
+  bool have_monitors_changed() const;
 };
 
 POLYBAR_NS_END

--- a/include/x11/extensions/randr.hpp
+++ b/include/x11/extensions/randr.hpp
@@ -40,6 +40,8 @@ struct randr_output {
 
   bool match(const string& o, bool exact = true) const;
   bool match(const position& p) const;
+
+  bool contains(const randr_output& output) const;
 };
 
 using monitor_t = shared_ptr<randr_output>;

--- a/include/x11/extensions/randr.hpp
+++ b/include/x11/extensions/randr.hpp
@@ -42,6 +42,8 @@ struct randr_output {
   bool match(const position& p) const;
 
   bool contains(const randr_output& output) const;
+
+  bool equals(const randr_output& output) const;
 };
 
 using monitor_t = shared_ptr<randr_output>;

--- a/include/x11/extensions/randr.hpp
+++ b/include/x11/extensions/randr.hpp
@@ -51,7 +51,7 @@ namespace randr_util {
 
   monitor_t make_monitor(xcb_randr_output_t randr, string name, unsigned short int w, unsigned short int h, short int x, short int y,
       bool primary);
-  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only = false);
+  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only = false, bool purge_clones = true);
   monitor_t match_monitor(vector<monitor_t> monitors, const string& name, bool exact_match);
 
   void get_backlight_range(connection& conn, const monitor_t& mon, backlight_values& dst);

--- a/include/x11/extensions/randr.hpp
+++ b/include/x11/extensions/randr.hpp
@@ -51,7 +51,7 @@ namespace randr_util {
 
   monitor_t make_monitor(xcb_randr_output_t randr, string name, unsigned short int w, unsigned short int h, short int x, short int y,
       bool primary);
-  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only = false, bool realloc = false);
+  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only = false);
   monitor_t match_monitor(vector<monitor_t> monitors, const string& name, bool exact_match);
 
   void get_backlight_range(connection& conn, const monitor_t& mon, backlight_values& dst);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -74,7 +74,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   auto monitor_name_fallback = m_conf.get(bs, "monitor-fallback", ""s);
   m_opts.monitor_strict = m_conf.get(bs, "monitor-strict", m_opts.monitor_strict);
   m_opts.monitor_exact = m_conf.get(bs, "monitor-exact", m_opts.monitor_exact);
-  auto monitors = randr_util::get_monitors(m_connection, m_connection.screen()->root, m_opts.monitor_strict);
+  auto monitors = randr_util::get_monitors(m_connection, m_connection.screen()->root, m_opts.monitor_strict, false);
 
   if (monitors.empty()) {
     throw application_error("No monitors found");
@@ -92,7 +92,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   // if still not found (and not strict matching), get first connected monitor
   if (monitor_name.empty() && !m_opts.monitor_strict) {
-    auto connected_monitors = randr_util::get_monitors(m_connection, m_connection.screen()->root, true);
+    auto connected_monitors = randr_util::get_monitors(m_connection, m_connection.screen()->root, true, false);
     if (!connected_monitors.empty()) {
       monitor_name = connected_monitors[0]->name;
       m_log.warn("No monitor specified, using \"%s\"", monitor_name);

--- a/src/components/screen.cpp
+++ b/src/components/screen.cpp
@@ -1,4 +1,5 @@
 #include <csignal>
+#include <algorithm>
 #include <thread>
 
 #include "components/config.hpp"
@@ -33,7 +34,7 @@ screen::screen(connection& conn, signal_emitter& emitter, const logger& logger, 
     , m_log(logger)
     , m_conf(conf)
     , m_root(conn.root())
-    , m_monitors(randr_util::get_monitors(m_connection, m_root, true))
+    , m_monitors(randr_util::get_monitors(m_connection, m_root, true, false))
     , m_size({conn.screen()->width_in_pixels, conn.screen()->height_in_pixels}) {
   // Check if the reloading has been disabled by the user
   if (!m_conf.get("settings", "screenchange-reload", false)) {
@@ -88,7 +89,7 @@ screen::~screen() {
 /**
  * Handle XCB_RANDR_SCREEN_CHANGE_NOTIFY events
  *
- * If the screen dimensions have changed we raise USR1 to trigger a reload
+ * If any of the monitors have changed we raise USR1 to trigger a reload
  */
 void screen::handle(const evt::randr_screen_change_notify& evt) {
   if (m_sigraised || evt->request_window != m_proxy) {
@@ -98,24 +99,49 @@ void screen::handle(const evt::randr_screen_change_notify& evt) {
   auto screen = m_connection.screen(true);
   auto changed = false;
 
+  // We need to reload if the screen size changed as well
   if (screen->width_in_pixels != m_size.w || screen->height_in_pixels != m_size.h) {
     changed = true;
   } else {
-    auto monitors = randr_util::get_monitors(m_connection, m_root, true, false);
-    for (size_t n = 0; n < monitors.size(); n++) {
-      if (n < m_monitors.size() && monitors[n]->output != m_monitors[n]->output) {
-        changed = true;
-      }
+    changed = have_monitors_changed();
+  }
+
+  if (changed) {
+    m_log.warn("randr_screen_change_notify (%ux%u)... reloading", evt->width, evt->height);
+    m_sig.emit(exit_reload{});
+    m_sigraised = true;
+  }
+}
+
+/**
+ * Checks if the stored monitor list is different from a newly fetched one
+ *
+ * Fetches the monitor list and compares it with the one stored
+ */
+bool screen::have_monitors_changed() const {
+  auto monitors = randr_util::get_monitors(m_connection, m_root, true, false);
+
+  if(monitors.size() != m_monitors.size()) {
+    return true;
+  }
+
+  for (auto m : m_monitors) {
+    auto it = std::find_if(monitors.begin(), monitors.end(),
+        [m] (auto& monitor) -> bool {
+        return m->equals(*monitor);
+        });
+
+    /*
+     * Every monitor in the stored list should also exist in the newly fetched
+     * list. If this holds then the two lists are equivalent since they have
+     * the same size
+     */
+    if(it == monitors.end()) {
+      return true;
     }
   }
 
-  if (!changed) {
-    return;
-  }
-
-  m_log.warn("randr_screen_change_notify (%ux%u)... reloading", evt->width, evt->height);
-  m_sig.emit(exit_reload{});
-  m_sigraised = true;
+  return false;
 }
 
 POLYBAR_NS_END

--- a/src/components/screen.cpp
+++ b/src/components/screen.cpp
@@ -101,7 +101,7 @@ void screen::handle(const evt::randr_screen_change_notify& evt) {
   if (screen->width_in_pixels != m_size.w || screen->height_in_pixels != m_size.h) {
     changed = true;
   } else {
-    auto monitors = randr_util::get_monitors(m_connection, m_root, true, true);
+    auto monitors = randr_util::get_monitors(m_connection, m_root, true);
     for (size_t n = 0; n < monitors.size(); n++) {
       if (n < m_monitors.size() && monitors[n]->output != m_monitors[n]->output) {
         changed = true;

--- a/src/components/screen.cpp
+++ b/src/components/screen.cpp
@@ -101,7 +101,7 @@ void screen::handle(const evt::randr_screen_change_notify& evt) {
   if (screen->width_in_pixels != m_size.w || screen->height_in_pixels != m_size.h) {
     changed = true;
   } else {
-    auto monitors = randr_util::get_monitors(m_connection, m_root, true);
+    auto monitors = randr_util::get_monitors(m_connection, m_root, true, false);
     for (size_t n = 0; n < monitors.size(); n++) {
       if (n < m_monitors.size() && monitors[n]->output != m_monitors[n]->output) {
         changed = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,8 @@ int main(int argc, char** argv) {
       command_line::option{"-c", "--config", "Path to the configuration file", "FILE"},
       command_line::option{"-r", "--reload", "Reload when the configuration has been modified"},
       command_line::option{"-d", "--dump", "Print value of PARAM in bar section and exit", "PARAM"},
-      command_line::option{"-m", "--list-monitors", "Print list of available monitors and exit"},
+      command_line::option{"-m", "--list-monitors", "Print list of available monitors and exit (Removes cloned monitors)"},
+      command_line::option{"-M", "--list-all-monitors", "Print list of all available monitors (Including cloned monitors) and exit"},
       command_line::option{"-w", "--print-wmname", "Print the generated WM_NAME and exit"},
       command_line::option{"-s", "--stdout", "Output data to stdout instead of drawing it to the X window"},
       command_line::option{"-p", "--png", "Save png snapshot to FILE after running for 3 seconds", "FILE"},
@@ -75,8 +76,10 @@ int main(int argc, char** argv) {
     //==================================================
     // List available XRandR entries
     //==================================================
-    if (cli->has("list-monitors")) {
-      for (auto&& mon : randr_util::get_monitors(conn, conn.root(), true)) {
+    if (cli->has("list-monitors") || cli->has("list-all-monitors")) {
+      bool purge_clones = !cli->has("list-all-monitors");
+      auto monitors = randr_util::get_monitors(conn, conn.root(), true, purge_clones);
+      for (auto&& mon : monitors) {
         if (WITH_XRANDR_MONITORS && mon->output == XCB_NONE) {
           printf("%s: %ix%i+%i+%i (XRandR monitor%s)\n", mon->name.c_str(), mon->w, mon->h, mon->x, mon->y,
               mon->primary ? ", primary" : "");

--- a/src/modules/xbacklight.cpp
+++ b/src/modules/xbacklight.cpp
@@ -20,7 +20,7 @@ namespace modules {
       : static_module<xbacklight_module>(bar, move(name_)), m_connection(connection::make()) {
     auto output = m_conf.get(name(), "output", m_bar.monitor->name);
 
-    auto monitors = randr_util::get_monitors(m_connection, m_connection.root(), bar.monitor_strict);
+    auto monitors = randr_util::get_monitors(m_connection, m_connection.root(), bar.monitor_strict, false);
 
     m_output = randr_util::match_monitor(monitors, output, bar.monitor_exact);
 

--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -33,7 +33,7 @@ bool randr_output::match(const position& p) const {
 }
 
 /**
- * Checks if inner is contained withing this.
+ * Checks if inner is contained within `this`
  *
  * Also returns true for outputs that occupy the exact same space
  */

--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -80,7 +80,7 @@ namespace randr_util {
   /**
    * Create a list of all available randr outputs
    */
-  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only) {
+  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only, bool purge_clones) {
     vector<monitor_t> monitors;
 
 #if WITH_XRANDR_MONITORS
@@ -148,6 +148,11 @@ namespace randr_util {
       }
 
       // Test if there are any clones in the set
+
+      if (!purge_clones) {
+        continue;
+      }
+
       for (auto& monitor : monitors) {
         if ((*m) == monitor || monitor->w == 0) {
           continue;

--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -42,6 +42,16 @@ bool randr_output::contains(const randr_output& inner) const {
     && inner.y >= y && inner.y + inner.h <= y + h;
 }
 
+/**
+ * Checks if the given output is the same as this
+ *
+ * Looks at xcb_randr_output_t, position, dimension, name and 'primary'
+ */
+bool randr_output::equals(const randr_output& o) const {
+  return o.output == output && o.x == x && o.y == y && o.w == w && o.h == h &&
+    o.primary == primary && o.name == name;
+}
+
 namespace randr_util {
   /**
    * XRandR version

--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -80,14 +80,8 @@ namespace randr_util {
   /**
    * Create a list of all available randr outputs
    */
-  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only, bool realloc) {
-    static vector<monitor_t> monitors;
-
-    if (realloc) {
-      monitors.clear();
-    } else if (!monitors.empty()) {
-      return monitors;
-    }
+  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only) {
+    vector<monitor_t> monitors;
 
 #if WITH_XRANDR_MONITORS
     if (check_monitor_support()) {

--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -176,16 +176,6 @@ namespace randr_util {
           monitors.end());
     }
 
-    sort(monitors.begin(), monitors.end(), [](monitor_t& m1, monitor_t& m2) -> bool {
-      if (m1->x < m2->x || m1->y + m1->h <= m2->y) {
-        return true;
-      }
-      if (m1->x > m2->x || m1->y + m1->h > m2->y) {
-        return -1;
-      }
-      return false;
-    });
-
     return monitors;
   }
 


### PR DESCRIPTION
When a monitor is connected which is automatically mirrored polybar can crash when the monitor name it is currently running gets removed in `get_monitors` (see #1191).

This also adds a new commandline argument `-M --list-all-monitors` that also lists cloned monitors. I couldn't change the behavior of `-m` since some people rely on `polybar -m` to display polybar on all monitors.

~I have not tested this yet but I will once I get some time at home.~

This also fixes the bugged clone removal code.

Fixes #1191
Fixes #1794