### PR TITLE
fix(timer_module): sleep until next full interval

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -37,7 +37,7 @@ namespace drawtypes {
   using animation_t = shared_ptr<animation>;
   class iconset;
   using iconset_t = shared_ptr<iconset>;
-}
+}  // namespace drawtypes
 
 class builder;
 class config;
@@ -130,6 +130,8 @@ namespace modules {
     void broadcast();
     void idle();
     void sleep(chrono::duration<double> duration);
+    template <class Clock, class Duration>
+    void sleep_until(chrono::time_point<Clock, Duration> point);
     void wakeup();
     string get_format() const;
     string get_output();
@@ -160,6 +162,6 @@ namespace modules {
   };
 
   // }}}
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -117,6 +117,15 @@ namespace modules {
   }
 
   template <typename Impl>
+  template <class Clock, class Duration>
+  void module<Impl>::sleep_until(chrono::time_point<Clock, Duration> point) {
+    if (running()) {
+      std::unique_lock<std::mutex> lck(m_sleeplock);
+      m_sleephandler.wait_until(lck, point);
+    }
+  }
+
+  template <typename Impl>
   void module<Impl>::wakeup() {
     m_log.trace("%s: Release sleep lock", name());
     m_sleephandler.notify_all();


### PR DESCRIPTION
Any timer_module based module would sleep for the set interval and then
continue running. Depending on the start time of polybar this
sleep pattern might not be aligned, which causes such modules to always
update in a shifted manner.
Consider the date module as an example. If the update interval is set to
60 seconds and polybar was started at 13:37:37, polybar would update the
clock at 13:38:37, 13:39:37 and so on.
To make matters worse, if a module would perform lengthy checks this
interval might drift over time, causing even more inconsistent updating.

This patch extends the base module with a sleep_until method that calls
the corresponding function on the sleephandler. Additionally the
timer_module is extended to compute the remaining time until the next
interval passes and sleep accordingly.

Closes #2064

Co-developed-by: Dominik Töllner <dominik.toellner@stud.uni-hannover.de>