### PR TITLE
controller: Stop printing errors for non-unique modules

### DIFF
--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -88,30 +88,6 @@ controller::controller(connection& conn, signal_emitter& emitter, const logger& 
   if (!created_modules) {
     throw application_error("No modules created");
   }
-
-  /*
-   * Check if each module name only appears once
-   */
-  std::sort(m_modules.begin(), m_modules.end(), [](const auto& m1, const auto& m2) { return m1->name() < m2->name(); });
-
-  auto dup_it = m_modules.cbegin();
-
-  do {
-    auto equal_predicate = [](const module_t& m1, const module_t& m2) { return m1->name() == m2->name(); };
-    dup_it = std::adjacent_find(dup_it, m_modules.cend(), equal_predicate);
-
-    if (dup_it != m_modules.cend()) {
-      m_log.err(
-          "The module \"%s\" appears multiple times in your modules list. "
-          "This is deprecated and should be avoided, as it can lead to inconsistent behavior. "
-          "Both modules will be displayed for now.",
-          (*dup_it)->name());
-
-      dup_it = std::find_if_not(dup_it, m_modules.cend(), std::bind(equal_predicate, *dup_it, std::placeholders::_1));
-    } else {
-      break;
-    }
-  } while (true);
 }
 
 /**


### PR DESCRIPTION
Functionality-wise reverts the changes from #1534

In #1907 we have decided to allow the same module to appear multiple
times (and deliver actions to all matching modules). But since that PR
will likely take longer to get merged, I want to remove the error from
polybar because the message it prints isn't really true anymore.