### PR TITLE
Add low and critical battery states

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -13,6 +13,8 @@ namespace modules {
       CHARGING,
       DISCHARGING,
       FULL,
+      LOW,
+      CRITICAL
     };
 
     enum class value {
@@ -66,6 +68,8 @@ namespace modules {
     static constexpr const char* FORMAT_CHARGING{"format-charging"};
     static constexpr const char* FORMAT_DISCHARGING{"format-discharging"};
     static constexpr const char* FORMAT_FULL{"format-full"};
+    static constexpr const char* FORMAT_LOW{"format-low"};
+    static constexpr const char* FORMAT_CRITICAL{"format-critical"};
 
     static constexpr const char* TAG_ANIMATION_CHARGING{"<animation-charging>"};
     static constexpr const char* TAG_ANIMATION_DISCHARGING{"<animation-discharging>"};
@@ -74,6 +78,8 @@ namespace modules {
     static constexpr const char* TAG_LABEL_CHARGING{"<label-charging>"};
     static constexpr const char* TAG_LABEL_DISCHARGING{"<label-discharging>"};
     static constexpr const char* TAG_LABEL_FULL{"<label-full>"};
+    static constexpr const char* TAG_LABEL_LOW{"<label-low>"};
+    static constexpr const char* TAG_LABEL_CRITICAL{"<label-critical>"};
 
     static const size_t SKIP_N_UNCHANGED{3_z};
 
@@ -85,6 +91,8 @@ namespace modules {
     label_t m_label_charging;
     label_t m_label_discharging;
     label_t m_label_full;
+    label_t m_label_low;
+    label_t m_label_critical;
     animation_t m_animation_charging;
     animation_t m_animation_discharging;
     progressbar_t m_bar_capacity;
@@ -100,6 +108,8 @@ namespace modules {
     int m_percentage{0};
 
     int m_fullat{100};
+    int m_lowat{30};
+    int m_critat{10};
     string m_timeformat;
     size_t m_unchanged{SKIP_N_UNCHANGED};
     chrono::duration<double> m_interval{};


### PR DESCRIPTION
Use `low-at` and `crit-at` configuration variables to control thresholds. Set to 30% and 10% respectively by default.