### PR TITLE
Add Code Triage-Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A fast and easy-to-use tool for creating status bars.
 <a href="https://polybar.readthedocs.io"><img src="https://readthedocs.org/projects/polybar/badge/?version=latest"></a>
 <a href="https://codecov.io/gh/polybar/polybar/branch/master"><img src="https://codecov.io/gh/polybar/polybar/branch/master/graph/badge.svg"></a>
 <a href="https://github.com/polybar/polybar/blob/master/LICENSE"><img src="https://img.shields.io/github/license/polybar/polybar.svg"></a>
+<a href="https://www.codetriage.com/polybar/polybar"><img src="https://www.codetriage.com/polybar/polybar/badges/users.svg"></a>
 </p>
 
 **Polybar** aims to help users build beautiful and highly customizable status bars


### PR DESCRIPTION
I added the repo to code triage to get regular mails about open issues of polybar. Since I cannot program C++ well, I can maybe help better by reviewing issues. Maybe other people can and want to do the same. After all, polybar has many users who know about its configuration and such.

If you choose to decline this PR, I just get mails. If you choose to accept it, maybe some people are attracted to help out with the triage part of issues. At the very least, it is another nice-looking badge on the README and I heard that is the latest craze among the kids these days. :smile: 