### PR TITLE
fix(file): Don't add slash to relative path

### DIFF
--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -238,6 +238,12 @@ namespace file_util {
    */
   const string expand(const string& path) {
     string ret;
+    /*
+     * This doesn't capture all cases for absolute paths but the other cases
+     * (tilde and env variable) have the initial '/' character in their
+     * expansion already and will thus not require adding '/' to the beginning.
+     */
+    bool is_absolute = path.size() > 0 && path.at(0) == '/';
     vector<string> p_exploded = string_util::split(path, '/');
     for (auto& section : p_exploded) {
       switch(section[0]) {
@@ -250,8 +256,10 @@ namespace file_util {
       }
     }
     ret = string_util::join(p_exploded, "/");
-    if (ret[0] != '/')
+    // Don't add an initial slash for relative paths
+    if (ret[0] != '/' && is_absolute) {
       ret.insert(0, 1, '/');
+    }
     return ret;
   }
 }


### PR DESCRIPTION
This fixes a regression introduced in
56e24992dfe2fba32b1f6b07fc37ab7d0a7c6aba where relative config file
paths weren't recognized because file_util::expand just added a slash
to the beginning.

That is calling `polybar -c config example` would try to load the config
file at `/config` instead of using the relative path as before.

In all other cases where expand is used this change shouldn't matter
because polybar only accepts absolute paths everyhwere else.
Theoretically this would now allow relative paths (relative to the cwd
where polybar was called) but this shouldn't used (or documented)
because that behavior will change when merging #1523 which would make
paths relative to the polybar config.

Ref #1523
Ref 56e24992dfe2fba32b1f6b07fc37ab7d0a7c6aba