### PR TITLE
feat(github): offline label & fixes

### DIFF
--- a/include/modules/github.hpp
+++ b/include/modules/github.hpp
@@ -16,18 +16,24 @@ namespace modules {
 
     bool update();
     bool build(builder* builder, const string& tag) const;
+    string get_format() const;
+
 
    private:
     void update_label(int);
     int get_number_of_notification();
     string request();
     static constexpr auto TAG_LABEL = "<label>";
+    static constexpr auto TAG_LABEL_OFFLINE = "<label-offline>";
+    static constexpr auto FORMAT_OFFLINE = "format-offline";
 
     label_t m_label{};
+    label_t m_label_offline{};
     string m_api_url;
     string m_accesstoken{};
     unique_ptr<http_downloader> m_http{};
     bool m_empty_notifications{false};
+    std::atomic<bool> m_offline{false};
   };
 }
 

--- a/src/modules/github.cpp
+++ b/src/modules/github.cpp
@@ -98,9 +98,16 @@ namespace modules {
   }
 
   void github_module::update_label(const int notifications) {
-    if ((0 != notifications || m_empty_notifications) && m_label) {
+    if (!m_label) {
+      return;
+    }
+
+    if (0 != notifications || m_empty_notifications) {
       m_label->reset_tokens();
       m_label->replace_token("%notifications%", to_string(notifications));
+    }
+    else {
+      m_label->clear();
     }
   }
 

--- a/src/modules/github.cpp
+++ b/src/modules/github.cpp
@@ -105,8 +105,7 @@ namespace modules {
     if (0 != notifications || m_empty_notifications) {
       m_label->reset_tokens();
       m_label->replace_token("%notifications%", to_string(notifications));
-    }
-    else {
+    } else {
       m_label->clear();
     }
   }


### PR DESCRIPTION
Fixes #1815.

Should resolve the segfault issue with #910. The defaults are such that if offline the module displays `Offline` instead of the current `Notifications: -1`. Notifications are still set to -1 and a flag is set to indicate online/offline status which causes `format-offline` to be used when offline.

I haven't tested exhaustively but everything seemed to be working with a couple different configs on my machine.

MAINTAINER EDIT:
Closes #910