### PR TITLE
feat(pulse): Show volume in decibels

### DIFF
--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -38,6 +38,7 @@ class pulseaudio {
     int process_events();
 
     int get_volume();
+    double get_decibels();
     void set_volume(float percentage);
     void inc_volume(int delta_perc);
     void set_mute(bool mode);

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -50,6 +50,7 @@ namespace modules {
     int m_interval{5};
     atomic<bool> m_muted{false};
     atomic<int> m_volume{0};
+    atomic<double> m_decibels{0};
   };
 }
 

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -155,6 +155,13 @@ int pulseaudio::get_volume() {
 }
 
 /**
+ * Get volume in decibels
+ */
+double pulseaudio::get_decibels() {
+  return pa_sw_volume_to_dB(pa_cvolume_max(&cv));
+}
+
+/**
  * Set volume to given percentage
  */
 void pulseaudio::set_volume(float percentage) {

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -66,11 +66,13 @@ namespace modules {
 
     // Get volume and mute state
     m_volume = 100;
+    m_decibels = PA_DECIBEL_MININFTY;
     m_muted = false;
 
     try {
       if (m_pulseaudio) {
         m_volume = m_volume * m_pulseaudio->get_volume() / 100.0f;
+        m_decibels = m_pulseaudio->get_decibels();
         m_muted = m_muted || m_pulseaudio->is_muted();
       }
     } catch (const pulseaudio_error& err) {
@@ -81,11 +83,13 @@ namespace modules {
     if (m_label_volume) {
       m_label_volume->reset_tokens();
       m_label_volume->replace_token("%percentage%", to_string(m_volume));
+      m_label_volume->replace_token("%decibels%", string_util::floating_point(m_decibels, 2, true));
     }
 
     if (m_label_muted) {
       m_label_muted->reset_tokens();
       m_label_muted->replace_token("%percentage%", to_string(m_volume));
+      m_label_muted->replace_token("%decibels%", string_util::floating_point(m_decibels, 2, true));
     }
 
     return true;


### PR DESCRIPTION
Add ` %decibels%` token in pulseaudio module.
Implements #1886.

Tested on two archlinux devices and everything seems fine.