### PR TITLE
module::network: Ability to change speed unit text (B/s)

### DIFF
--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -82,14 +82,14 @@ namespace net {
 
     string ip() const;
     string ip6() const;
-    string downspeed(int minwidth = 3) const;
-    string upspeed(int minwidth = 3) const;
+    string downspeed(int minwidth = 3, const string& unit = "B/s") const;
+    string upspeed(int minwidth = 3, const string& unit = "B/s") const;
     void set_unknown_up(bool unknown = true);
 
    protected:
     void check_tuntap_or_bridge();
     bool test_interface() const;
-    string format_speedrate(float bytes_diff, int minwidth) const;
+    string format_speedrate(float bytes_diff, int minwidth, const string& unit) const;
     void query_ip6();
 
     const logger& m_log;

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -52,6 +52,7 @@ namespace modules {
     int m_udspeed_minwidth{0};
     bool m_accumulate{false};
     bool m_unknown_up{false};
+    string m_udspeed_unit{"B/s"};
   };
 }
 

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -153,17 +153,17 @@ namespace net {
   /**
    * Get download speed rate
    */
-  string network::downspeed(int minwidth) const {
+  string network::downspeed(int minwidth, const string& unit) const {
     float bytes_diff = m_status.current.received - m_status.previous.received;
-    return format_speedrate(bytes_diff, minwidth);
+    return format_speedrate(bytes_diff, minwidth, unit);
   }
 
   /**
    * Get upload speed rate
    */
-  string network::upspeed(int minwidth) const {
+  string network::upspeed(int minwidth, const string& unit) const {
     float bytes_diff = m_status.current.transmitted - m_status.previous.transmitted;
-    return format_speedrate(bytes_diff, minwidth);
+    return format_speedrate(bytes_diff, minwidth, unit);
   }
 
   /**
@@ -223,14 +223,14 @@ namespace net {
   /**
    * Format up- and download speed
    */
-  string network::format_speedrate(float bytes_diff, int minwidth) const {
+  string network::format_speedrate(float bytes_diff, int minwidth, const string& unit) const {
     // Get time difference in seconds as a float
     const std::chrono::duration<float> duration = m_status.current.time - m_status.previous.time;
     float time_diff = duration.count();
     float speedrate = bytes_diff / time_diff;
 
-    vector<string> suffixes{"GB", "MB"};
-    string suffix{"KB"};
+    vector<string> suffixes{"G", "M"};
+    string suffix{"K"};
 
     while ((speedrate /= 1000) > 999) {
       suffix = suffixes.back();
@@ -238,7 +238,7 @@ namespace net {
     }
 
     return sstream() << std::setw(minwidth) << std::setfill(' ') << std::setprecision(0) << std::fixed << speedrate
-                     << " " << suffix << "/s";
+                     << " " << suffix << unit;
   }
 
   // }}}

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -21,7 +21,7 @@ namespace modules {
     m_accumulate = m_conf.get(name(), "accumulate-stats", m_accumulate);
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
     m_unknown_up = m_conf.get<bool>(name(), "unknown-as-up", false);
-    m_udspeed_unit = m_conf.get<string>(name(), "udspeed-unit", m_udspeed_unit);
+    m_udspeed_unit = m_conf.get<string>(name(), "speed-unit", m_udspeed_unit);
 
     m_conf.warn_deprecated(name(), "udspeed-minwidth", "%downspeed:min:max% and %upspeed:min:max%");
 

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -21,6 +21,7 @@ namespace modules {
     m_accumulate = m_conf.get(name(), "accumulate-stats", m_accumulate);
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
     m_unknown_up = m_conf.get<bool>(name(), "unknown-as-up", false);
+    m_udspeed_unit = m_conf.get<string>(name(), "udspeed-unit", m_udspeed_unit);
 
     m_conf.warn_deprecated(name(), "udspeed-minwidth", "%downspeed:min:max% and %upspeed:min:max%");
 
@@ -109,8 +110,8 @@ namespace modules {
       m_counter = 0;
     }
 
-    auto upspeed = network->upspeed(m_udspeed_minwidth);
-    auto downspeed = network->downspeed(m_udspeed_minwidth);
+    auto upspeed = network->upspeed(m_udspeed_minwidth, m_udspeed_unit);
+    auto downspeed = network->downspeed(m_udspeed_minwidth, m_udspeed_unit);
 
     // Update label contents
     const auto replace_tokens = [&](label_t& label) {


### PR DESCRIPTION
I feel like having `B/s` at the end of the speed value is generally not necessary and takes too much space.

This pull request adds a `udspeed-unit` variable to be able to display the unit text in other formats. By default the value is `B/s` to keep the old behaviour. The K/M/G suffixes are still hardcoded and are displayed just before the unit.
Note: this is a "text-only" feature, setting `speed-unit = "b/s` won't change the output value from bytes per second to bits per second.

Examples:
`speed-unit = ""` will display speeds like: `128 ` `42K` `64G`
`speed-unit = "Bytes/sec"` will display speeds like: `128 Bytes/sec` `42KBytes/sec` `64GBytes/sec`