### PR TITLE
CPU Adapter

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -1,22 +1,12 @@
 #pragma once
 
-#include "settings.hpp"
+#include "modules/cpu_adapter.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
 namespace modules {
-  struct cpu_time {
-    unsigned long long user;
-    unsigned long long nice;
-    unsigned long long system;
-    unsigned long long idle;
-    unsigned long long steal;
-    unsigned long long total;
-  };
-
-  using cpu_time_t = unique_ptr<cpu_time>;
-
   class cpu_module : public timer_module<cpu_module> {
    public:
     explicit cpu_module(const bar_settings&, string);
@@ -24,15 +14,13 @@ namespace modules {
     bool update();
     bool build(builder* builder, const string& tag) const;
 
-   protected:
-    bool read_values();
-    float get_load(size_t core) const;
-
    private:
     static constexpr auto TAG_LABEL = "<label>";
     static constexpr auto TAG_BAR_LOAD = "<bar-load>";
     static constexpr auto TAG_RAMP_LOAD = "<ramp-load>";
     static constexpr auto TAG_RAMP_LOAD_PER_CORE = "<ramp-coreload>";
+
+    cpu_adapter_t m_adapter;
 
     progressbar_t m_barload;
     ramp_t m_rampload;
@@ -40,12 +28,9 @@ namespace modules {
     label_t m_label;
     int m_ramp_padding;
 
-    vector<cpu_time_t> m_cputimes;
-    vector<cpu_time_t> m_cputimes_prev;
-
     float m_total = 0;
     vector<float> m_load;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/cpu_adapter.hpp
+++ b/include/modules/cpu_adapter.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "common.hpp"
+#include "components/logger.hpp"
+
+POLYBAR_NS
+
+namespace modules {
+  enum class cpu_state { STOPPED = 0, RUNNING, ERROR };
+
+  struct cpu_time {
+    uint64_t user;
+    uint64_t nice;
+    uint64_t system;
+    uint64_t idle;
+    uint64_t iowait;
+    uint64_t irq;
+    uint64_t softirq;
+    uint64_t steal;
+    uint64_t guest;
+    uint64_t total;
+  };
+
+  using cpu_time_t = unique_ptr<cpu_time>;
+
+  class cpu_adapter {
+   public:
+    cpu_adapter();
+    /**
+     * Transitions the adapter from the STOPPED to the RUNNING state
+     * Can transition to ERROR as well
+     */
+    void start();
+    /**
+     * Transitions from RUNNING or ERROR to STOPPED
+     */
+    void stop();
+    /**
+     * Reads new load values
+     *
+     * Must be in the RUNNING state
+     */
+    bool update();
+    cpu_state get_state() const;
+
+    /**
+     * Returns the load for each core as a number between 0 and 1
+     *
+     * Must be in the RUNNING state
+     */
+    vector<float> get_load() const;
+
+    /**
+     * Returns the number of cores in the current measurement
+     *
+     * Must be in the RUNNING state
+     */
+    int num_cores() const;
+
+   protected:
+    vector<cpu_time_t> read_values();
+
+   private:
+    const logger& m_log;
+
+    cpu_state m_state{cpu_state::STOPPED};
+
+    vector<cpu_time_t> m_cputimes_prev;
+    vector<float> m_load;
+  };
+
+  using cpu_adapter_t = unique_ptr<cpu_adapter>;
+}  // namespace modules
+
+POLYBAR_NS_END

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -1,14 +1,13 @@
+#include "modules/cpu.hpp"
+
 #include <fstream>
 #include <istream>
-
-#include "modules/cpu.hpp"
 
 #include "drawtypes/label.hpp"
 #include "drawtypes/progressbar.hpp"
 #include "drawtypes/ramp.hpp"
-#include "utils/math.hpp"
-
 #include "modules/meta/base.inl"
+#include "utils/math.hpp"
 
 POLYBAR_NS
 
@@ -22,9 +21,7 @@ namespace modules {
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 
-    // warmup cpu times
-    read_values();
-    read_values();
+    m_adapter = make_unique<cpu_adapter>();
 
     if (m_formatter->has(TAG_BAR_LOAD)) {
       m_barload = load_progressbar(m_bar, m_conf, name(), TAG_BAR_LOAD);
@@ -41,26 +38,32 @@ namespace modules {
   }
 
   bool cpu_module::update() {
-    if (!read_values()) {
+    if (!m_adapter->update()) {
+      // TODO maybe there should be cooldown period so that if an error is
+      // permanent, we don't retry 40 times per second.
+      if(m_adapter->get_state() != cpu_state::RUNNING) {
+        m_adapter->start();
+      }
+
       return false;
     }
 
     m_total = 0.0f;
     m_load.clear();
 
-    auto cores_n = m_cputimes.size();
+    auto cores_n = m_adapter->num_cores();
     if (!cores_n) {
       return false;
     }
 
+    m_load = m_adapter->get_load();
     vector<string> percentage_cores;
-    for (size_t i = 0; i < cores_n; i++) {
-      auto load = get_load(i);
-      m_total += load;
-      m_load.emplace_back(load);
+    for (auto load : m_load) {
+      float load_perc = math_util::percentage(load, 1.0f);
+      m_total += load_perc;
 
       if (m_label) {
-        percentage_cores.emplace_back(to_string(static_cast<int>(load + 0.5)));
+        percentage_cores.emplace_back(to_string(static_cast<int>(load_perc + 0.5)));
       }
     }
 
@@ -69,7 +72,8 @@ namespace modules {
     if (m_label) {
       m_label->reset_tokens();
       m_label->replace_token("%percentage%", to_string(static_cast<int>(m_total + 0.5)));
-      m_label->replace_token("%percentage-sum%", to_string(static_cast<int>(m_total * static_cast<float>(cores_n) + 0.5)));
+      m_label->replace_token(
+          "%percentage-sum%", to_string(static_cast<int>(m_total * static_cast<float>(cores_n) + 0.5)));
       m_label->replace_token("%percentage-cores%", string_util::join(percentage_cores, "% ") + "%");
 
       for (size_t i = 0; i < percentage_cores.size(); i++) {
@@ -93,7 +97,7 @@ namespace modules {
         if (i++ > 0) {
           builder->space(m_ramp_padding);
         }
-        builder->node(m_rampload_core->get_by_percentage(load));
+        builder->node(m_rampload_core->get_by_percentage(math_util::percentage(load, 1.0f)));
       }
       builder->node(builder->flush());
     } else {
@@ -101,62 +105,6 @@ namespace modules {
     }
     return true;
   }
-
-  bool cpu_module::read_values() {
-    m_cputimes_prev.swap(m_cputimes);
-    m_cputimes.clear();
-
-    try {
-      std::ifstream in(PATH_CPU_INFO);
-      string str;
-
-      while (std::getline(in, str) && str.compare(0, 3, "cpu") == 0) {
-        // skip line with accumulated value
-        if (str.compare(0, 4, "cpu ") == 0) {
-          continue;
-        }
-
-        auto values = string_util::split(str, ' ');
-
-        m_cputimes.emplace_back(new cpu_time);
-        m_cputimes.back()->user = std::stoull(values[1], nullptr, 10);
-        m_cputimes.back()->nice = std::stoull(values[2], nullptr, 10);
-        m_cputimes.back()->system = std::stoull(values[3], nullptr, 10);
-        m_cputimes.back()->idle = std::stoull(values[4], nullptr, 10);
-        m_cputimes.back()->steal = std::stoull(values[8], nullptr, 10);
-        m_cputimes.back()->total = m_cputimes.back()->user + m_cputimes.back()->nice + m_cputimes.back()->system +
-                                   m_cputimes.back()->idle + m_cputimes.back()->steal;
-      }
-    } catch (const std::ios_base::failure& e) {
-      m_log.err("Failed to read CPU values (what: %s)", e.what());
-    }
-
-    return !m_cputimes.empty();
-  }
-
-  float cpu_module::get_load(size_t core) const {
-    if (m_cputimes.empty() || m_cputimes_prev.empty()) {
-      return 0;
-    } else if (core >= m_cputimes.size() || core >= m_cputimes_prev.size()) {
-      return 0;
-    }
-
-    auto& last = m_cputimes[core];
-    auto& prev = m_cputimes_prev[core];
-
-    auto last_idle = last->idle;
-    auto prev_idle = prev->idle;
-
-    auto diff = last->total - prev->total;
-
-    if (diff == 0) {
-      return 0;
-    }
-
-    float percentage = 100.0f * (diff - (last_idle - prev_idle)) / diff;
-
-    return math_util::cap<float>(percentage, 0, 100);
-  }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/cpu_adapter.cpp
+++ b/src/modules/cpu_adapter.cpp
@@ -1,0 +1,138 @@
+#include "modules/cpu_adapter.hpp"
+
+#include <fstream>
+
+#include "settings.hpp"
+#include "utils/string.hpp"
+
+POLYBAR_NS
+
+namespace modules {
+
+  cpu_adapter::cpu_adapter() : m_log(logger::make()) {}
+
+  void cpu_adapter::start() {
+    // Warmup CPU times
+    m_cputimes_prev = read_values();
+
+    m_state = cpu_state::RUNNING;
+
+    update();
+  }
+
+  void cpu_adapter::stop() {
+    m_state = cpu_state::STOPPED;
+    m_cputimes_prev.clear();
+    m_load.clear();
+  }
+
+  bool cpu_adapter::update() {
+    if (m_state != cpu_state::RUNNING) {
+      return false;
+    }
+
+    auto cputimes = read_values();
+
+    // TODO what if read_values fails and sets the ERROR state
+
+    if (cputimes.empty()) {
+      return false;
+    }
+
+    auto n = cputimes.size();
+
+    m_load.resize(n, 0);
+
+    /*
+     * If the number of cores change between updates the current or the previous
+     * cpu_times vector may have different lengths, so we only iterate until the
+     * end of the shorter one.
+     */
+    auto m = std::min(n, m_cputimes_prev.size());
+
+    for (size_t i = 0; i < m; i++) {
+      auto prev_idle = m_cputimes_prev[i]->idle;
+      auto prev_total = m_cputimes_prev[i]->total;
+
+      auto idle = cputimes[i]->idle;
+      auto total = cputimes[i]->total;
+
+      auto idle_diff = idle - prev_idle;
+      auto total_diff = total - prev_total;
+
+      float load;
+      if (total_diff == 0) {
+        /*
+         * The total cputimes have not changed since the last update, so we
+         * return 0 because we would get -inf load otherwise.
+         * This generally shouldn't happen because the times in /proc/stat
+         * should be monotonically increasing.
+         */
+        load = 0.0f;
+      } else {
+        load = 1.0f - static_cast<float>(idle_diff) / static_cast<float>(total_diff);
+      }
+
+      m_load[i] = load;
+    }
+
+    m_cputimes_prev.swap(cputimes);
+    cputimes.clear();
+    return true;
+  }
+
+  cpu_state cpu_adapter::get_state() const {
+    return m_state;
+  }
+
+  vector<float> cpu_adapter::get_load() const {
+    return m_load;
+  }
+
+  int cpu_adapter::num_cores() const {
+    return m_load.size();
+  }
+
+  vector<cpu_time_t> cpu_adapter::read_values() {
+    vector<cpu_time_t> cputimes;
+    try {
+      std::ifstream in(PATH_CPU_INFO);
+      string str;
+
+      while (std::getline(in, str) && str.compare(0, 3, "cpu") == 0) {
+        // skip line with accumulated value
+        if (str.compare(0, 4, "cpu ") == 0) {
+          continue;
+        }
+
+        auto values = string_util::split(str, ' ');
+
+        cpu_time_t cputime = std::make_unique<cpu_time>();
+
+        cputime->user = std::stoull(values[1], nullptr, 10);
+        cputime->nice = std::stoull(values[2], nullptr, 10);
+        cputime->system = std::stoull(values[3], nullptr, 10);
+        cputime->idle = std::stoull(values[4], nullptr, 10);
+        cputime->iowait = std::stoull(values[5], nullptr, 10);
+        cputime->irq = std::stoull(values[6], nullptr, 10);
+        cputime->softirq = std::stoull(values[7], nullptr, 10);
+        cputime->steal = std::stoull(values[8], nullptr, 10);
+        cputime->guest = std::stoull(values[9], nullptr, 10);
+
+        cputime->total = cputime->user + cputime->nice + cputime->system + cputime->idle + cputime->iowait +
+                         cputime->irq + cputime->softirq + cputime->steal + cputime->guest;
+
+        cputimes.push_back(std::move(cputime));
+      }
+    } catch (const std::ios_base::failure& e) {
+      // TODO put into error state
+      m_log.err("Failed to read CPU values (what: %s)", e.what());
+      cputimes.clear();
+    }
+
+    return cputimes;
+  }
+
+}  // namespace modules
+
+POLYBAR_NS_END


### PR DESCRIPTION
This is a first proof of concept for something discussed in #1529. I separated out all the "backend" logic in the cpu module that gathers the data for the module into an adapter that is instantiated by the module. I also tried to see how well the module state machine idea could be implemented.

Separating out this backend logic that talks to the "outside world" to gather data has the benefit that it makes the cpu module more easily testable by creating a mock implementation of the adapter. It theoretically also allows for implementing multiple adapters that work on different OSes (though I have not implemented any of that yet).

The idea for the module state machines was to make the module more robust but also have things like warning states for high usage etc.
I'm not really sure the adapter is the right place to put that state machine. For one, if there are multiple adapters, each would have to reimplement the warning states and so on, even though the logic for those is the same. Also the adapter should only be responsible for gathering data and the "frontend" should be responsible for deciding if we are in a warning state or not.

Maybe it would be a better idea to divide each module into three components:

* The adapter: Is responsible for gathering information for the module
* The module state machine: Calls the adapter to read information and handles state transitions should either the adapter return an error or should the new data indicate a new state (high temperature, battery discharging/charging).
* The module itself: 
  * Triggers updates in the state machine. 
  * Determines the `format-*` to use depending on the state. 
  * Reads data from the state machine and uses it to produce the module output.

@Lomadriel what are your thoughts on the module state machine idea?