### PR TITLE
Disable modernize-use-trailing-return-type warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,7 @@ Checks: '
         modernize-*,
         -modernize-raw-string-literal,
         -modernize-use-bool-literals,
+        -modernize-use-trailing-return-type,
         -readability-implicit-bool-cast,
         -readability-else-after-return,
         -readability-named-parameter,


### PR DESCRIPTION
This disables clang-tidy's modernize-use-trailing-return-type warning.