### PR TITLE
Check for OpenBSD and set -Wno-c99-extensions

### DIFF
--- a/cmake/01-core.cmake
+++ b/cmake/01-core.cmake
@@ -32,6 +32,11 @@ if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/lib")
 endif()
 
+if (CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+  # libinotify uses c99 extension, so suppress this error
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c99-extensions")
+endif()
+
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=parentheses-equality")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-zero-length-array")


### PR DESCRIPTION
Please find below a patch to get polybar building on OpenBSD.

The basics work fine, though many modules lack support for OpenBSD (e.g. due to absence of `/proc`) but I'll have a look at addressing this in due time.