### PR TITLE
build: allow building packages with CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,3 +165,25 @@ install(FILES config
   COMPONENT config)
 
 # }}}
+# Build Linux packages {{{
+if(CPACK_GENERATOR)
+  # General
+  set(CPACK_PACKAGE_VERSION "${version_txt}")
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A fast and easy-to-use tool for creating status bars.")
+
+  # DEB
+  set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+  set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Polybar developers")
+  set(CPACK_DEBIAN_PACKAGE_SECTION "x11")
+  set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
+
+  # RPM
+  set(CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
+  set(CPACK_RPM_PACKAGE_AUTOREQPROV ON)
+  set(CPACK_RPM_PACKAGE_VENDOR "Polybar developers")
+  set(CPACK_RPM_PACKAGE_GROUP "System/GUI/Other")
+  set(CPACK_RPM_PACKAGE_PRIORITY "optional")
+
+  include(CPack)
+endif()


### PR DESCRIPTION
I have just successfully compiled polybar for Debian Buster and packaged it up into an installable deb package that I can throw into my own local repo.  This has several advantages:  I can build the package in a container and deploy to my normal system without having to install all of the build dependencies on it.  When installing the package from my local repo, APT will do the dependency resolution for me and only install the runtime dependencies.

Right now, the packaging option in CMake is turned off my default.  Building the package works via the new `package` target.

Open questions/future work:
- [ ] Possibly add the package building option to `build.sh`
- [ ] Maybe automatically build packages on Travis CI and deploy via GitHub releases.
- [ ] Perhaps users do not want to build both DEB and RPM (for which they'd have to have `dpkg` and `rpm` installed) so maybe split the CMake option into two.

Here is what building the package looks like in the terminal:
```console
root@debian:~/polybar/build# make package
[  5%] Built target xpp
[  9%] Built target jsoncpp_lib_static
[ 11%] Built target i3ipc++
[ 92%] Built target poly
[ 94%] Built target polybar
[100%] Built target polybar-msg
Run CPack packaging tool...
CPack: Create package using TGZ
CPack: Install projects
CPack: - Run preinstall target for: polybar
CPack: - Install project: polybar
CPack: Create package
CPack: - package: /root/polybar/build/polybar-3.4.0-Linux.tar.gz generated.
CPack: Create package using RPM
CPack: Install projects
CPack: - Run preinstall target for: polybar
CPack: - Install project: polybar
CPack: Create package
-- CPackRPM:Debug: Using CPACK_RPM_ROOTDIR=/root/polybar/build/_CPack_Packages/Linux/RPM
CPackRPM: Will use GENERATED spec file: /root/polybar/build/_CPack_Packages/Linux/RPM/SPECS/polybar.spec
CPack: - package: /root/polybar/build/polybar-3.4.0-Linux.rpm generated.
CPack: Create package using DEB
CPack: Install projects
CPack: - Run preinstall target for: polybar
CPack: - Install project: polybar
CPack: Create package
CPackDeb: - Generating dependency list
CPack: - package: /root/polybar/build/polybar-3.4.0-Linux.deb generated.
```