### PR TITLE
Add padding support for progressbar drawtype

### DIFF
--- a/include/drawtypes/progressbar.hpp
+++ b/include/drawtypes/progressbar.hpp
@@ -18,6 +18,7 @@ namespace drawtypes {
     void set_indicator(label_t&& indicator);
     void set_gradient(bool mode);
     void set_colors(vector<string>&& colors);
+    void set_padding(side_values padding);
 
     string output(float percentage);
 
@@ -31,6 +32,7 @@ namespace drawtypes {
     unsigned int m_width;
     unsigned int m_colorstep = 1;
     bool m_gradient = false;
+    side_values m_padding{0U, 0U};
 
     label_t m_fill;
     label_t m_empty;

--- a/src/drawtypes/progressbar.cpp
+++ b/src/drawtypes/progressbar.cpp
@@ -118,7 +118,6 @@ namespace drawtypes {
     pbar->set_colors(conf.get_list(section, name + "-foreground", {}));
 
     const auto get_left_right = [&](string key) {
-    fprintf(stderr, "getting padding for key=%s\n", key.c_str());
       auto value = conf.get(section, key, 0U);
       auto left = conf.get(section, key + "-left", value);
       auto right = conf.get(section, key + "-right", value);
@@ -126,7 +125,6 @@ namespace drawtypes {
     };
 
     auto padding = get_left_right(name + "-padding");
-    fprintf(stderr, "setting padding to %i, %i\n", padding.left, padding.right);
     pbar->set_padding(padding);
 
     label_t icon_empty;

--- a/src/drawtypes/progressbar.cpp
+++ b/src/drawtypes/progressbar.cpp
@@ -56,7 +56,6 @@ namespace drawtypes {
     unsigned int fill_width = math_util::percentage_to_value(perc, m_width);
     unsigned int empty_width = m_width - fill_width;
 
-
     // Output fill icons
     fill(perc, fill_width);
     output = string_util::replace_all(output, "%fill%", m_builder->flush());


### PR DESCRIPTION
This is a basic implementation of padding for progressbar, based loosely on the implementation for label.

I also looked at animation and ramp, but it appears they should get padding support automatically due to the use of load_optional_label() and copy_undefined() in their load methods.

This was targeting at resolving issue #809 .