### PR TITLE
fix(xworkspaces): Show _NET_NUMBER_OF_DESKTOPS desktops

### DIFF
--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -5,12 +5,11 @@
 
 #include "drawtypes/iconset.hpp"
 #include "drawtypes/label.hpp"
+#include "modules/meta/base.inl"
 #include "utils/factory.hpp"
 #include "utils/math.hpp"
 #include "x11/atoms.hpp"
 #include "x11/connection.hpp"
-
-#include "modules/meta/base.inl"
 
 POLYBAR_NS
 
@@ -240,8 +239,8 @@ namespace modules {
       names.erase(names.begin() + desktops_number, names.end());
       return names;
     }
-    for (unsigned int i = names.size(); i < desktops_number + 1; i++) {
-      names.insert(names.end(), to_string(i));
+    for (unsigned int i = names.size(); i < desktops_number; i++) {
+      names.insert(names.end(), to_string(i + 1));
     }
     return names;
   }


### PR DESCRIPTION
In the case where _NET_NUMBER_OF_DESKTOPS > |_NET_DESKTOP_NAMES|
the last branch of the get_desktop_names method would return a vector
with _NET_NUMBER_OF_DESKTOPS + 1 elements because we iterate until
_NET_NUMBER_OF_DESKTOPS + 1.

Fixes #1983