### PR TITLE
fix(bar): Configure position before remapping

### DIFF
--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -74,6 +74,8 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
 
  protected:
   void restack_window();
+  void reconfigue_window();
+  void reconfigure_geom();
   void reconfigure_pos();
   void reconfigure_struts();
   void reconfigure_wm_hints();


### PR DESCRIPTION
Some WMs like i3 discard position information when unmapping the bar and
because of that the bar would be at the wrong position after being
remapped.

Fixes #1484
Ref: https://github.com/i3/i3/pull/3834