### PR TITLE
fix(test): Gtest compilation failure

### DIFF
--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           release-1.10.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
In master gtest fails to build with the error

/home/travis/build/polybar/polybar/build/googletest-src/googlemock/include/gmock/gmock-more-actions.h:138:1: error: ISO C++11 requires at least one argument for the "..." in a variadic macro [-Werror]
 ACTION_P(ReturnPointee, pointer) { return *pointer; }

We had a lot of failed builds because gtest often breaks stuff in
master. From now on we will just use a release tag. Whenever there is a
new release, we manually update this file.

Ref: google/googletest#2678