### PR TITLE
refactor(builder): Remove unused add_space parameter

### DIFF
--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -19,11 +19,11 @@ class builder {
   void reset();
   string flush();
   void append(string text);
-  void node(string str, bool add_space = false);
-  void node(string str, int font_index, bool add_space = false);
-  void node(const label_t& label, bool add_space = false);
-  void node_repeat(const string& str, size_t n, bool add_space = false);
-  void node_repeat(const label_t& label, size_t n, bool add_space = false);
+  void node(string str);
+  void node(string str, int font_index);
+  void node(const label_t& label);
+  void node_repeat(const string& str, size_t n);
+  void node_repeat(const label_t& label, size_t n);
   void offset(int pixels = 0);
   void space(size_t width);
   void space();

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -94,16 +94,12 @@ void builder::append(string text) {
  *
  * This will also parse raw syntax tags
  */
-void builder::node(string str, bool add_space) {
+void builder::node(string str) {
   if (str.empty()) {
     return;
   }
 
   append(move(str));
-
-  if (add_space) {
-    space();
-  }
 }
 
 /**
@@ -111,16 +107,16 @@ void builder::node(string str, bool add_space) {
  *
  * \see builder::node
  */
-void builder::node(string str, int font_index, bool add_space) {
+void builder::node(string str, int font_index) {
   font(font_index);
-  node(move(str), add_space);
+  node(move(str));
   font_close();
 }
 
 /**
  * Insert tags for given label
  */
-void builder::node(const label_t& label, bool add_space) {
+void builder::node(const label_t& label) {
   if (!label || !*label) {
     return;
   }
@@ -149,7 +145,7 @@ void builder::node(const label_t& label, bool add_space) {
     space(label->m_padding.left);
   }
 
-  node(text, label->m_font, add_space);
+  node(text, label->m_font);
 
   if (label->m_padding.right > 0) {
     space(label->m_padding.right);
@@ -177,19 +173,19 @@ void builder::node(const label_t& label, bool add_space) {
 /**
  * Repeat text string n times
  */
-void builder::node_repeat(const string& str, size_t n, bool add_space) {
+void builder::node_repeat(const string& str, size_t n) {
   string text;
   text.reserve(str.size() * n);
   while (n--) {
     text += str;
   }
-  node(text, add_space);
+  node(text);
 }
 
 /**
  * Repeat label contents n times
  */
-void builder::node_repeat(const label_t& label, size_t n, bool add_space) {
+void builder::node_repeat(const label_t& label, size_t n) {
   string text;
   string label_text{label->get()};
   text.reserve(label_text.size() * n);
@@ -198,7 +194,7 @@ void builder::node_repeat(const label_t& label, size_t n, bool add_space) {
   }
   label_t tmp{new label_t::element_type{text}};
   tmp->replace_defined_values(label);
-  node(tmp, add_space);
+  node(tmp);
 }
 
 /**


### PR DESCRIPTION
the `node` and `node_repeat` were never called with the optional
parameter add_space. And its default value is false, so the
corresponding code was never used.

I think in general it is better to just have the user of those functions
call `builder::space` when they need to instead of adding more
complexity to the `node*` functions.