### PR TITLE
Temperature module, ramp drawstyle uses wrong icon for temperatures near base and warn temperatures

### DIFF
--- a/include/drawtypes/ramp.hpp
+++ b/include/drawtypes/ramp.hpp
@@ -16,6 +16,7 @@ namespace drawtypes {
     void add(label_t&& icon);
     label_t get(size_t index);
     label_t get_by_percentage(float percentage);
+    label_t get_by_percentage_with_borders(float percentage);
     operator bool();
 
    protected:

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -24,7 +24,7 @@ namespace drawtypes {
   }
 
   ramp::operator bool() {
-    return m_icons.size() >= 2;
+    return !m_icons.empty();
   }
 
   /**

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -19,8 +19,16 @@ namespace drawtypes {
   }
 
   label_t ramp::get_by_percentage_with_borders(float percentage) {
-    size_t index = percentage * (m_icons.size() - 2) / 100.0f + 1;
-    return m_icons[math_util::cap<size_t>(index, 0, m_icons.size() - 1)];
+    size_t index;
+    if (percentage <= 0.0f) {
+      index = 0;
+    } else if (percentage >= 100.0f) {
+      index = m_icons.size() - 1;
+    } else {
+      size_t index = percentage * (m_icons.size() - 2) / 100.0f + 1;
+      index = math_util::cap<size_t>(index, 0, m_icons.size() - 1);
+    }
+    return m_icons[index];
   }
 
   ramp::operator bool() {

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -25,7 +25,7 @@ namespace drawtypes {
     } else if (percentage >= 100.0f) {
       index = m_icons.size() - 1;
     } else {
-      size_t index = percentage * (m_icons.size() - 2) / 100.0f + 1;
+      index = percentage * (m_icons.size() - 2) / 100.0f + 1;
       index = math_util::cap<size_t>(index, 0, m_icons.size() - 1);
     }
     return m_icons[index];

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -18,6 +18,11 @@ namespace drawtypes {
     return m_icons[math_util::cap<size_t>(index, 0, m_icons.size() - 1)];
   }
 
+  label_t ramp::get_by_percentage_with_borders(float percentage) {
+    size_t index = percentage * (m_icons.size() - 2) / 100.0f + 1;
+    return m_icons[math_util::cap<size_t>(index, 0, m_icons.size() - 1)];
+  }
+
   ramp::operator bool() {
     return !m_icons.empty();
   }

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -53,7 +53,7 @@ namespace modules {
   bool temperature_module::update() {
     m_temp = std::strtol(file_util::contents(m_path).c_str(), nullptr, 10) / 1000.0f + 0.5f;
     int temp_f = floor(((1.8 * m_temp) + 32) + 0.5);
-    m_perc = math_util::cap(math_util::percentage(m_temp, m_tempbase, m_tempwarn), 0, 100);
+    m_perc = math_util::unbounded_percentage(m_temp, m_tempbase, m_tempwarn);
 
     string temp_c_string = to_string(m_temp);
     string temp_f_string = to_string(temp_f);
@@ -97,7 +97,7 @@ namespace modules {
     } else if (tag == TAG_LABEL_WARN) {
       builder->node(m_label.at(temp_state::WARN));
     } else if (tag == TAG_RAMP) {
-      builder->node(m_ramp->get_by_percentage(m_perc));
+      builder->node(m_ramp->get_by_percentage_with_borders(m_perc));
     } else {
       return false;
     }


### PR DESCRIPTION
## Bug Description

**Expected behavior**
In the Temperature module [documentation](https://github.com/polybar/polybar/wiki/Module:-temperature), the ramp settings says:

> The icon selection will range from `base-temperature` to `warn-temperature`,
> temperatures above `warn-temperature` will use the last icon
> and temperatures below `base-temperature` will use `ramp-0`

This leads the user to think that the last icon is _only_ used for temperatures above warn-temperature, and likewise ramp-0 for temperatures below base-temperature.

**Actual behavior**

The the last icon is actually used for temperatures slightly below warn-temperature, and ramp-0 for temperatures slightly above base-temperature. This disrupts the style of the module ([example](https://imgur.com/a/IX9kKIQ)).

## Reproduction

Using this module and font-awesome:

```
[module/temp0]
type = internal/temperature
thermal-zone = 0
base-temperature = 40
warn-temperature = 80

format = <ramp><label>
format-warn = <ramp><label-warn>

label = "%temperature-c%"
label-foreground = ${color.temp-shade}
label-background = ${color.bg}
label-padding= 1

label-warn = "%temperature-c%"
label-warn-foreground = ${color.fg-alt}
label-warn-background = ${color.temp-shade}
label-warn-padding = 2
ramp-0 = 
ramp-1 = 
ramp-2 = 
ramp-3 = 
ramp-4 = 
ramp-5 = 
ramp-6 = 
ramp-padding-left = 1
ramp-foreground = ${color.temp-shade}
ramp-background = ${color.bg}
ramp-6-foreground = ${color.fg-alt}
ramp-6-background = ${color.temp-shade}
```

Which should produce the [above](https://imgur.com/a/IX9kKIQ) output, we can see that the icon in ramp-6 is used for 71C, which is below the warn-temperature of 74C.
This causes the ramp and label nodes to have different styles, making the whole thing ugly.

## What I did to fix it

I made the temperature module calculate the variable `m_perc` as an unbounded-percentage instead of a normal percentage, this will allow temperatures below and above the normal range be reflected in the percentage value.

I wrote a ramp function `get_by_percentage_with_border` which will use the first and last ramp icons exclusively for percentage values outside the range (0, 100) and used it for the ramp in temperature instead
