### PR TITLE
feat: Add option to not enforce unique module names

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -39,7 +39,7 @@ namespace drawtypes {
   using animation_t = shared_ptr<animation>;
   class iconset;
   using iconset_t = shared_ptr<iconset>;
-}
+}  // namespace drawtypes
 
 class builder;
 class config;
@@ -106,6 +106,8 @@ namespace modules {
     virtual string name() const = 0;
     virtual bool running() const = 0;
 
+    virtual bool allow_multiple() const = 0;
+
     virtual void start() = 0;
     virtual void stop() = 0;
     virtual void halt(string error_message) = 0;
@@ -127,6 +129,8 @@ namespace modules {
     void halt(string error_message);
     void teardown();
     string contents();
+
+    bool allow_multiple() const;
 
    protected:
     void broadcast();
@@ -154,6 +158,7 @@ namespace modules {
     thread m_mainthread;
 
     bool m_handle_events{true};
+    const bool m_allow_multiple{false};
 
    private:
     atomic<bool> m_enabled{true};
@@ -162,6 +167,6 @@ namespace modules {
   };
 
   // }}}
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -19,7 +19,8 @@ namespace modules {
       , m_name("module/" + name)
       , m_builder(make_unique<builder>(bar))
       , m_formatter(make_unique<module_formatter>(m_conf, m_name))
-      , m_handle_events(m_conf.get(m_name, "handle-events", true)) {}
+      , m_handle_events(m_conf.get(m_name, "handle-events", true))
+      , m_allow_multiple(m_conf.get(m_name, "allow-multiple", false)) {}
 
   template <typename Impl>
   module<Impl>::~module() noexcept {
@@ -90,6 +91,17 @@ namespace modules {
       m_changed = false;
     }
     return m_cache;
+  }
+
+  /**
+   * Whether this module can appear multiple times in the module list.
+   *
+   * It's false by default because module names need to be unique. If it is set
+   * to true, there is no guarantee how actions for this module will behave.
+   */
+  template <typename Impl>
+  bool module<Impl>::allow_multiple() const {
+    return m_allow_multiple;
   }
 
   // }}}

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -23,6 +23,9 @@ namespace modules {
     bool running() const {                                                              \
       return false;                                                                     \
     }                                                                                   \
+    bool allow_multiple() const {                                                       \
+      return false;                                                                     \
+    }                                                                                   \
     void start() {}                                                                     \
     void stop() {}                                                                      \
     void halt(string) {}                                                                \

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -100,13 +100,18 @@ controller::controller(connection& conn, signal_emitter& emitter, const logger& 
     dup_it = std::adjacent_find(dup_it, m_modules.cend(), equal_predicate);
 
     if (dup_it != m_modules.cend()) {
-      m_log.err(
-          "The module \"%s\" appears multiple times in your modules list. "
-          "This is deprecated and should be avoided, as it can lead to inconsistent behavior. "
-          "Both modules will be displayed for now.",
-          (*dup_it)->name());
+      auto mod = *dup_it;
+      if (mod->allow_multiple()) {
+        m_log.info("Module %s appears multiple times, the module allows this.", mod->name());
+      } else {
+        m_log.err(
+            "The module \"%s\" appears multiple times in your modules list. "
+            "This is deprecated and should be avoided, as it can lead to inconsistent behavior. "
+            "All modules will be displayed for now.",
+            mod->name());
+      }
 
-      dup_it = std::find_if_not(dup_it, m_modules.cend(), std::bind(equal_predicate, *dup_it, std::placeholders::_1));
+      dup_it = std::find_if_not(dup_it, m_modules.cend(), std::bind(equal_predicate, mod, std::placeholders::_1));
     } else {
       break;
     }


### PR DESCRIPTION
Adds a new config key `allow-multiple` to every module section, by
default it's set to `false`.

If set to true, the controller will not emit an error when that module
appears multiple times.

There are still some cases where using the same module multiple times is
desirable. For example when you want to have different separators on the
left side than on the right side. adi1090x's polybar-themes does this
in several places.

Since in the future the module name is used to target actions, this will
lead to unspecified behavior when such a module receives an action.
I think when sending actions to modules, we will check allow_multiple()
and either not deliver the action at all or just emit an error.

Ref: https://github.com/adi1090x/polybar-themes