### PR TITLE
Allow compilation and execution without composite extension enabled

### DIFF
--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -101,7 +101,11 @@ class renderer
   const bar_settings& m_bar;
   std::shared_ptr<bg_slice> m_background;
 
-  int m_depth{32};
+  #if WITH_XCOMPOSITE
+    int m_depth{32};
+  #else
+    int m_depth{24};
+  #endif
   xcb_window_t m_window;
   xcb_colormap_t m_colormap;
   xcb_visualtype_t* m_visual;

--- a/include/x11/extensions/composite.hpp
+++ b/include/x11/extensions/composite.hpp
@@ -2,10 +2,6 @@
 
 #include "settings.hpp"
 
-#if not WITH_XCOMPOSITE
-#error "X Composite extension is disabled..."
-#endif
-
 #include <xcb/composite.h>
 #include <xpp/proto/composite.hpp>
 

--- a/src/x11/extensions/composite.cpp
+++ b/src/x11/extensions/composite.cpp
@@ -9,11 +9,13 @@ namespace composite_util {
    * Query for the XCOMPOSITE extension
    */
   void query_extension(connection& conn) {
-    conn.composite().query_version(XCB_COMPOSITE_MAJOR_VERSION, XCB_COMPOSITE_MINOR_VERSION);
+    #if WITH_XCOMPOSITE
+        conn.composite().query_version(XCB_COMPOSITE_MAJOR_VERSION, XCB_COMPOSITE_MINOR_VERSION);
 
-    if (!conn.extension<xpp::composite::extension>()->present) {
-      throw application_error("Missing X extension: Composite");
-    }
+        if (!conn.extension<xpp::composite::extension>()->present) {
+          throw application_error("Missing X extension: Composite");
+        }
+    #endif
   }
 }
 


### PR DESCRIPTION
I didn't want to move too many things around, so this is compile time right now, requiring -DWITH_XCOMPOSITE:BOOL=FALSE