### PR TITLE
Right-click on pulseaudio launches control panel

### DIFF
--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "settings.hpp"
+#include "utils/command.hpp"
 #include "modules/meta/event_module.hpp"
 #include "modules/meta/input_handler.hpp"
 
@@ -50,6 +51,7 @@ namespace modules {
 
     int m_interval{5};
     string m_controlpanelapp;
+    unique_ptr<command> m_controlpanelcmd;
     atomic<bool> m_muted{false};
     atomic<int> m_volume{0};
     atomic<double> m_decibels{0};

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -39,6 +39,7 @@ namespace modules {
     static constexpr auto EVENT_VOLUME_UP = "pa_volup";
     static constexpr auto EVENT_VOLUME_DOWN = "pa_voldown";
     static constexpr auto EVENT_TOGGLE_MUTE = "pa_volmute";
+    static constexpr auto EVENT_OPEN_CONTROL_PANEL = "pa_volctl";
 
     progressbar_t m_bar_volume;
     ramp_t m_ramp_volume;
@@ -48,6 +49,7 @@ namespace modules {
     pulseaudio_t m_pulseaudio;
 
     int m_interval{5};
+    string m_controlpanelapp;
     atomic<bool> m_muted{false};
     atomic<int> m_volume{0};
     atomic<double> m_decibels{0};

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -18,6 +18,11 @@ namespace modules {
     // Load configuration values
     m_interval = m_conf.get(name(), "interval", m_interval);
 
+    m_controlpanelapp = m_conf.get(name(), "control-panel", "pavucontrol"s);
+    if (m_controlpanelapp.compare(m_controlpanelapp.length() - 1, 1, "&"s) != 0) {
+        m_controlpanelapp += "&";
+    }
+
     auto sink_name = m_conf.get(name(), "sink", ""s);
     bool m_max_volume = m_conf.get(name(), "use-ui-max", true);
 
@@ -107,6 +112,7 @@ namespace modules {
 
     if (m_handle_events) {
       m_builder->cmd(mousebtn::LEFT, EVENT_TOGGLE_MUTE);
+      m_builder->cmd(mousebtn::RIGHT, EVENT_OPEN_CONTROL_PANEL);
       m_builder->cmd(mousebtn::SCROLL_UP, EVENT_VOLUME_UP);
       m_builder->cmd(mousebtn::SCROLL_DOWN, EVENT_VOLUME_DOWN);
     }
@@ -142,6 +148,12 @@ namespace modules {
       if (m_pulseaudio && !m_pulseaudio->get_name().empty()) {
         if (cmd.compare(0, strlen(EVENT_TOGGLE_MUTE), EVENT_TOGGLE_MUTE) == 0) {
           m_pulseaudio->toggle_mute();
+        } else if (cmd.compare(0, strlen(EVENT_OPEN_CONTROL_PANEL), EVENT_OPEN_CONTROL_PANEL) == 0) {
+            m_log.info("%s: Launching pulseaudio control panel (%s)", name(), this->m_controlpanelapp);
+            int rc = system(this->m_controlpanelapp.c_str());
+            if (rc != 0) {
+                m_log.info("%s: Launch of pulseaudio control panel failed with rc = %i", name(), rc);
+            }
         } else if (cmd.compare(0, strlen(EVENT_VOLUME_UP), EVENT_VOLUME_UP) == 0) {
           // cap above 100 (~150)?
           m_pulseaudio->inc_volume(m_interval);

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -19,9 +19,6 @@ namespace modules {
     m_interval = m_conf.get(name(), "interval", m_interval);
 
     m_controlpanelapp = m_conf.get(name(), "control-panel", "pavucontrol"s);
-    if (m_controlpanelapp.compare(m_controlpanelapp.length() - 1, 1, "&"s) != 0) {
-        m_controlpanelapp += "&";
-    }
 
     auto sink_name = m_conf.get(name(), "sink", ""s);
     bool m_max_volume = m_conf.get(name(), "use-ui-max", true);
@@ -149,10 +146,12 @@ namespace modules {
         if (cmd.compare(0, strlen(EVENT_TOGGLE_MUTE), EVENT_TOGGLE_MUTE) == 0) {
           m_pulseaudio->toggle_mute();
         } else if (cmd.compare(0, strlen(EVENT_OPEN_CONTROL_PANEL), EVENT_OPEN_CONTROL_PANEL) == 0) {
-            m_log.info("%s: Launching pulseaudio control panel (%s)", name(), this->m_controlpanelapp);
-            int rc = system(this->m_controlpanelapp.c_str());
-            if (rc != 0) {
-                m_log.info("%s: Launch of pulseaudio control panel failed with rc = %i", name(), rc);
+            if (!m_controlpanelcmd || !m_controlpanelcmd->is_running()) {
+                m_log.info("%s: Launching pulseaudio control panel (%s)", name(), this->m_controlpanelapp);
+                m_controlpanelcmd = command_util::make_command(m_controlpanelapp);
+                m_controlpanelcmd->exec(false);
+            } else {
+                m_log.info("%s: Pulseaudio control panel already running", name(), this->m_controlpanelapp);
             }
         } else if (cmd.compare(0, strlen(EVENT_VOLUME_UP), EVENT_VOLUME_UP) == 0) {
           // cap above 100 (~150)?


### PR DESCRIPTION
This is a tiny commit that scratches an itch for me but I suspect others would find useful.  It creates an easy way to get into the audio control panel.

From the commit message:
Adds a new EVENT_OPEN_CONTROL_PANEL event to the pulseaudio module.

The event is bound to right-click, and it's handler invokes the
"control-panel" app as defined in the config file (default is
"pavucontrol")

If the specified control panel command does not end in "&", one is
appended so that the system() all will not block.