### PR TITLE
fix(config): Allow empty string as ref fallback

### DIFF
--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -281,7 +281,7 @@ class config {
     }
 
     if (env_util::has(var)) {
-      string env_value{env_util::get(var.c_str())};
+      string env_value{env_util::get(var)};
       m_log.info("Environment var reference ${%s} found (value=%s)", var, env_value);
       return convert<T>(move(env_value));
     } else if (has_default) {

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -280,7 +280,7 @@ class config {
       var.erase(pos);
     }
 
-    if (env_util::has(var.c_str())) {
+    if (env_util::has(var)) {
       string env_value{env_util::get(var.c_str())};
       m_log.info("Environment var reference ${%s} found (value=%s)", var, env_value);
       return convert<T>(move(env_value));


### PR DESCRIPTION
There is also a lot of refactoring that could be done here but since we are rewriting parts of the config parser already we'll do it there.