### PR TITLE
doc: Add Gitter room

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,3 +98,10 @@ notifications:
     use_notice: true
     on_success: change
     on_failure: change
+  webhooks:
+    urls:
+      # For the https://gitter.im/polybar/polybar gitter room
+      - https://webhooks.gitter.im/e/10bdbe25961312646ace
+    on_success: change
+    on_failure: always
+    on_start: never

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img src="banner.png" alt="Polybar">
+  <img src="banner.png" alt="Polybar">
 </p>
 
 <p align="center">
@@ -10,6 +10,7 @@ A fast and easy-to-use tool for creating status bars.
 <a href="https://github.com/polybar/polybar/releases"><img src="https://img.shields.io/github/release/polybar/polybar.svg"></a>
 <a href="https://travis-ci.com/polybar/polybar"><img src="https://travis-ci.com/polybar/polybar.svg?branch=master"></a>
 <a href="https://polybar.readthedocs.io"><img src="https://readthedocs.org/projects/polybar/badge/?version=latest"></a>
+<a href="https://gitter.im/polybar/polybar"><img src="https://badges.gitter.im/polybar/polybar.svg"></a>
 <a href="https://codecov.io/gh/polybar/polybar/branch/master"><img src="https://codecov.io/gh/polybar/polybar/branch/master/graph/badge.svg"></a>
 <a href="https://github.com/polybar/polybar/blob/master/LICENSE"><img src="https://img.shields.io/github/license/polybar/polybar.svg"></a>
 <a href="https://www.codetriage.com/polybar/polybar"><img src="https://www.codetriage.com/polybar/polybar/badges/users.svg"></a>
@@ -180,6 +181,7 @@ Or you can copy the example config from `/usr/share/doc/polybar/config` or ` /us
 ## Community
 Want to get in touch?
 
+* Join our Gitter room at [gitter.im/polybar/polybar](https://gitter.im/polybar/polybar)
 * We have our own subreddit at [r/polybar](https://www.reddit.com/r/polybar).
 * Chat with us in the `#polybar` IRC channel on the `chat.freenode.net` server.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,8 +5,9 @@ If you need help or troubleshooting tips or just have a question:
 
 * Read the [Known Issues page](https://github.com/polybar/polybar/wiki/Known-Issues), maybe others had the same issue before.
 * Read the [Wiki page](https://github.com/polybar/polybar/wiki) for the thing you have problems with.
+* Join our Gitter room at [gitter.im/polybar/polybar](https://gitter.im/polybar/polybar)
 * Ask in our reddit community at [r/polybar](https://www.reddit.com/r/polybar)
-* Join the official IRC channel `#polybar` on the `chat.freenode.net` network. Make sure to let your IRC client be connected long enough to get an answer, if you disconnect after 15 minutes, you will likely not get any response.
+* Join the official IRC channel `#polybar` on the `chat.freenode.net` network. If you don't get an answer try asking on [Gitter](https://gitter.im/polybar/polybar).
 * Ask on [Unix & Linux StackExchange](https://unix.stackexchange.com/). Though not all questions may be suited over there, make sure you're [on topic](https://unix.stackexchange.com/help/on-topic).
 
 Please **do not** use the github issue tracker to ask for help or if you have a question, it is meant for bug reports and feature requests. Issues will be closed and you will be referred to the above resources.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -22,8 +22,7 @@ Getting Help
 ============
 
 * `Polybar Wiki <https://github.com/polybar/polybar/wiki>`_
+* `Gitter <https://gitter.im/polybar/polybar>`_
 * `/r/polybar <https://reddit.com/r/polybar>`_ on reddit
 * ``#polybar`` on ``chat.freenode.net``
-* `Unix & Linux StackExchange <https://unix.stackexchange.com/>`_
-
 


### PR DESCRIPTION
The Gitter room https://gitter.im/polybar/polybar should serve a similar
purpose as the IRC room with the benefit that messages persist and can
be received when offline.

From now on gitter should be the place where the polybar community
lives. Reddit is great for asking longer questions in the style of a
forum but not so great for quick back and forth conversations. IRC is
better in that aspect but has the serious downside that you have to stay
connected to get an answer and messages are not logged (only by your
client).

Both reddit and IRC are here to stay and I will still check them
regularly, but we should encourage people to join gitter.