### PR TITLE
fix(doc): Set SPHINX_BUILD in standalone doc builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: focal
 language: cpp
 
 env:
@@ -21,7 +21,7 @@ addons:
         - libxcb-image0-dev
         - libxcb-randr0-dev
         - libxcb-util0-dev
-        - python-xcbgen
+        - python3-xcbgen
         - xcb-proto
       - &optional_deps
         - libxcb-xkb-dev

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 # Only used if documentation is built on its own
 project(polybar-doc NONE)
 
+if(NOT SPHINX_BUILD)
+  set(SPHINX_BUILD "sphinx-build")
+endif()
+
 set(SPHINX_FLAGS "" CACHE STRING "Flags to pass to sphinx-build")
 separate_arguments(sphinx_flags UNIX_COMMAND "${SPHINX_FLAGS}")
 


### PR DESCRIPTION
If we build only the documentation by invoking `cmake` on the `doc`
folder, the `SPHINX_BUILD` variable is not set and instead of

```
sphinx-build -b html ...
```

it will just execute

```
-b html ...
```

This produces an error but doesn't fail the build because apparently if
the command starts with a dash an error is non-fatal.

Fixes #2191