### PR TITLE
Add support for keyword include-directory

### DIFF
--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -109,6 +109,7 @@ namespace file_util {
   vector<string> glob(string pattern);
   const string expand(const string& path);
   string get_config_path();
+  vector<string> list_files(const string& dirname);
 
   template <typename... Args>
   decltype(auto) make_file_descriptor(Args&&... args) {

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -144,6 +144,13 @@ void config_parser::parse_file(const string& file, file_list path) {
 
     if (!line.is_header && line.key == "include-file") {
       parse_file(file_util::expand(line.value), path);
+    } else if (!line.is_header && line.key == "include-directory") {
+      const string expanded_path = file_util::expand(line.value);
+      vector<string> file_list = file_util::list_files(expanded_path);
+      sort(file_list.begin(), file_list.end());
+      for (const auto& filename : file_list) {
+        parse_file(expanded_path + "/" + filename, path);
+      }
     } else {
       m_lines.push_back(line);
     }

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -1,5 +1,6 @@
 #include "utils/file.hpp"
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <glob.h>
 #include <sys/stat.h>
@@ -293,6 +294,27 @@ namespace file_util {
       }
     }
     return "";
+  }
+
+  /**
+   * Return a list of file names in a directory.
+   */
+  vector<string> list_files(const string& dirname) {
+    vector<string> files;
+    DIR* dir;
+    if ((dir = opendir(dirname.c_str())) != NULL) {
+      struct dirent* ent;
+      while ((ent = readdir(dir)) != NULL) {
+        // Type can be unknown for filesystems that do not support d_type
+        if ((ent->d_type & DT_REG) ||
+            ((ent->d_type & DT_UNKNOWN) && strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0)) {
+          files.push_back(ent->d_name);
+        }
+      }
+      closedir(dir);
+      return files;
+    }
+    throw system_error("Failed to open directory stream for " + dirname);
   }
 }  // namespace file_util
 


### PR DESCRIPTION
Adds `include-directory` keyword which receives as an argument a path to a directory. This keyword allows the importing of all regular files included in the given directory.
```
include-directory = /path/to/directory
```
Closes #1946