### PR TITLE
refactor(builder): Remove unused condition parameter

### DIFF
--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -47,9 +47,9 @@ class builder {
   void underline(const string& color = "");
   void underline_close();
   void control(controltag tag);
-  void cmd(mousebtn index, string action, bool condition = true);
+  void cmd(mousebtn index, string action);
   void cmd(mousebtn index, string action, const label_t& label);
-  void cmd_close(bool condition = true);
+  void cmd_close();
 
  protected:
   string background_hex();

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -429,8 +429,8 @@ void builder::control(controltag tag) {
 /**
  * Open command tag
  */
-void builder::cmd(mousebtn index, string action, bool condition) {
-  if (condition && !action.empty()) {
+void builder::cmd(mousebtn index, string action) {
+  if (!action.empty()) {
     action = string_util::replace_all(action, ":", "\\:");
     tag_open(syntaxtag::A, to_string(static_cast<int>(index)) + ":" + action + ":");
   }
@@ -441,7 +441,7 @@ void builder::cmd(mousebtn index, string action, bool condition) {
  */
 void builder::cmd(mousebtn index, string action, const label_t& label) {
   if (label && *label) {
-    cmd(index, action, true);
+    cmd(index, action);
     node(label);
     tag_close(syntaxtag::A);
   }
@@ -450,10 +450,8 @@ void builder::cmd(mousebtn index, string action, const label_t& label) {
 /**
  * Close command tag
  */
-void builder::cmd_close(bool condition) {
-  if (condition) {
-    tag_close(syntaxtag::A);
-  }
+void builder::cmd_close() {
+  tag_close(syntaxtag::A);
 }
 
 /**


### PR DESCRIPTION
Same as in #1952, the methods are never called with the optional
parameter, except once where it is called with the default value.

Ref: #1952