### PR TITLE
feat(memory): Add different formats for different memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /tags
 /compile_commands.json
 /config
+/.clangd
+/.vscode
 *.bak
 *.pyc
 *.swp

--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -7,16 +7,20 @@ POLYBAR_NS
 
 namespace modules {
   enum class memtype { NONE = 0, TOTAL, USED, FREE, SHARED, BUFFERS, CACHE, AVAILABLE };
+  enum class mem_state { NORMAL = 0, WARN, CRITICAL };
 
   class memory_module : public timer_module<memory_module> {
    public:
     explicit memory_module(const bar_settings&, string);
 
     bool update();
+    string get_format() const;
     bool build(builder* builder, const string& tag) const;
 
    private:
     static constexpr const char* TAG_LABEL{"<label>"};
+    static constexpr const char* TAG_LABEL_WARN{"<label-warn>"};
+    static constexpr const char* TAG_LABEL_CRITICAL{"<label-critical>"};
     static constexpr const char* TAG_BAR_USED{"<bar-used>"};
     static constexpr const char* TAG_BAR_FREE{"<bar-free>"};
     static constexpr const char* TAG_RAMP_USED{"<ramp-used>"};
@@ -25,10 +29,14 @@ namespace modules {
     static constexpr const char* TAG_BAR_SWAP_FREE{"<bar-swap-free>"};
     static constexpr const char* TAG_RAMP_SWAP_USED{"<ramp-swap-used>"};
     static constexpr const char* TAG_RAMP_SWAP_FREE{"<ramp-swap-free>"};
+    static constexpr const char* FORMAT_WARN{"format-warn"};
+    static constexpr const char* FORMAT_CRITICAL{"format-critical"};
 
-    label_t m_label;
+    map<mem_state, label_t> m_label;
     progressbar_t m_bar_memused;
     progressbar_t m_bar_memfree;
+    int m_mem_atwarning;
+    int m_mem_atcritical;
     int m_perc_memused{0};
     int m_perc_memfree{0};
     ramp_t m_ramp_memused;
@@ -40,6 +48,6 @@ namespace modules {
     ramp_t m_ramp_swapused;
     ramp_t m_ramp_swapfree;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -1,3 +1,5 @@
+#include "modules/memory.hpp"
+
 #include <fstream>
 #include <iomanip>
 #include <istream>
@@ -5,10 +7,8 @@
 #include "drawtypes/label.hpp"
 #include "drawtypes/progressbar.hpp"
 #include "drawtypes/ramp.hpp"
-#include "modules/memory.hpp"
-#include "utils/math.hpp"
-
 #include "modules/meta/base.inl"
+#include "utils/math.hpp"
 
 POLYBAR_NS
 
@@ -17,9 +17,18 @@ namespace modules {
 
   memory_module::memory_module(const bar_settings& bar, string name_) : timer_module<memory_module>(bar, move(name_)) {
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
+    m_mem_atwarning = m_conf.get(name(), "warn-at", 60);
+    m_mem_atcritical = m_conf.get(name(), "critical-at", 90);
 
-    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_USED, TAG_BAR_FREE, TAG_RAMP_USED, TAG_RAMP_FREE,
-                                                 TAG_BAR_SWAP_USED, TAG_BAR_SWAP_FREE, TAG_RAMP_SWAP_USED, TAG_RAMP_SWAP_FREE});
+    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL,
+        {TAG_LABEL, TAG_BAR_USED, TAG_BAR_FREE, TAG_RAMP_USED, TAG_RAMP_FREE, TAG_BAR_SWAP_USED, TAG_BAR_SWAP_FREE,
+            TAG_RAMP_SWAP_USED, TAG_RAMP_SWAP_FREE});
+    m_formatter->add(FORMAT_WARN, TAG_LABEL_WARN,
+        {TAG_LABEL_WARN, TAG_BAR_USED, TAG_BAR_FREE, TAG_RAMP_USED, TAG_RAMP_FREE, TAG_BAR_SWAP_USED, TAG_BAR_SWAP_FREE,
+            TAG_RAMP_SWAP_USED, TAG_RAMP_SWAP_FREE});
+    m_formatter->add(FORMAT_CRITICAL, TAG_LABEL_CRITICAL,
+        {TAG_LABEL_CRITICAL, TAG_BAR_USED, TAG_BAR_FREE, TAG_RAMP_USED, TAG_RAMP_FREE, TAG_BAR_SWAP_USED,
+            TAG_BAR_SWAP_FREE, TAG_RAMP_SWAP_USED, TAG_RAMP_SWAP_FREE});
 
     if (m_formatter->has(TAG_BAR_USED)) {
       m_bar_memused = load_progressbar(m_bar, m_conf, name(), TAG_BAR_USED);
@@ -27,10 +36,10 @@ namespace modules {
     if (m_formatter->has(TAG_BAR_FREE)) {
       m_bar_memfree = load_progressbar(m_bar, m_conf, name(), TAG_BAR_FREE);
     }
-    if(m_formatter->has(TAG_RAMP_USED)) {
+    if (m_formatter->has(TAG_RAMP_USED)) {
       m_ramp_memused = load_ramp(m_conf, name(), TAG_RAMP_USED);
     }
-    if(m_formatter->has(TAG_RAMP_FREE)) {
+    if (m_formatter->has(TAG_RAMP_FREE)) {
       m_ramp_memfree = load_ramp(m_conf, name(), TAG_RAMP_FREE);
     }
     if (m_formatter->has(TAG_BAR_SWAP_USED)) {
@@ -39,15 +48,21 @@ namespace modules {
     if (m_formatter->has(TAG_BAR_SWAP_FREE)) {
       m_bar_swapfree = load_progressbar(m_bar, m_conf, name(), TAG_BAR_SWAP_FREE);
     }
-    if(m_formatter->has(TAG_RAMP_SWAP_USED)) {
+    if (m_formatter->has(TAG_RAMP_SWAP_USED)) {
       m_ramp_swapused = load_ramp(m_conf, name(), TAG_RAMP_SWAP_USED);
     }
-    if(m_formatter->has(TAG_RAMP_SWAP_FREE)) {
+    if (m_formatter->has(TAG_RAMP_SWAP_FREE)) {
       m_ramp_swapfree = load_ramp(m_conf, name(), TAG_RAMP_SWAP_FREE);
     }
 
     if (m_formatter->has(TAG_LABEL)) {
-      m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%percentage_used%%");
+      m_label[mem_state::NORMAL] = load_optional_label(m_conf, name(), TAG_LABEL, "%percentage_used%%");
+    }
+    if (m_formatter->has(TAG_LABEL_WARN)) {
+      m_label[mem_state::WARN] = load_optional_label(m_conf, name(), TAG_LABEL_WARN, "%percentage_used%%");
+    }
+    if (m_formatter->has(TAG_LABEL_CRITICAL)) {
+      m_label[mem_state::CRITICAL] = load_optional_label(m_conf, name(), TAG_LABEL_CRITICAL, "%percentage_used%%");
     }
   }
 
@@ -66,7 +81,8 @@ namespace modules {
         size_t sep_off = line.find(':');
         size_t value_off = line.find_first_of("123456789", sep_off);
 
-        if (sep_off == std::string::npos || value_off == std::string::npos) continue;
+        if (sep_off == std::string::npos || value_off == std::string::npos)
+          continue;
 
         std::string id = line.substr(0, sep_off);
         unsigned long long int value = std::strtoull(&line[value_off], nullptr, 10);
@@ -78,7 +94,8 @@ namespace modules {
       kb_swap_free = parsed["SwapFree"];
 
       // newer kernels (3.4+) have an accurate available memory field,
-      // see https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
+      // see
+      // https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
       // for details
       if (parsed.count("MemAvailable")) {
         kb_avail = parsed["MemAvailable"];
@@ -96,27 +113,40 @@ namespace modules {
     m_perc_swap_used = 100 - m_perc_swap_free;
 
     // replace tokens
-    if (m_label) {
-      m_label->reset_tokens();
-      m_label->replace_token("%gb_used%", string_util::filesize_gb(kb_total - kb_avail, 2, m_bar.locale));
-      m_label->replace_token("%gb_free%", string_util::filesize_gb(kb_avail, 2, m_bar.locale));
-      m_label->replace_token("%gb_total%", string_util::filesize_gb(kb_total, 2, m_bar.locale));
-      m_label->replace_token("%mb_used%", string_util::filesize_mb(kb_total - kb_avail, 0, m_bar.locale));
-      m_label->replace_token("%mb_free%", string_util::filesize_mb(kb_avail, 0, m_bar.locale));
-      m_label->replace_token("%mb_total%", string_util::filesize_mb(kb_total, 0, m_bar.locale));
-      m_label->replace_token("%percentage_used%", to_string(m_perc_memused));
-      m_label->replace_token("%percentage_free%", to_string(m_perc_memfree));
-      m_label->replace_token("%percentage_swap_used%", to_string(m_perc_swap_used));
-      m_label->replace_token("%percentage_swap_free%", to_string(m_perc_swap_free));
-      m_label->replace_token("%mb_swap_total%", string_util::filesize_mb(kb_swap_total, 0, m_bar.locale));
-      m_label->replace_token("%mb_swap_free%", string_util::filesize_mb(kb_swap_free, 0, m_bar.locale));
-      m_label->replace_token("%mb_swap_used%", string_util::filesize_mb(kb_swap_total - kb_swap_free, 0, m_bar.locale));
-      m_label->replace_token("%gb_swap_total%", string_util::filesize_gb(kb_swap_total, 2, m_bar.locale));
-      m_label->replace_token("%gb_swap_free%", string_util::filesize_gb(kb_swap_free, 2, m_bar.locale));
-      m_label->replace_token("%gb_swap_used%", string_util::filesize_gb(kb_swap_total - kb_swap_free, 2, m_bar.locale));
+    auto states = {mem_state::NORMAL, mem_state::WARN, mem_state::CRITICAL};
+    for (auto memory_state : states) {
+      if (m_label[memory_state]) {
+        auto label = m_label.at(memory_state);
+        label->reset_tokens();
+        label->replace_token("%gb_used%", string_util::filesize_gb(kb_total - kb_avail, 2, m_bar.locale));
+        label->replace_token("%gb_free%", string_util::filesize_gb(kb_avail, 2, m_bar.locale));
+        label->replace_token("%gb_total%", string_util::filesize_gb(kb_total, 2, m_bar.locale));
+        label->replace_token("%mb_used%", string_util::filesize_mb(kb_total - kb_avail, 0, m_bar.locale));
+        label->replace_token("%mb_free%", string_util::filesize_mb(kb_avail, 0, m_bar.locale));
+        label->replace_token("%mb_total%", string_util::filesize_mb(kb_total, 0, m_bar.locale));
+        label->replace_token("%percentage_used%", to_string(m_perc_memused));
+        label->replace_token("%percentage_free%", to_string(m_perc_memfree));
+        label->replace_token("%percentage_swap_used%", to_string(m_perc_swap_used));
+        label->replace_token("%percentage_swap_free%", to_string(m_perc_swap_free));
+        label->replace_token("%mb_swap_total%", string_util::filesize_mb(kb_swap_total, 0, m_bar.locale));
+        label->replace_token("%mb_swap_free%", string_util::filesize_mb(kb_swap_free, 0, m_bar.locale));
+        label->replace_token("%mb_swap_used%", string_util::filesize_mb(kb_swap_total - kb_swap_free, 0, m_bar.locale));
+        label->replace_token("%gb_swap_total%", string_util::filesize_gb(kb_swap_total, 2, m_bar.locale));
+        label->replace_token("%gb_swap_free%", string_util::filesize_gb(kb_swap_free, 2, m_bar.locale));
+        label->replace_token("%gb_swap_used%", string_util::filesize_gb(kb_swap_total - kb_swap_free, 2, m_bar.locale));
+      }
     }
-
     return true;
+  }
+
+  string memory_module::get_format() const {
+    if (m_perc_memused >= m_mem_atcritical) {
+      return FORMAT_CRITICAL;
+    } else if (m_perc_memused >= m_mem_atwarning) {
+      return FORMAT_WARN;
+    } else {
+      return DEFAULT_FORMAT;
+    }
   }
 
   bool memory_module::build(builder* builder, const string& tag) const {
@@ -125,7 +155,11 @@ namespace modules {
     } else if (tag == TAG_BAR_FREE) {
       builder->node(m_bar_memfree->output(m_perc_memfree));
     } else if (tag == TAG_LABEL) {
-      builder->node(m_label);
+      builder->node(m_label.at(mem_state::NORMAL));
+    } else if (tag == TAG_LABEL_WARN) {
+      builder->node(m_label.at(mem_state::WARN));
+    } else if (tag == TAG_LABEL_CRITICAL) {
+      builder->node(m_label.at(mem_state::CRITICAL));
     } else if (tag == TAG_RAMP_FREE) {
       builder->node(m_ramp_memfree->get_by_percentage(m_perc_memfree));
     } else if (tag == TAG_RAMP_USED) {
@@ -143,6 +177,6 @@ namespace modules {
     }
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END


### PR DESCRIPTION
Added and implement these options for #2141 
- `warn-at` - to specify percentage of used memory on which choose warn
- `critical-at` - to specify critical percentage of used memory
- `<label-warn>`
- ` format-warn`
- `<label-critical>`
- `format-critical`

I tried to mimic temperature module behaviour for different temperature level, tell me if I can somehow improve code.
(For example, I don't understand why we need to replace tokens for all labels even when there is only one used. But it works :D )