### PR TITLE
Fix controller.cpp compilation on GCC 6.3

### DIFF
--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -97,7 +97,7 @@ controller::controller(connection& conn, signal_emitter& emitter, const logger& 
   auto dup_it = m_modules.cbegin();
 
   do {
-    auto equal_predicate = [](const auto& m1, const auto& m2) { return m1->name() == m2->name(); };
+    auto equal_predicate = [](const module_t& m1, const module_t& m2) { return m1->name() == m2->name(); };
     dup_it = std::adjacent_find(dup_it, m_modules.cend(), equal_predicate);
 
     if (dup_it != m_modules.cend()) {


### PR DESCRIPTION
This fixes the below error:

     /code/polybar/src/components/controller.cpp:110:117:   required from here
     /code/polybar/src/components/controller.cpp:100:60: error: passing ‘const volatile std::shared_ptr<polybar::modules::module_interface>’ as ‘this’ argument discards qualifiers [-fpermissive]
          auto equal_predicate = [](auto& m1, auto& m2) { return m1->name() == m2->name(); };