### PR TITLE
Renderer alignment fixes

### DIFF
--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -108,10 +108,9 @@ namespace cairo {
     }
 
     context& operator<<(const linear_gradient& l) {
-      if (l.steps.size() >= 2) {
+      auto stops = l.steps.size();
+      if (stops >= 2) {
         auto pattern = cairo_pattern_create_linear(l.x1, l.y1, l.x2, l.y2);
-        *this << pattern;
-        auto stops = l.steps.size();
         auto step = 1.0 / (stops - 1);
         auto offset = 0.0;
         for (auto&& color : l.steps) {
@@ -124,6 +123,7 @@ namespace cairo {
           // clang-format on
           offset += step;
         }
+        *this << pattern;
         cairo_pattern_destroy(pattern);
       }
       return *this;

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -1,4 +1,5 @@
 #include "components/renderer.hpp"
+
 #include "cairo/context.hpp"
 #include "components/config.hpp"
 #include "events/signal.hpp"
@@ -454,11 +455,25 @@ double renderer::block_x(alignment a) const {
       return std::max(base_pos - block_w(a) / 2.0, min_pos);
     }
     case alignment::RIGHT: {
-      double gap{0.0};
-      if (block_w(alignment::LEFT) || block_w(alignment::CENTER)) {
-        gap = BLOCK_GAP;
+      /*
+       * The block immediately to the left of this block
+       *
+       * Generally the center block unless it is empty.
+       */
+      alignment left_barrier = alignment::CENTER;
+
+      if (block_w(alignment::CENTER) == 0) {
+        left_barrier = alignment::LEFT;
       }
-      return std::max(m_rect.width - block_w(a), block_x(alignment::CENTER) + gap + block_w(alignment::CENTER));
+
+      // The minimum x position this block can start at
+      double min_pos = block_x(left_barrier) + block_w(left_barrier);
+
+      if (block_w(left_barrier) != 0) {
+        min_pos += BLOCK_GAP;
+      }
+
+      return std::max(m_rect.width - block_w(a), min_pos);
     }
     default:
       return 0.0;


### PR DESCRIPTION
I finally found the issue in https://github.com/polybar/polybar/issues/591!!

Turns out it wasn't the tray code but the code that calculates the block positions. It didn't work when the center block was empty and the right block grew too large (with `fixed-center = true`).

There were also some bugs with `fixed-center` which basically made `fixed-center = true` not work reliably if the right block was too large. I basically rewrote the entire logic there.

The definition of what `fixed-center` exactly does wasn't really clear as well and since the code was full of bugs, I found it hard to figure out what the intention was. Here is what I came up with:

* `fixed-center = true`: The center block stays at the center of the bar
whenever possible. It can be pushed to the left if the right block takes
too much space and to the right if the left block takes too much space
* `fixed-center = false`: The center block will be in the middle between
the left and right block whenever possible. If there is not enough space
between those two, the center block will be directly to the right of the
left block and pushes out the right block

This should preserve the same behavior as it has now (for the cases where there were no bugs).

Finally there were some bugs with how the falloff gradient was drawn.

@x70b1 Can you check that this also fixes #1903

Fixes #591 
Fixes #1903
Fixes #1838
Fixes #1268