### PR TITLE
Revert "fix(aur): Add xorgproto package as make dependency"

### DIFF
--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -13,7 +13,7 @@ optdepends=("i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "xorg-fonts-misc: Font used in example config")
-makedepends=("cmake" "git" "python" "pkg-config" "xorgproto" "python-sphinx" "i3-wm")
+makedepends=("cmake" "git" "python" "pkg-config" "python-sphinx" "i3-wm")
 provides=("polybar")
 conflicts=("polybar")
 install="${_pkgname}.install"

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -12,7 +12,7 @@ optdepends=("i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "xorg-fonts-misc: Font used in example config")
-makedepends=("cmake" "git" "python" "pkg-config" "xorgproto" "python-sphinx" "i3-wm")
+makedepends=("cmake" "git" "python" "pkg-config" "python-sphinx" "i3-wm")
 conflicts=("polybar-git")
 install="${pkgname}.install"
 source=(${url}/releases/download/${pkgver}/polybar-${pkgver}.tar)


### PR DESCRIPTION
Reverts polybar/polybar#1962

Some things were reverted on the Arch side, so this issue no longer occurs. Polybar doesn't directly depend on `xorgproto`, only its dependencies need the `.pc` files provided by `xorgproto`. So we really shouldn't have it in the `makedepends`.

Ref: https://lists.archlinux.org/pipermail/arch-dev-public/2019-December/029767.html