### PR TITLE
build: Update i3ipcpp submodule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ addons:
         - libxcb1-dev
         - xutils-dev
         - i3-wm
+        - libjsoncpp-dev
         - libasound2-dev
         - libpulse-dev
         - libcairo2-dev


### PR DESCRIPTION
With this we no longer distribute the jsoncpp 1.7.7 source with polybar.
It is possible that polybar will no longer build on older systems that
have an ancient version of jsoncpp (>= 5 years).

Ref: polybar/i3ipcpp#9