### PR TITLE
feat(i3, bspwm) Support prefix matching workspace names for icons

### DIFF
--- a/include/drawtypes/iconset.hpp
+++ b/include/drawtypes/iconset.hpp
@@ -13,7 +13,7 @@ namespace drawtypes {
    public:
     void add(string id, label_t&& icon);
     bool has(const string& id);
-    label_t get(const string& id, const string& fallback_id = "", bool fuzzy_match = false);
+    label_t get(const string& id, const string& fallback_id = "", bool fuzzy_match = false, bool prefix_match = false);
     operator bool();
 
    protected:

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -88,6 +88,7 @@ namespace modules {
     bool m_inlinemode{false};
     string_util::hash_type m_hash{0U};
     bool m_fuzzy_match{false};
+    bool m_prefix_match{false};
 
     // used while formatting output
     size_t m_index{0U};

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -91,6 +91,7 @@ namespace modules {
     bool m_pinworkspaces{false};
     bool m_strip_wsnumbers{false};
     bool m_fuzzy_match{false};
+    bool m_prefix_match{false};
 
     unique_ptr<i3_util::connection_t> m_ipc;
   };

--- a/src/drawtypes/iconset.cpp
+++ b/src/drawtypes/iconset.cpp
@@ -11,7 +11,19 @@ namespace drawtypes {
     return m_icons.find(id) != m_icons.end();
   }
 
-  label_t iconset::get(const string& id, const string& fallback_id, bool fuzzy_match) {
+  label_t iconset::get(const string& id, const string& fallback_id, bool fuzzy_match, bool prefix_match) {
+    // match the workspace number
+    if (prefix_match) {
+      std::string prefix = id.substr(0, id.find(":"));
+      for (auto const& ent1 : m_icons) {
+        if (ent1.first.find(prefix) == 0) {
+          return ent1.second;
+        }
+      }
+      return m_icons.find(fallback_id)->second;
+    }
+
+    // match any part of the workspace name
     if (fuzzy_match) {
       for (auto const& ent1 : m_icons) {
         if (id.find(ent1.first) != std::string::npos) {

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -57,6 +57,7 @@ namespace modules {
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
     m_inlinemode = m_conf.get(name(), "inline-mode", m_inlinemode);
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
+    m_prefix_match = m_conf.get(name(), "prefix-match", m_prefix_match);
 
     // Add formats and create components
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, {TAG_LABEL_STATE}, {TAG_LABEL_MONITOR, TAG_LABEL_MODE});
@@ -340,7 +341,7 @@ namespace modules {
       }
 
       if (workspace_mask && m_formatter->has(TAG_LABEL_STATE)) {
-        auto icon = m_icons->get(value, DEFAULT_ICON, m_fuzzy_match);
+        auto icon = m_icons->get(value, DEFAULT_ICON, m_fuzzy_match, m_prefix_match);
         auto label = m_statelabels.at(workspace_mask)->clone();
 
         if (!m_monitors.back()->focused) {

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -31,6 +31,7 @@ namespace modules {
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
     m_strip_wsnumbers = m_conf.get(name(), "strip-wsnumbers", m_strip_wsnumbers);
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
+    m_prefix_match = m_conf.get(name(), "prefix-match", m_prefix_match);
 
     m_conf.warn_deprecated(name(), "wsname-maxlen", "%name:min:max%");
 
@@ -160,7 +161,7 @@ namespace modules {
         // Trim leading and trailing whitespace
         ws_name = string_util::trim(move(ws_name), ' ');
 
-        auto icon = m_icons->get(ws->name, DEFAULT_WS_ICON, m_fuzzy_match);
+        auto icon = m_icons->get(ws->name, DEFAULT_WS_ICON, m_fuzzy_match, m_prefix_match);
         auto label = m_statelabels.find(ws_state)->second->clone();
 
         label->reset_tokens();


### PR DESCRIPTION
Inspired by https://github.com/polybar/polybar/pull/359, this PR adds a `prefix-match` config to the i3 and bspwm modules which behaves similarly to `fuzzy-match`, but has to match the entire part of the workspace name before the colon. This fixes workspaces 1 and 10 getting the same icon like they do with `fuzzy-match`.

`prefix-match = true` will override `fuzzy-match = true` which I don't _love_ but I don't know of a different way to add this feature in a way that doesn't break existing configs.