### PR TITLE
Feature pulseaudio controlplanel

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -106,6 +106,17 @@ namespace modules {
     string output{module::get_output()};
 
     if (m_handle_events) {
+        auto click_middle = m_conf.get(name(), "click-middle", ""s);
+        auto click_right = m_conf.get(name(), "click-right", ""s);
+
+        if (!click_middle.empty()) {
+            m_builder->cmd(mousebtn::MIDDLE, click_middle);
+        }
+
+        if (!click_right.empty()) {
+            m_builder->cmd(mousebtn::RIGHT, click_right);
+        }
+
       m_builder->cmd(mousebtn::LEFT, EVENT_TOGGLE_MUTE);
       m_builder->cmd(mousebtn::SCROLL_UP, EVENT_VOLUME_UP);
       m_builder->cmd(mousebtn::SCROLL_DOWN, EVENT_VOLUME_DOWN);

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -106,16 +106,16 @@ namespace modules {
     string output{module::get_output()};
 
     if (m_handle_events) {
-        auto click_middle = m_conf.get(name(), "click-middle", ""s);
-        auto click_right = m_conf.get(name(), "click-right", ""s);
+      auto click_middle = m_conf.get(name(), "click-middle", ""s);
+      auto click_right = m_conf.get(name(), "click-right", ""s);
 
-        if (!click_middle.empty()) {
-            m_builder->cmd(mousebtn::MIDDLE, click_middle);
-        }
+      if (!click_middle.empty()) {
+        m_builder->cmd(mousebtn::MIDDLE, click_middle);
+      }
 
-        if (!click_right.empty()) {
-            m_builder->cmd(mousebtn::RIGHT, click_right);
-        }
+      if (!click_right.empty()) {
+        m_builder->cmd(mousebtn::RIGHT, click_right);
+      }
 
       m_builder->cmd(mousebtn::LEFT, EVENT_TOGGLE_MUTE);
       m_builder->cmd(mousebtn::SCROLL_UP, EVENT_VOLUME_UP);

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -1,20 +1,20 @@
 #include "modules/pulseaudio.hpp"
+
 #include "adapters/pulseaudio.hpp"
 #include "drawtypes/label.hpp"
 #include "drawtypes/progressbar.hpp"
 #include "drawtypes/ramp.hpp"
-#include "utils/math.hpp"
-
 #include "modules/meta/base.inl"
-
 #include "settings.hpp"
+#include "utils/math.hpp"
 
 POLYBAR_NS
 
 namespace modules {
   template class module<pulseaudio_module>;
 
-  pulseaudio_module::pulseaudio_module(const bar_settings& bar, string name_) : event_module<pulseaudio_module>(bar, move(name_)) {
+  pulseaudio_module::pulseaudio_module(const bar_settings& bar, string name_)
+      : event_module<pulseaudio_module>(bar, move(name_)) {
     // Load configuration values
     m_interval = m_conf.get(name(), "interval", m_interval);
 
@@ -168,6 +168,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END


### PR DESCRIPTION
This PR adds a config option to specify a control panel for pulseaudio.  The default is pavucontrol.

It also listens for right-click events and uses command_util to launch the specified control panel.