### PR TITLE
Checks if the configuration file exists

### DIFF
--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -108,6 +108,7 @@ namespace file_util {
   bool is_fifo(const string& filename);
   vector<string> glob(string pattern);
   const string expand(const string& path);
+  string get_config_path();
 
   template <typename... Args>
   decltype(auto) make_file_descriptor(Args&&... args) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     //==================================================
     // Load user configuration
     //==================================================
-    string confpath = "";
+    string confpath;
 
     // Make sure a bar name is passed in
     if (!cli->has(0)) {
@@ -106,18 +106,8 @@ int main(int argc, char** argv) {
 
     if (cli->has("config")) {
       confpath = cli->get("config");
-    }
-    if (env_util::has("XDG_CONFIG_HOME") && confpath.empty()) {
-      confpath = env_util::get("XDG_CONFIG_HOME") + "/polybar/config";
-      if (!file_util::exists(confpath)) {
-        confpath = "";
-      }
-    }
-    if (env_util::has("HOME") && confpath.empty()) {
-      confpath = env_util::get("HOME") + "/.config/polybar/config";
-      if (!file_util::exists(confpath)) {
-        confpath = "";
-      }
+    } else {
+      confpath = file_util::get_config_path();
     }
     if (confpath.empty()) {
       throw application_error("Define configuration using --config=PATH");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     //==================================================
     // Load user configuration
     //==================================================
-    string confpath;
+    string confpath = "";
 
     // Make sure a bar name is passed in
     if (!cli->has(0)) {
@@ -106,11 +106,20 @@ int main(int argc, char** argv) {
 
     if (cli->has("config")) {
       confpath = cli->get("config");
-    } else if (env_util::has("XDG_CONFIG_HOME")) {
+    }
+    if (env_util::has("XDG_CONFIG_HOME") && confpath.empty()) {
       confpath = env_util::get("XDG_CONFIG_HOME") + "/polybar/config";
-    } else if (env_util::has("HOME")) {
+      if (!file_util::exists(confpath)) {
+        confpath = "";
+      }
+    }
+    if (env_util::has("HOME") && confpath.empty()) {
       confpath = env_util::get("HOME") + "/.config/polybar/config";
-    } else {
+      if (!file_util::exists(confpath)) {
+        confpath = "";
+      }
+    }
+    if (confpath.empty()) {
       throw application_error("Define configuration using --config=PATH");
     }
 

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -274,6 +274,26 @@ namespace file_util {
     }
     return ret;
   }
+
+  /*
+   * Search for polybar config and returns the path if found
+   */
+  string get_config_path() {
+    string confpath;
+    if (env_util::has("XDG_CONFIG_HOME")) {
+      confpath = env_util::get("XDG_CONFIG_HOME") + "/polybar/config";
+      if (exists(confpath)) {
+        return confpath;
+      }
+    }
+    if (env_util::has("HOME")) {
+      confpath = env_util::get("HOME") + "/.config/polybar/config";
+      if (exists(confpath)) {
+        return confpath;
+      }
+    }
+    return "";
+  }
 }  // namespace file_util
 
 POLYBAR_NS_END


### PR DESCRIPTION
**Description**

Today when polybar start it does the following configuration search:

1.  ` -c/--config ` parameter
2. `$XDG_CONFIG_HOME/polybar/config` , if the variable is set
3. `$HOME/polybar/config` , if the variable is set
4. Throw error

But it doesn't check if the file exists, this pull request solves that, so the new configuration search is:

1.  `-c/--config`  parameter (if specified)
2. `$XDG_CONFIG_HOME/polybar/config` , if the file exists (variable still being checked)
3. `$HOME/.config/polybar/config` , if the file exists (variable still being checked)
4. Throw error

**Solves**

This PR closes the issue [2016](https://github.com/polybar/polybar/issues/2016), this issue also ask for a change that makes a lot of sense but it'd be another PR:

move the example of config file from `.../doc/polybar/config` to `.../doc/polybar/examples/config` , that change need an update on wiki.