### PR TITLE
font: Show context in unmatched character warning

### DIFF
--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cairo/cairo-xcb.h>
+
 #include <algorithm>
 #include <cmath>
 #include <deque>
@@ -218,7 +219,7 @@ namespace cairo {
 
         char unicode[6]{'\0'};
         utils::ucs4_to_utf8(unicode, chars.begin()->codepoint);
-        m_log.warn("Dropping unmatched character %s (U+%04x)", unicode, chars.begin()->codepoint);
+        m_log.warn("Dropping unmatched character %s (U+%04x) in '%s'", unicode, chars.begin()->codepoint, t.contents);
         utf8.erase(chars.begin()->offset, chars.begin()->length);
         for (auto&& c : chars) {
           c.offset -= chars.begin()->length;
@@ -353,6 +354,6 @@ namespace cairo {
     std::deque<pair<double, double>> m_points;
     int m_activegroups{0};
   };
-}
+}  // namespace cairo
 
 POLYBAR_NS_END


### PR DESCRIPTION
As suggested by @kronn (#1959)

This is a slightly modified patch introduced by @ayosec in their repo
for packaging polybar .deb packages.

Ref: https://github.com/ayosec/polybar-debian
Ref: https://github.com/ayosec/polybar-debian/blob/master/patches/0001-Show-full-contents-when-an-unmatched-character-is-fo.patch