### PR TITLE
feat(net): interface discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#2108`](https://github.com/polybar/polybar/issues/2108))
 - `internal/xworkspaces`: Make the urgent hint persistent
   ([`#1081`](https://github.com/polybar/polybar/issues/1081))
+- `internal/network`: `interface-type` may be used in place of `interface` to
+  automatically select a network interface
+  ([`#2025`](https://github.com/polybar/polybar/pull/2025))
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <chrono>
-#include <cstdlib>
-
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 
+#include <chrono>
+#include <cstdlib>
+
 #include "common.hpp"
-#include "settings.hpp"
-#include "errors.hpp"
 #include "components/logger.hpp"
+#include "errors.hpp"
+#include "settings.hpp"
 #include "utils/math.hpp"
 
 #if WITH_LIBNL
@@ -38,6 +38,8 @@ namespace net {
   DEFINE_ERROR(network_error);
 
   bool is_wireless_interface(const string& ifname);
+  std::string find_wireless_interface();
+  std::string find_wired_interface();
 
   // types {{{
 


### PR DESCRIPTION
Allows you to specify `interface-type=wired/wireless` instead of `interface=ifname`

Closes #339