### PR TITLE
fix(aur): Add xorgproto package as make dependency

### DIFF
--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -13,7 +13,7 @@ optdepends=("i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "xorg-fonts-misc: Font used in example config")
-makedepends=("cmake" "git" "python" "pkg-config" "python-sphinx" "i3-wm")
+makedepends=("cmake" "git" "python" "pkg-config" "xorgproto" "python-sphinx" "i3-wm")
 provides=("polybar")
 conflicts=("polybar")
 install="${_pkgname}.install"

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -12,7 +12,7 @@ optdepends=("i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "xorg-fonts-misc: Font used in example config")
-makedepends=("cmake" "git" "python" "pkg-config" "python-sphinx" "i3-wm")
+makedepends=("cmake" "git" "python" "pkg-config" "xorgproto" "python-sphinx" "i3-wm")
 conflicts=("polybar-git")
 install="${pkgname}.install"
 source=(${url}/releases/download/${pkgver}/polybar-${pkgver}.tar)


### PR DESCRIPTION
xorgproto always was a make dependency (I think) but it was
automatically included indirectly by another dependency.
Arch recently cleaned up some xorg related packages which made xorgproto
no longer an indirect dependency of polybar which spams cmake with
messages like:

```
Package 'xproto', required by 'xau', not found
Package 'xproto', required by 'xdmcp', not found
Package 'xproto', required by 'xau', not found
Package 'xproto', required by 'xdmcp', not found
Package 'xproto', required by 'xau', not found
Package 'xproto', required by 'xdmcp', not found
Package 'xproto', required by 'xau', not found
Package 'xproto', required by 'xdmcp', not found
```

And during `make` finally completely fails the build because some
library's include directories are not honored because the xproto.pc file
cannot be found:

```
In file included from /home/patrick96/Projects/github.com/patrick96/polybar/include/cairo/utils.hpp:3,
                 from /home/patrick96/Projects/github.com/patrick96/polybar/src/cairo/utils.cpp:3:
/usr/include/cairo/cairo-ft.h:46:10: fatal error: ft2build.h: No such file or directory
   46 | #include <ft2build.h>
      |          ^~~~~~~~~~~~
```

Ref: https://bugs.archlinux.org/task/64892

I have already uploaded this to the AUR