### PR TITLE
Update GitHub API deprecating authentication

### DIFF
--- a/include/modules/github.hpp
+++ b/include/modules/github.hpp
@@ -18,7 +18,6 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
     string get_format() const;
 
-
    private:
     void update_label(int);
     int get_number_of_notification();
@@ -30,11 +29,12 @@ namespace modules {
     label_t m_label{};
     label_t m_label_offline{};
     string m_api_url;
+    string m_user;
     string m_accesstoken{};
     unique_ptr<http_downloader> m_http{};
     bool m_empty_notifications{false};
     std::atomic<bool> m_offline{false};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/utils/http.hpp
+++ b/include/utils/http.hpp
@@ -10,7 +10,7 @@ class http_downloader {
   http_downloader(int connection_timeout = 5);
   ~http_downloader();
 
-  string get(const string& url);
+  string get(const string& url, const string& user = "", const string& password = "");
   long response_code();
 
  protected:
@@ -25,6 +25,6 @@ namespace http_util {
   decltype(auto) make_downloader(Args&&... args) {
     return factory_util::unique<http_downloader>(forward<Args>(args)...);
   }
-}
+}  // namespace http_util
 
 POLYBAR_NS_END

--- a/src/modules/github.cpp
+++ b/src/modules/github.cpp
@@ -17,6 +17,7 @@ namespace modules {
   github_module::github_module(const bar_settings& bar, string name_)
       : timer_module<github_module>(bar, move(name_)), m_http(http_util::make_downloader()) {
     m_accesstoken = m_conf.get(name(), "token");
+    m_user = m_conf.get(name(), "user", ""s);
     m_api_url = m_conf.get(name(), "api-url", "https://api.github.com/"s);
     if (m_api_url.back() != '/') {
       m_api_url += '/';
@@ -52,7 +53,12 @@ namespace modules {
   }
 
   string github_module::request() {
-    string content{m_http->get(m_api_url + "notifications?access_token=" + m_accesstoken)};
+    string content;
+    if (m_user.empty()) {
+      content = m_http->get(m_api_url + "notifications?access_token=" + m_accesstoken);
+    } else {
+      content = m_http->get(m_api_url + "notifications", m_user, m_accesstoken);
+    }
 
     long response_code{m_http->response_code()};
     switch (response_code) {

--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -1,10 +1,12 @@
+#include "utils/http.hpp"
+
 #include <curl/curl.h>
 #include <curl/easy.h>
+
 #include <sstream>
 
 #include "errors.hpp"
 #include "settings.hpp"
-#include "utils/http.hpp"
 
 POLYBAR_NS
 
@@ -23,10 +25,16 @@ http_downloader::~http_downloader() {
   curl_easy_cleanup(m_curl);
 }
 
-string http_downloader::get(const string& url) {
+string http_downloader::get(const string& url, const string& user, const string& password) {
   std::stringstream out{};
   curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &out);
+  if (!user.empty()) {
+    curl_easy_setopt(m_curl, CURLOPT_USERNAME, user.c_str());
+  }
+  if (!password.empty()) {
+    curl_easy_setopt(m_curl, CURLOPT_PASSWORD, password.c_str());
+  }
 
   auto res = curl_easy_perform(m_curl);
   if (res != CURLE_OK) {


### PR DESCRIPTION
**Description** 

The github module only authenticate by query string, and this method is deprecated:
https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters

There is no reason to remove it before the method stop working, so I've made possible to the user choose which authentication method he will use:

* The parameter token remain unchanged.
* If the parameter user is passed then the module will use the not deprecated method, passing user and token on the body of the requisition. Otherwise the module will use the deprecated method.

PS: Some of the files that I've worked on this PR was not on Polybar code style, and that makes some style updates.

**Solves**

This PR closes the issue [2002](https://github.com/polybar/polybar/issues/2002).

**Extra changes**

It's nice to update [this page](https://github.com/polybar/polybar/wiki/Module:-github) of Polybar wiki, here a [pastebin](https://pastebin.com/cqwFpBWn) with the suggested modification.