### PR TITLE
i3: Add possibility to sort workspaces by name

### DIFF
--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -88,6 +88,7 @@ namespace modules {
     bool m_revscroll{true};
     bool m_wrap{true};
     bool m_indexsort{false};
+    bool m_namesort{false};
     bool m_pinworkspaces{false};
     bool m_strip_wsnumbers{false};
     bool m_fuzzy_match{false};

--- a/include/utils/i3.hpp
+++ b/include/utils/i3.hpp
@@ -14,6 +14,7 @@ namespace i3_util {
   using workspace_t = i3ipc::workspace_t;
 
   const auto ws_numsort = [](shared_ptr<workspace_t> a, shared_ptr<workspace_t> b) { return a->num < b->num; };
+  const auto ws_namesort = [](shared_ptr<workspace_t> a, shared_ptr<workspace_t> b) { return a->name < b->name; };
 
   vector<shared_ptr<workspace_t>> workspaces(const connection_t& conn, const string& output = "");
   shared_ptr<workspace_t> focused_workspace(const connection_t&);

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -28,6 +28,7 @@ namespace modules {
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
     m_wrap = m_conf.get(name(), "wrapping-scroll", m_wrap);
     m_indexsort = m_conf.get(name(), "index-sort", m_indexsort);
+    m_namesort = m_conf.get(name(), "name-sort", m_namesort);
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
     m_strip_wsnumbers = m_conf.get(name(), "strip-wsnumbers", m_strip_wsnumbers);
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
@@ -135,6 +136,8 @@ namespace modules {
 
       if (m_indexsort) {
         sort(workspaces.begin(), workspaces.end(), i3_util::ws_numsort);
+      } else if (m_namesort) {
+        sort(workspaces.begin(), workspaces.end(), i3_util::ws_namesort);
       }
 
       for (auto&& ws : workspaces) {


### PR DESCRIPTION
In i3 it is possible to assign workspaces with arbitrary names without
assigning it a specific index. Polybar however, is only able to sort the
workspaces by index, leaving named workspaces in seemingly random order
received from i3.

Make it possible to configure sorting on workspace names by adding an
option ("name-sort") for the i3 module.