### PR TITLE
Prioritize battery full-at over state

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -286,12 +286,12 @@ namespace modules {
    * Get the current battery state
    */
   battery_module::state battery_module::current_state() {
-    if (!read(*m_state_reader)) {
-      return battery_module::state::DISCHARGING;
-    } else if (read(*m_capacity_reader) < m_fullat) {
-      return battery_module::state::CHARGING;
-    } else {
+    if (read(*m_capacity_reader) >= m_fullat) {
       return battery_module::state::FULL;
+    } else if (!read(*m_state_reader)) {
+      return battery_module::state::DISCHARGING;
+    } else {
+      return battery_module::state::CHARGING;
     }
   }
 
@@ -303,7 +303,7 @@ namespace modules {
   }
 
   int battery_module::clamp_percentage(int percentage, state state) const {
-    if (state == battery_module::state::FULL && percentage >= m_fullat) {
+    if (state == battery_module::state::FULL &&# percentage >= m_fullat) {
       return 100;
     }
     return percentage;

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -303,7 +303,7 @@ namespace modules {
   }
 
   int battery_module::clamp_percentage(int percentage, state state) const {
-    if (state == battery_module::state::FULL &&# percentage >= m_fullat) {
+    if (state == battery_module::state::FULL && percentage >= m_fullat) {
       return 100;
     }
     return percentage;


### PR DESCRIPTION
In my opinion, the `full-at` option should take priority over the charging state of the battery.
Especially if the charging state might be corrupted.

Closes #1622 (issue for Thinkpad laptops)