### PR TITLE
Warning style on temperature should be inclusive

### DIFF
--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -84,7 +84,7 @@ namespace modules {
   }
 
   string temperature_module::get_format() const {
-    if (m_temp > m_tempwarn) {
+    if (m_temp >= m_tempwarn) {
       return FORMAT_WARN;
     } else {
       return DEFAULT_FORMAT;


### PR DESCRIPTION
Given `warn-temperature = 75`, The style should be changed to the warning variant _at_ `75` rather than _after_.