### PR TITLE
bar: Make module separator a label

### DIFF
--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -10,10 +10,6 @@ POLYBAR_NS
 using std::map;
 
 // fwd decl
-namespace drawtypes {
-  class label;
-  using label_t = shared_ptr<label>;
-}  // namespace drawtypes
 using namespace drawtypes;
 
 class builder {

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -12,6 +12,12 @@ POLYBAR_NS
 // fwd {{{
 struct randr_output;
 using monitor_t = shared_ptr<randr_output>;
+
+namespace drawtypes {
+  class label;
+}
+
+using label_t = shared_ptr<drawtypes::label>;
 // }}}
 
 struct enum_hash {
@@ -159,7 +165,7 @@ struct bar_settings {
 
   struct radius radius {};
   int spacing{0};
-  string separator{};
+  label_t separator{};
 
   string wmname{};
   string locale{};

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -18,9 +18,6 @@ namespace drawtypes {
     bool zpad{false};
   };
 
-  class label;
-  using label_t = shared_ptr<label>;
-
   class label : public non_copyable_mixin<label> {
    public:
     string m_foreground{};

--- a/include/drawtypes/progressbar.hpp
+++ b/include/drawtypes/progressbar.hpp
@@ -9,10 +9,6 @@
 POLYBAR_NS
 
 namespace drawtypes {
-  // fwd
-  class label;
-  using label_t = shared_ptr<label>;
-
   class progressbar : public non_copyable_mixin<progressbar> {
    public:
     explicit progressbar(const bar_settings& bar, int width, string format);

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -29,8 +29,6 @@ using std::map;
 // fwd decl {{{
 
 namespace drawtypes {
-  class label;
-  using label_t = shared_ptr<label>;
   class ramp;
   using ramp_t = shared_ptr<ramp>;
   class progressbar;

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -7,6 +7,7 @@
 #include "components/screen.hpp"
 #include "components/taskqueue.hpp"
 #include "components/types.hpp"
+#include "drawtypes/label.hpp"
 #include "events/signal.hpp"
 #include "events/signal_emitter.hpp"
 #include "utils/bspwm.hpp"
@@ -155,7 +156,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   // Load configuration values
   m_opts.origin = m_conf.get(bs, "bottom", false) ? edge::BOTTOM : edge::TOP;
   m_opts.spacing = m_conf.get(bs, "spacing", m_opts.spacing);
-  m_opts.separator = m_conf.get(bs, "separator", ""s);
+  m_opts.separator = drawtypes::load_optional_label(m_conf, bs, "separator", "");
   m_opts.locale = m_conf.get(bs, "locale", ""s);
 
   auto radius = m_conf.get<double>(bs, "radius", 0.0);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -1,6 +1,7 @@
+#include "components/bar.hpp"
+
 #include <algorithm>
 
-#include "components/bar.hpp"
 #include "components/config.hpp"
 #include "components/parser.hpp"
 #include "components/renderer.hpp"
@@ -110,7 +111,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.monitor = randr_util::match_monitor(monitors, monitor_name, m_opts.monitor_exact);
   monitor_t fallback{};
 
-  if(!monitor_name_fallback.empty()) {
+  if (!monitor_name_fallback.empty()) {
     fallback = randr_util::match_monitor(monitors, monitor_name_fallback, m_opts.monitor_exact);
   }
 
@@ -259,7 +260,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   auto offsety = m_conf.get(m_conf.section(), "offset-y", ""s);
 
   m_opts.size.w = geom_format_to_pixels(w, m_opts.monitor->w);
-  m_opts.size.h = geom_format_to_pixels(h, m_opts.monitor->h);;
+  m_opts.size.h = geom_format_to_pixels(h, m_opts.monitor->h);
   m_opts.offset.x = geom_format_to_pixels(offsetx, m_opts.monitor->w);
   m_opts.offset.y = geom_format_to_pixels(offsety, m_opts.monitor->h);
 
@@ -279,10 +280,9 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
     throw application_error("Resulting bar height is out of bounds (" + to_string(m_opts.size.h) + ")");
   }
 
-  m_log.info("Bar geometry: %ix%i+%i+%i; Borders: %d,%d,%d,%d", m_opts.size.w,
-      m_opts.size.h, m_opts.pos.x, m_opts.pos.y,
-      m_opts.borders[edge::TOP].size, m_opts.borders[edge::RIGHT].size,
-      m_opts.borders[edge::BOTTOM].size, m_opts.borders[edge::LEFT].size);
+  m_log.info("Bar geometry: %ix%i+%i+%i; Borders: %d,%d,%d,%d", m_opts.size.w, m_opts.size.h, m_opts.pos.x,
+      m_opts.pos.y, m_opts.borders[edge::TOP].size, m_opts.borders[edge::RIGHT].size, m_opts.borders[edge::BOTTOM].size,
+      m_opts.borders[edge::LEFT].size);
 
   m_log.trace("bar: Attach X event sink");
   m_connection.attach_sink(this, SINK_PRIORITY_BAR);
@@ -633,18 +633,22 @@ void bar::handle(const evt::motion_notify& evt) {
   m_log.trace("bar: Detected motion: %i at pos(%i, %i)", evt->detail, evt->event_x, evt->event_y);
 #if WITH_XCURSOR
   m_motion_pos = evt->event_x;
-  // scroll cursor is less important than click cursor, so we shouldn't return until we are sure there is no click action
+  // scroll cursor is less important than click cursor, so we shouldn't return until we are sure there is no click
+  // action
   bool found_scroll = false;
   const auto find_click_area = [&](const action& action) {
-    if (!m_opts.cursor_click.empty() && !(action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN || action.button == mousebtn::NONE)) {
+    if (!m_opts.cursor_click.empty() &&
+        !(action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN ||
+            action.button == mousebtn::NONE)) {
       if (!string_util::compare(m_opts.cursor, m_opts.cursor_click)) {
         m_opts.cursor = m_opts.cursor_click;
         m_sig.emit(cursor_change{string{m_opts.cursor}});
       }
       return true;
-    } else if (!m_opts.cursor_scroll.empty() && (action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN)) {
+    } else if (!m_opts.cursor_scroll.empty() &&
+               (action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN)) {
       if (!found_scroll) {
-          found_scroll = true;
+        found_scroll = true;
       }
     }
     return false;
@@ -653,11 +657,11 @@ void bar::handle(const evt::motion_notify& evt) {
   for (auto&& action : m_renderer->actions()) {
     if (action.test(m_motion_pos)) {
       m_log.trace("Found matching input area");
-      if(find_click_area(action))
+      if (find_click_area(action))
         return;
     }
   }
-  if(found_scroll) {
+  if (found_scroll) {
     if (!string_util::compare(m_opts.cursor, m_opts.cursor_scroll)) {
       m_opts.cursor = m_opts.cursor_scroll;
       m_sig.emit(cursor_change{string{m_opts.cursor}});
@@ -667,11 +671,11 @@ void bar::handle(const evt::motion_notify& evt) {
   for (auto&& action : m_opts.actions) {
     if (!action.command.empty()) {
       m_log.trace("Found matching fallback handler");
-      if(find_click_area(action))
+      if (find_click_area(action))
         return;
     }
   }
-  if(found_scroll) {
+  if (found_scroll) {
     if (!string_util::compare(m_opts.cursor, m_opts.cursor_scroll)) {
       m_opts.cursor = m_opts.cursor_scroll;
       m_sig.emit(cursor_change{string{m_opts.cursor}});
@@ -812,7 +816,7 @@ bool bar::on(const signals::eventqueue::start&) {
   if (m_opts.dimvalue != 1.0) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
-  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() ) {
+  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty()) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
   }
   m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_STRUCTURE_NOTIFY);
@@ -856,7 +860,8 @@ bool bar::on(const signals::ui::unshade_window&) {
   double steptime{25.0 / 2.0};
   m_anim_step = distance / steptime / 2.0;
 
-  m_taskqueue->defer_unique("window-shade", 25ms,
+  m_taskqueue->defer_unique(
+      "window-shade", 25ms,
       [&](size_t remaining) {
         if (!m_opts.shaded) {
           m_sig.emit(signals::ui::tick{});
@@ -895,7 +900,8 @@ bool bar::on(const signals::ui::shade_window&) {
   double steptime{25.0 / 2.0};
   m_anim_step = distance / steptime / 2.0;
 
-  m_taskqueue->defer_unique("window-shade", 25ms,
+  m_taskqueue->defer_unique(
+      "window-shade", 25ms,
       [&](size_t remaining) {
         if (m_opts.shaded) {
           m_sig.emit(signals::ui::tick{});
@@ -955,7 +961,7 @@ bool bar::on(const signals::ui::dim_window& sig) {
 
 #if WITH_XCURSOR
 bool bar::on(const signals::ui::cursor_change& sig) {
-  if(!cursor_util::set_cursor(m_connection, m_connection.screen(), m_opts.window, sig.cast())) {
+  if (!cursor_util::set_cursor(m_connection, m_connection.screen(), m_opts.window, sig.cast())) {
     m_log.warn("Failed to create cursor context");
   }
   m_connection.flush();

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -3,6 +3,7 @@
 #include <csignal>
 
 #include "components/bar.hpp"
+#include "components/builder.hpp"
 #include "components/config.hpp"
 #include "components/ipc.hpp"
 #include "components/logger.hpp"
@@ -447,11 +448,14 @@ void controller::process_inputdata() {
 bool controller::process_update(bool force) {
   const bar_settings& bar{m_bar->settings()};
   string contents;
-  string separator{bar.separator};
   string padding_left(bar.padding.left, ' ');
   string padding_right(bar.padding.right, ' ');
   string margin_left(bar.module_margin.left, ' ');
   string margin_right(bar.module_margin.right, ' ');
+
+  builder build{bar};
+  build.node(bar.separator);
+  string separator{build.flush()};
 
   for (const auto& block : m_blocks) {
     string block_contents;


### PR DESCRIPTION
Some people use text modules instead of the `separator` key in the bar
section to better configure the separator (colors, fonts). Since we
disallowed the same module being used multiple times in #1534, this will
now print an error message.

This should help with this a bit.

Ref #1913