### PR TITLE
refactor(config): Throw missing section error

### DIFF
--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -84,7 +84,10 @@ class config {
   template <typename T = string>
   T get(const string& section, const string& key) const {
     auto it = m_sections.find(section);
-    if (it == m_sections.end() || it->second.find(key) == it->second.end()) {
+    if (it == m_sections.end()) {
+      throw key_error("Missing section \"" + section + "\"");
+    }
+    if (it->second.find(key) == it->second.end()) {
       throw key_error("Missing parameter \"" + section + "." + key + "\"");
     }
     return dereference<T>(section, key, it->second.at(key), convert<T>(string{it->second.at(key)}));


### PR DESCRIPTION
Makes error messages less confusing if for some reason a key in an
non-existent section is requested.