### PR TITLE
refactor: Deprecate throttle-input-for setting

### DIFF
--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -132,16 +132,6 @@ class controller
   std::chrono::milliseconds m_swallow_update{10};
 
   /**
-   * \brief Time to throttle input events
-   */
-  std::chrono::milliseconds m_swallow_input{30};
-
-  /**
-   * \brief Time of last handled input event
-   */
-  std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds> m_lastinput;
-
-  /**
    * \brief Input data
    */
   string m_inputdata;


### PR DESCRIPTION
If an input is enqueued as a response to an input, the new input will be
swallowed because it will likely be enqueued less than 30ms after the
original event.
This is not something that is an issue right now but it is required to
finish #1907 where, in order to close the menu after a click, the menu
module gets an exec action that closes the menu and adds a command to
the event queue.

The setting also isn't too useful since it will just break polybar input
handling if inputs arrive too fast instead of (possibly) slowing down
the bar.