### PR TITLE
github: Add subreddit as contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Polybar subreddit
+    url: https://www.reddit.com/r/polybar
+    about: Please ask and answer questions here.


### PR DESCRIPTION
This is yet another way to steer people towards reddit for questions
instead of using the github issue tracker

Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

In the end the issue chooser will look something like this:

![2019-11-03-111216_1246x555_scrot](https://user-images.githubusercontent.com/2452038/68083633-32275c80-fe2b-11e9-924a-4b77ec94fad7.png)
