### PR TITLE
feat(bspwm): Add dimmed monitor label

### DIFF
--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -74,6 +74,7 @@ namespace modules {
     map<mode, label_t> m_modelabels;
     map<unsigned int, label_t> m_statelabels;
     label_t m_monitorlabel;
+    label_t m_dimmed_monitorlabel;
     iconset_t m_icons;
 
     /**

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -63,6 +63,7 @@ namespace modules {
 
     if (m_formatter->has(TAG_LABEL_MONITOR)) {
       m_monitorlabel = load_optional_label(m_conf, name(), "label-monitor", DEFAULT_MONITOR_LABEL);
+      m_dimmed_monitorlabel = load_optional_label(m_conf, name(), "label-dimmed-monitor");
     }
 
     if (m_formatter->has(TAG_LABEL_STATE)) {
@@ -234,6 +235,11 @@ namespace modules {
 
         if (m_monitorlabel) {
           m_monitors.back()->label = m_monitorlabel->clone();
+
+          if (tag[0] == 'm') {
+            m_monitors.back()->label->replace_defined_values(m_dimmed_monitorlabel);
+          }
+
           m_monitors.back()->label->replace_token("%name%", value);
         }
       }


### PR DESCRIPTION
This commit adds `label-dimmed-monitor` for monitors that are not focused. Defined values override those from `label-monitor` to retain the previous behavior.

For instance, the following config can be used to assign a specific color to unfocused monitors while having the same padding:

```ini
label-monitor-foreground = ${monitor-fg-color}
label-monitor-padding = 1
label-dimmed-monitor-foreground = ${monitor-fg-color-alt}
```