### PR TITLE
build: drop python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If you are using **Gentoo**, both release and git-master versions are available 
 A compiler with C++14 support ([clang-3.4+](http://llvm.org/releases/download.html), [gcc-5.1+](https://gcc.gnu.org/releases.html)), [cmake 3.1+](https://cmake.org/download/), [git](https://git-scm.com/downloads)
 - `cairo`
 - `libxcb`
-- `python2`
+- `python`
 - `xcb-proto`
 - `xcb-util-image`
 - `xcb-util-wm`

--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -14,8 +14,7 @@ optdepends=("i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "xorg-fonts-misc: Font used in example config")
-makedepends=("cmake" "git" "python" "python2" "pkg-config" "python-sphinx"
-             "i3-wm")
+makedepends=("cmake" "git" "python" "pkg-config" "python-sphinx" "i3-wm")
 provides=("polybar")
 conflicts=("polybar")
 install="${_pkgname}.install"


### PR DESCRIPTION
Ref: https://github.com/polybar/xpp/pull/17
Fixes #1892

**Release notes:** All mentions of python2 can be removed from the wiki.
The `polybar` `PKGBUILD` can be updated.