### PR TITLE
Add missing <stdexcept> header

### DIFF
--- a/include/errors.hpp
+++ b/include/errors.hpp
@@ -2,6 +2,7 @@
 
 #include <cerrno>
 #include <cstring>
+#include <stdexcept>
 
 #include "common.hpp"
 


### PR DESCRIPTION
This is dependent on a PR to xpp that does the same. Newer compilers
(GCC10 in particular) are stricter about which headers provide the
std exception types.