### PR TITLE
aur: Use Release mode in cmake

### DIFF
--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -32,7 +32,7 @@ prepare() {
 build() {
   cd "${_pkgname}/build" || exit 1
   # Force cmake to use system python (to detect xcbgen)
-  cmake -DCMAKE_INSTALL_PREFIX=/usr -DPYTHON_EXECUTABLE=/usr/bin/python3 ..
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=/usr/bin/python3 ..
   cmake --build .
 }
 

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -24,7 +24,7 @@ prepare() {
 
 build() {
   cd "${pkgname}/build" || exit 1
-  cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release ..
   cmake --build .
 }
 


### PR DESCRIPTION
This is already the default but our packaging guidelines recommend this,
so we should also follow them.