### PR TITLE
Consider steal time in CPU load calculation

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -11,6 +11,7 @@ namespace modules {
     unsigned long long nice;
     unsigned long long system;
     unsigned long long idle;
+    unsigned long long steal;
     unsigned long long total;
   };
 

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -125,7 +125,7 @@ namespace modules {
         m_cputimes.back()->idle = std::stoull(values[4], nullptr, 10);
         m_cputimes.back()->steal = std::stoull(values[8], nullptr, 10);
         m_cputimes.back()->total = m_cputimes.back()->user + m_cputimes.back()->nice + m_cputimes.back()->system +
-                                   m_cputimes.back()->idle + m_cpu_times.back()->steal;
+                                   m_cputimes.back()->idle + m_cputimes.back()->steal;
       }
     } catch (const std::ios_base::failure& e) {
       m_log.err("Failed to read CPU values (what: %s)", e.what());

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -123,8 +123,9 @@ namespace modules {
         m_cputimes.back()->nice = std::stoull(values[2], nullptr, 10);
         m_cputimes.back()->system = std::stoull(values[3], nullptr, 10);
         m_cputimes.back()->idle = std::stoull(values[4], nullptr, 10);
-        m_cputimes.back()->total =
-            m_cputimes.back()->user + m_cputimes.back()->nice + m_cputimes.back()->system + m_cputimes.back()->idle;
+        m_cputimes.back()->steal = std::stoull(values[8], nullptr, 10);
+        m_cputimes.back()->total = m_cputimes.back()->user + m_cputimes.back()->nice + m_cputimes.back()->system +
+                                   m_cputimes.back()->idle + m_cpu_times.back()->steal;
       }
     } catch (const std::ios_base::failure& e) {
       m_log.err("Failed to read CPU values (what: %s)", e.what());


### PR DESCRIPTION
In a virtualized environment (e.g., Chrome OS), steal time can be non-negligible. This PR fixes an issue where the machine can be entirely (100% across all cores according to htop) busy, but polybar reports only 30-40% load.