### PR TITLE
Allow viewing free memory via memory module

### DIFF
--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -8,6 +8,7 @@ POLYBAR_NS
 namespace modules {
   enum class memtype { NONE = 0, TOTAL, USED, FREE, SHARED, BUFFERS, CACHE, AVAILABLE };
 
+
   class memory_module : public timer_module<memory_module> {
    public:
     explicit memory_module(const bar_settings&, string);
@@ -31,6 +32,10 @@ namespace modules {
     progressbar_t m_bar_memfree;
     int m_perc_memused{0};
     int m_perc_memfree{0};
+    int m_perc_memavail{0};
+    int m_perc_memavailused{0};
+    int m_perc_memactualfree{0};
+    int m_perc_memactualfreeused{0};
     ramp_t m_ramp_memused;
     ramp_t m_ramp_memfree;
     progressbar_t m_bar_swapused;

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -52,6 +52,7 @@ namespace modules {
   }
 
   bool memory_module::update() {
+    unsigned long long kb_free{0ULL};
     unsigned long long kb_total{0ULL};
     unsigned long long kb_avail{0ULL};
     unsigned long long kb_swap_total{0ULL};
@@ -73,6 +74,7 @@ namespace modules {
         parsed[id] = value;
       }
 
+      kb_free = parsed["MemFree"];
       kb_total = parsed["MemTotal"];
       kb_swap_total = parsed["SwapTotal"];
       kb_swap_free = parsed["SwapFree"];
@@ -92,6 +94,10 @@ namespace modules {
 
     m_perc_memfree = math_util::percentage(kb_avail, kb_total);
     m_perc_memused = 100 - m_perc_memfree;
+    m_perc_memavail = math_util::percentage(kb_avail, kb_total);
+    m_perc_memavailused = 100 - m_perc_memavail;
+    m_perc_memactualfree = math_util::percentage(kb_free, kb_total);
+    m_perc_memactualfreeused = 100 - m_perc_memactualfree;
     m_perc_swap_free = math_util::percentage(kb_swap_free, kb_swap_total);
     m_perc_swap_used = 100 - m_perc_swap_free;
 
@@ -106,6 +112,10 @@ namespace modules {
       m_label->replace_token("%mb_total%", string_util::filesize_mb(kb_total, 0, m_bar.locale));
       m_label->replace_token("%percentage_used%", to_string(m_perc_memused));
       m_label->replace_token("%percentage_free%", to_string(m_perc_memfree));
+      m_label->replace_token("%percentage_available%", to_string(m_perc_memavail));
+      m_label->replace_token("%percentage_available_used%", to_string(m_perc_memavailused));
+      m_label->replace_token("%percentage_actualfree%", to_string(m_perc_memactualfree));
+      m_label->replace_token("%percentage_actualfree_used%", to_string(m_perc_memactualfreeused));
       m_label->replace_token("%percentage_swap_used%", to_string(m_perc_swap_used));
       m_label->replace_token("%percentage_swap_free%", to_string(m_perc_swap_free));
       m_label->replace_token("%mb_swap_total%", string_util::filesize_mb(kb_swap_total, 0, m_bar.locale));


### PR DESCRIPTION
Add labels to memory module that allow users to display both free and
available memory separately. Closes #2028.

Free memory is memory that is truly not being used, while available
memory includes memory that is technically being used but is readily
available for other processes.