### PR TITLE
feat(i3): Add label for separator between outputs

### DIFF
--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -34,12 +34,13 @@ namespace modules {
     };
 
     struct workspace {
-      explicit workspace(string name, enum state state_, label_t&& label)
-          : name(name), state(state_), label(forward<label_t>(label)) {}
+      explicit workspace(string name, string output, enum state state_, label_t&& label)
+          : name(name), output(output), state(state_), label(forward<label_t>(label)) {}
 
       operator bool();
 
       string name;
+      string output;
       enum state state;
       label_t label;
     };
@@ -82,6 +83,11 @@ namespace modules {
      * Separator that is inserted in between workspaces
      */
     label_t m_labelseparator;
+
+    /**
+     * Separator that is inserted in between outputs
+     */
+    label_t m_labeloutputseparator;
 
     bool m_click{true};
     bool m_scroll{true};

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -53,6 +53,7 @@ namespace modules {
     }
 
     m_labelseparator = load_optional_label(m_conf, name(), "label-separator", "");
+    m_labeloutputseparator = load_optional_label(m_conf, name(), "label-output-separator", "");
 
     m_icons = factory_util::shared<iconset>();
     m_icons->add(DEFAULT_WS_ICON, factory_util::shared<label>(m_conf.get(name(), DEFAULT_WS_ICON, ""s)));
@@ -168,7 +169,7 @@ namespace modules {
         label->replace_token("%name%", ws_name);
         label->replace_token("%icon%", icon->get());
         label->replace_token("%index%", to_string(ws->num));
-        m_workspaces.emplace_back(factory_util::unique<workspace>(ws->name, ws_state, move(label)));
+        m_workspaces.emplace_back(factory_util::unique<workspace>(ws->name, ws->output, ws_state, move(label)));
       }
 
       return true;
@@ -188,6 +189,7 @@ namespace modules {
       }
 
       bool first = true;
+      std::string lastoutput;
       for (auto&& ws : m_workspaces) {
         /*
          * The separator should only be inserted in between the workspaces, so
@@ -196,9 +198,14 @@ namespace modules {
         if(first) {
           first = false;
         }
+        else if (*m_labeloutputseparator && lastoutput != ws->output) {
+          builder->node(m_labeloutputseparator);
+        }
         else if (*m_labelseparator) {
           builder->node(m_labelseparator);
         }
+
+        lastoutput = ws->output;
 
         if (m_click) {
           builder->cmd(mousebtn::LEFT, string{EVENT_CLICK} + ws->name);


### PR DESCRIPTION
This PR adds the option for a separator between workspaces on different outputs:

![screenshot](https://user-images.githubusercontent.com/1228306/79678637-d8122c00-81fd-11ea-8570-4e137a513aac.png)
