### PR TITLE
Release 3.4.3

### DIFF
--- a/include/utils/socket.hpp
+++ b/include/utils/socket.hpp
@@ -40,9 +40,9 @@ namespace socket_util {
    *   conn->receive(...);
    * \endcode
    */
-  auto make_unix_connection = [](string&& path) -> unique_ptr<unix_connection> {
+  inline unique_ptr<unix_connection> make_unix_connection(string&& path) {
     return factory_util::unique<unix_connection>(forward<string>(path));
-  };
+  }
 }
 
 POLYBAR_NS_END

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
 # Polybar version information
 # Update this on every release
 # This is used to create the version string if a git repo is not available
-3.4.2
+3.4.3


### PR DESCRIPTION
Fixes: GCC 10 Compilation (#2098), see #2097

EDIT: The draft for the github release is [here](https://github.com/polybar/polybar/releases/tag/untagged-0872a2a0acf42997f414)

I have only put this fix into the release because it gets more and more cumbersome to backport fixes into the release branch, the more fixes there are. We should release 3.5.0 fairly soon and then switch to a new branching model ASAP.