### PR TITLE
fix(modules): Only add reset tag on non-empty modules

### DIFF
--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -82,9 +82,11 @@ namespace modules {
       m_cache = CAST_MOD(Impl)->get_output();
       // Make sure builder is really empty
       m_builder->flush();
-      // Add a reset tag after the module
-      m_builder->control(controltag::R);
-      m_cache += m_builder->flush();
+      if (!m_cache.empty()) {
+        // Add a reset tag after the module
+        m_builder->control(controltag::R);
+        m_cache += m_builder->flush();
+      }
       m_changed = false;
     }
     return m_cache;


### PR DESCRIPTION
Adding the reset tag to empty modules makes polybar add margins and
separators for that empty module.

Fixes #1857

Ref #1596