### PR TITLE
build: Move non-macro variables into settings.cpp

### DIFF
--- a/include/components/ipc.hpp
+++ b/include/components/ipc.hpp
@@ -13,18 +13,9 @@ class signal_emitter;
 /**
  * Message types
  */
-struct ipc_command {
-  static constexpr const char* prefix{"cmd:"};
-  char payload[EVENT_SIZE]{'\0'};
-};
-struct ipc_hook {
-  static constexpr const char* prefix{"hook:"};
-  char payload[EVENT_SIZE]{'\0'};
-};
-struct ipc_action {
-  static constexpr const char* prefix{"action:"};
-  char payload[EVENT_SIZE]{'\0'};
-};
+static constexpr const char* ipc_command_prefix{"cmd:"};
+static constexpr const char* ipc_hook_prefix{"hook:"};
+static constexpr const char* ipc_action_prefix{"action:"};
 
 /**
  * Component used for inter-process communication.

--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -5,8 +5,6 @@
 
 POLYBAR_NS
 
-struct ipc_hook;  // fwd
-
 namespace modules {
   /**
    * Module that allow users to configure hooks on

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -45,8 +45,6 @@ extern const char* const APP_VERSION;
 #cmakedefine DEBUG_FONTCONFIG
 #endif
 
-static const size_t EVENT_SIZE = 64;
-
 static const int SIGN_PRIORITY_CONTROLLER{1};
 static const int SIGN_PRIORITY_SCREEN{2};
 static const int SIGN_PRIORITY_BAR{3};

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#define APP_NAME "@PROJECT_NAME@"
-#cmakedefine APP_VERSION "@APP_VERSION@"
+extern const char* const APP_NAME;
+extern const char* const APP_VERSION;
 
 #cmakedefine01 ENABLE_ALSA
 #cmakedefine01 ENABLE_MPD
@@ -59,54 +59,20 @@ static const int SINK_PRIORITY_SCREEN{2};
 static const int SINK_PRIORITY_TRAY{3};
 static const int SINK_PRIORITY_MODULE{4};
 
-static constexpr const char* ALSA_SOUNDCARD{"@SETTING_ALSA_SOUNDCARD@"};
-static constexpr const char* BSPWM_SOCKET_PATH{"@SETTING_BSPWM_SOCKET_PATH@"};
-static constexpr const char* BSPWM_STATUS_PREFIX{"@SETTING_BSPWM_STATUS_PREFIX@"};
-static constexpr const char* CONNECTION_TEST_IP{"@SETTING_CONNECTION_TEST_IP@"};
-static constexpr const char* PATH_ADAPTER{"@SETTING_PATH_ADAPTER@"};
-static constexpr const char* PATH_BACKLIGHT{"@SETTING_PATH_BACKLIGHT@"};
-static constexpr const char* PATH_BATTERY{"@SETTING_PATH_BATTERY@"};
-static constexpr const char* PATH_CPU_INFO{"@SETTING_PATH_CPU_INFO@"};
-static constexpr const char* PATH_MEMORY_INFO{"@SETTING_PATH_MEMORY_INFO@"};
-static constexpr const char* PATH_MESSAGING_FIFO{"@SETTING_PATH_MESSAGING_FIFO@"};
-static constexpr const char* PATH_TEMPERATURE_INFO{"@SETTING_PATH_TEMPERATURE_INFO@"};
+extern const char* const ALSA_SOUNDCARD;
+extern const char* const BSPWM_SOCKET_PATH;
+extern const char* const BSPWM_STATUS_PREFIX;
+extern const char* const CONNECTION_TEST_IP;
+extern const char* const PATH_ADAPTER;
+extern const char* const PATH_BACKLIGHT;
+extern const char* const PATH_BATTERY;
+extern const char* const PATH_CPU_INFO;
+extern const char* const PATH_MEMORY_INFO;
+extern const char* const PATH_MESSAGING_FIFO;
+extern const char* const PATH_TEMPERATURE_INFO;
 
-const auto version_details = [](const std::vector<std::string>& args) {
-  for (auto&& arg : args) {
-    if (arg.compare(0, 3, "-vv") == 0)
-      return true;
-  }
-  return false;
-};
+extern bool version_details(const std::vector<std::string>& args);
 
-// clang-format off
-const auto print_build_info = [](bool extended = false) {
-  printf("%s %s\n\n", APP_NAME, APP_VERSION);
-  printf("Features: %calsa %ccurl %ci3 %cmpd %cnetwork(%s) %cpulseaudio %cxkeyboard\n",
-    (ENABLE_ALSA       ? '+' : '-'),
-    (ENABLE_CURL       ? '+' : '-'),
-    (ENABLE_I3         ? '+' : '-'),
-    (ENABLE_MPD        ? '+' : '-'),
-    (ENABLE_NETWORK    ? '+' : '-'),
-    WIRELESS_LIB,
-    (ENABLE_PULSEAUDIO ? '+' : '-'),
-    (ENABLE_XKEYBOARD  ? '+' : '-'));
-  if (extended) {
-    printf("\n");
-    printf("X extensions: %crandr (%cmonitors) %ccomposite %cxkb %cxrm %cxcursor\n",
-      (WITH_XRANDR            ? '+' : '-'),
-      (WITH_XRANDR_MONITORS   ? '+' : '-'),
-      (WITH_XCOMPOSITE        ? '+' : '-'),
-      (WITH_XKB               ? '+' : '-'),
-      (WITH_XRM               ? '+' : '-'),
-      (WITH_XCURSOR           ? '+' : '-'));
-    printf("\n");
-    printf("Build type: @CMAKE_BUILD_TYPE@\n");
-    printf("Compiler: @CMAKE_CXX_COMPILER@\n");
-    printf("Compiler flags: @CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}\n");
-    printf("Linker flags: @CMAKE_EXE_LINKER_FLAGS@ ${CMAKE_EXE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}\n");
-  }
-};
-// clang-format on
+extern void print_build_info(bool extended = false);
 
 // vim:ft=cpp

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -11,7 +11,6 @@ extern const char* const APP_VERSION;
 #cmakedefine01 ENABLE_MPD
 #cmakedefine01 ENABLE_NETWORK
 #cmakedefine01 WITH_LIBNL
-#define WIRELESS_LIB "@WIRELESS_LIB@"
 #cmakedefine01 ENABLE_I3
 #cmakedefine01 ENABLE_CURL
 #cmakedefine01 ENABLE_PULSEAUDIO
@@ -54,10 +53,10 @@ static const int SIGN_PRIORITY_BAR{3};
 static const int SIGN_PRIORITY_RENDERER{4};
 static const int SIGN_PRIORITY_TRAY{5};
 
-static const int SINK_PRIORITY_BAR{1};
-static const int SINK_PRIORITY_SCREEN{2};
-static const int SINK_PRIORITY_TRAY{3};
-static const int SINK_PRIORITY_MODULE{4};
+extern const int SINK_PRIORITY_BAR;
+extern const int SINK_PRIORITY_SCREEN;
+extern const int SINK_PRIORITY_TRAY;
+extern const int SINK_PRIORITY_MODULE;
 
 extern const char* const ALSA_SOUNDCARD;
 extern const char* const BSPWM_SOCKET_PATH;
@@ -70,9 +69,10 @@ extern const char* const PATH_CPU_INFO;
 extern const char* const PATH_MEMORY_INFO;
 extern const char* const PATH_MESSAGING_FIFO;
 extern const char* const PATH_TEMPERATURE_INFO;
+extern const char* const WIRELESS_LIB;
 
-extern bool version_details(const std::vector<std::string>& args);
+bool version_details(const std::vector<std::string>& args);
 
-extern void print_build_info(bool extended = false);
+void print_build_info(bool extended = false);
 
 // vim:ft=cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,13 @@
 file(GLOB_RECURSE files RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.c[p]*)
 list(REMOVE_ITEM files main.cpp ipc.cpp)
 
+configure_file(
+  ${CMAKE_CURRENT_LIST_DIR}/settings.cpp.cmake
+  ${CMAKE_BINARY_DIR}/generated-sources/settings.cpp
+  ESCAPE_QUOTES)
+
+list(APPEND files ${CMAKE_BINARY_DIR}/generated-sources/settings.cpp)
+
 if(NOT ENABLE_ALSA)
   list(REMOVE_ITEM files modules/alsa.cpp)
   list(REMOVE_ITEM files adapters/alsa/control.cpp)
@@ -55,7 +62,6 @@ endif()
 if(NOT WITH_XCURSOR)
   list(REMOVE_ITEM files x11/cursor.cpp)
 endif()
-
 # }}}
 
 # Target: polybar {{{

--- a/src/components/ipc.cpp
+++ b/src/components/ipc.cpp
@@ -61,12 +61,12 @@ void ipc::receive_message() {
   } else if (bytes_read > 0) {
     string payload{string_util::trim(string{buffer}, '\n')};
 
-    if (payload.find(ipc_command::prefix) == 0) {
-      m_sig.emit(signals::ipc::command{payload.substr(strlen(ipc_command::prefix))});
-    } else if (payload.find(ipc_hook::prefix) == 0) {
-      m_sig.emit(signals::ipc::hook{payload.substr(strlen(ipc_hook::prefix))});
-    } else if (payload.find(ipc_action::prefix) == 0) {
-      m_sig.emit(signals::ipc::action{payload.substr(strlen(ipc_action::prefix))});
+    if (payload.find(ipc_command_prefix) == 0) {
+      m_sig.emit(signals::ipc::command{payload.substr(strlen(ipc_command_prefix))});
+    } else if (payload.find(ipc_hook_prefix) == 0) {
+      m_sig.emit(signals::ipc::hook{payload.substr(strlen(ipc_hook_prefix))});
+    } else if (payload.find(ipc_action_prefix) == 0) {
+      m_sig.emit(signals::ipc::action{payload.substr(strlen(ipc_action_prefix))});
     } else if (!payload.empty()) {
       m_log.warn("Received unknown ipc message: (payload=%s)", payload);
     }

--- a/src/settings.cpp.cmake
+++ b/src/settings.cpp.cmake
@@ -3,6 +3,11 @@
 const char* const APP_NAME{"@PROJECT_NAME@"};
 const char* const APP_VERSION{"@APP_VERSION@"};
 
+const int SINK_PRIORITY_BAR{1};
+const int SINK_PRIORITY_SCREEN{2};
+const int SINK_PRIORITY_TRAY{3};
+const int SINK_PRIORITY_MODULE{4};
+
 const char* const ALSA_SOUNDCARD{"@SETTING_ALSA_SOUNDCARD@"};
 const char* const BSPWM_SOCKET_PATH{"@SETTING_BSPWM_SOCKET_PATH@"};
 const char* const BSPWM_STATUS_PREFIX{"@SETTING_BSPWM_STATUS_PREFIX@"};
@@ -14,6 +19,7 @@ const char* const PATH_CPU_INFO{"@SETTING_PATH_CPU_INFO@"};
 const char* const PATH_MEMORY_INFO{"@SETTING_PATH_MEMORY_INFO@"};
 const char* const PATH_MESSAGING_FIFO{"@SETTING_PATH_MESSAGING_FIFO@"};
 const char* const PATH_TEMPERATURE_INFO{"@SETTING_PATH_TEMPERATURE_INFO@"};
+const char* const WIRELESS_LIB{"@WIRELESS_LIB@"};
 
 bool version_details(const std::vector<std::string>& args) {
   for (auto&& arg : args) {

--- a/src/settings.cpp.cmake
+++ b/src/settings.cpp.cmake
@@ -1,0 +1,56 @@
+#include "settings.hpp"
+
+const char* const APP_NAME{"@PROJECT_NAME@"};
+const char* const APP_VERSION{"@APP_VERSION@"};
+
+const char* const ALSA_SOUNDCARD{"@SETTING_ALSA_SOUNDCARD@"};
+const char* const BSPWM_SOCKET_PATH{"@SETTING_BSPWM_SOCKET_PATH@"};
+const char* const BSPWM_STATUS_PREFIX{"@SETTING_BSPWM_STATUS_PREFIX@"};
+const char* const CONNECTION_TEST_IP{"@SETTING_CONNECTION_TEST_IP@"};
+const char* const PATH_ADAPTER{"@SETTING_PATH_ADAPTER@"};
+const char* const PATH_BACKLIGHT{"@SETTING_PATH_BACKLIGHT@"};
+const char* const PATH_BATTERY{"@SETTING_PATH_BATTERY@"};
+const char* const PATH_CPU_INFO{"@SETTING_PATH_CPU_INFO@"};
+const char* const PATH_MEMORY_INFO{"@SETTING_PATH_MEMORY_INFO@"};
+const char* const PATH_MESSAGING_FIFO{"@SETTING_PATH_MESSAGING_FIFO@"};
+const char* const PATH_TEMPERATURE_INFO{"@SETTING_PATH_TEMPERATURE_INFO@"};
+
+bool version_details(const std::vector<std::string>& args) {
+  for (auto&& arg : args) {
+    if (arg.compare(0, 3, "-vv") == 0)
+      return true;
+  }
+  return false;
+}
+
+// clang-format off
+void print_build_info(bool extended) {
+  printf("%s %s\n\n", APP_NAME, APP_VERSION);
+  printf("Features: %calsa %ccurl %ci3 %cmpd %cnetwork(%s) %cpulseaudio %cxkeyboard\n",
+    (ENABLE_ALSA       ? '+' : '-'),
+    (ENABLE_CURL       ? '+' : '-'),
+    (ENABLE_I3         ? '+' : '-'),
+    (ENABLE_MPD        ? '+' : '-'),
+    (ENABLE_NETWORK    ? '+' : '-'),
+    WIRELESS_LIB,
+    (ENABLE_PULSEAUDIO ? '+' : '-'),
+    (ENABLE_XKEYBOARD  ? '+' : '-'));
+  if (extended) {
+    printf("\n");
+    printf("X extensions: %crandr (%cmonitors) %ccomposite %cxkb %cxrm %cxcursor\n",
+      (WITH_XRANDR            ? '+' : '-'),
+      (WITH_XRANDR_MONITORS   ? '+' : '-'),
+      (WITH_XCOMPOSITE        ? '+' : '-'),
+      (WITH_XKB               ? '+' : '-'),
+      (WITH_XRM               ? '+' : '-'),
+      (WITH_XCURSOR           ? '+' : '-'));
+    printf("\n");
+    printf("Build type: @CMAKE_BUILD_TYPE@\n");
+    printf("Compiler: @CMAKE_CXX_COMPILER@\n");
+    printf("Compiler flags: @CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}\n");
+    printf("Linker flags: @CMAKE_EXE_LINKER_FLAGS@ ${CMAKE_EXE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}\n");
+  }
+}
+// clang-format on
+
+// vim:ft=cpp

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -14,7 +14,7 @@ http_downloader::http_downloader(int connection_timeout) {
   curl_easy_setopt(m_curl, CURLOPT_CONNECTTIMEOUT, connection_timeout);
   curl_easy_setopt(m_curl, CURLOPT_FOLLOWLOCATION, true);
   curl_easy_setopt(m_curl, CURLOPT_NOSIGNAL, true);
-  curl_easy_setopt(m_curl, CURLOPT_USERAGENT, "polybar/" APP_VERSION);
+  curl_easy_setopt(m_curl, CURLOPT_USERAGENT, "polybar/" + string{APP_VERSION});
   curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, http_downloader::write);
   curl_easy_setopt(m_curl, CURLOPT_FORBID_REUSE, true);
 }

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -14,7 +14,7 @@ http_downloader::http_downloader(int connection_timeout) {
   curl_easy_setopt(m_curl, CURLOPT_CONNECTTIMEOUT, connection_timeout);
   curl_easy_setopt(m_curl, CURLOPT_FOLLOWLOCATION, true);
   curl_easy_setopt(m_curl, CURLOPT_NOSIGNAL, true);
-  curl_easy_setopt(m_curl, CURLOPT_USERAGENT, "polybar/" + string{APP_VERSION});
+  curl_easy_setopt(m_curl, CURLOPT_USERAGENT, ("polybar/" + string{APP_VERSION}).c_str());
   curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, http_downloader::write);
   curl_easy_setopt(m_curl, CURLOPT_FORBID_REUSE, true);
 }


### PR DESCRIPTION
Since APP_VERSION is different for every commit and almost all file
include settings.hpp, the whole project has to be rebuilt for every
commit. With this, hopefully, this can be greatly reduced and only
changed files need to be rebuilt. This will also help ccache