### PR TITLE
feat(github): add support for github enterprise

### DIFF
--- a/include/modules/github.hpp
+++ b/include/modules/github.hpp
@@ -18,7 +18,7 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    private:
-    void update_label(const int);
+    void update_label(int);
     int get_number_of_notification();
     string request();
     static constexpr auto TAG_LABEL = "<label>";

--- a/include/modules/github.hpp
+++ b/include/modules/github.hpp
@@ -24,6 +24,7 @@ namespace modules {
     static constexpr auto TAG_LABEL = "<label>";
 
     label_t m_label{};
+    string m_api_url;
     string m_accesstoken{};
     unique_ptr<http_downloader> m_http{};
     bool m_empty_notifications{false};

--- a/src/modules/github.cpp
+++ b/src/modules/github.cpp
@@ -16,8 +16,6 @@ namespace modules {
    */
   github_module::github_module(const bar_settings& bar, string name_)
       : timer_module<github_module>(bar, move(name_)), m_http(http_util::make_downloader()) {
-    using namespace std::string_literals;
-
     m_accesstoken = m_conf.get(name(), "token");
     m_api_url = m_conf.get(name(), "api-url", "https://api.github.com/"s);
     if (m_api_url.back() != '/') {

--- a/src/modules/github.cpp
+++ b/src/modules/github.cpp
@@ -16,7 +16,14 @@ namespace modules {
    */
   github_module::github_module(const bar_settings& bar, string name_)
       : timer_module<github_module>(bar, move(name_)), m_http(http_util::make_downloader()) {
+    using namespace std::string_literals;
+
     m_accesstoken = m_conf.get(name(), "token");
+    m_api_url = m_conf.get(name(), "api-url", "https://api.github.com/"s);
+    if (m_api_url.back() != '/') {
+      m_api_url += '/';
+    }
+
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 60s);
     m_empty_notifications = m_conf.get(name(), "empty-notifications", m_empty_notifications);
 
@@ -41,7 +48,7 @@ namespace modules {
   }
 
   string github_module::request() {
-    string content{m_http->get("https://api.github.com/notifications?access_token=" + m_accesstoken)};
+    string content{m_http->get(m_api_url + "notifications?access_token=" + m_accesstoken)};
 
     long response_code{m_http->response_code()};
     switch (response_code) {


### PR DESCRIPTION
Add support for github enterprise with a new key `api-url`.

This feature needs to be checked properly since I don't have access to the github of an entreprise.
I just checked that it works correctly with `github.com`.

Closes #1812.