### PR TITLE
config: Better error messages when opening files

### DIFF
--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -6,8 +6,6 @@
 #include "components/config.hpp"
 #include "components/logger.hpp"
 #include "errors.hpp"
-#include "utils/file.hpp"
-#include "utils/string.hpp"
 
 POLYBAR_NS
 

--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -102,6 +102,7 @@ class fd_stream : public StreamType {
 
 namespace file_util {
   bool exists(const string& filename);
+  bool is_file(const string& filename);
   string pick(const vector<string>& filenames);
   string contents(const string& filename);
   void write_contents(const string& filename, const string& contents);

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -1,7 +1,12 @@
 #include "components/config_parser.hpp"
 
 #include <algorithm>
+#include <cerrno>
+#include <cstring>
 #include <fstream>
+
+#include "utils/file.hpp"
+#include "utils/string.hpp"
 
 POLYBAR_NS
 
@@ -87,6 +92,14 @@ void config_parser::parse_file(const string& file, file_list path) {
 
     // We have already parsed this file in this path, so there are cyclic dependencies
     throw application_error("include-file: Dependency cycle detected:\n" + path_str);
+  }
+
+  if (!file_util::exists(file)) {
+    throw application_error("Failed to open config file " + file + ": " + strerror(errno));
+  }
+
+  if (!file_util::is_file(file)) {
+    throw application_error("Config file " + file + " is not a file");
   }
 
   m_log.trace("config_parser: Parsing %s", file);

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -170,10 +170,27 @@ int fd_streambuf::underflow() {
 namespace file_util {
   /**
    * Checks if the given file exist
+   *
+   * May also return false if the file status  cannot be read
+   *
+   * Sets errno when returning false
    */
   bool exists(const string& filename) {
     struct stat buffer {};
     return stat(filename.c_str(), &buffer) == 0;
+  }
+
+  /**
+   * Checks if the given path exists and is a file
+   */
+  bool is_file(const string& filename) {
+    struct stat buffer {};
+
+    if (stat(filename.c_str(), &buffer) != 0) {
+      return false;
+    }
+
+    return S_ISREG(buffer.st_mode);
   }
 
   /**


### PR DESCRIPTION
If a config file is a directory, ifstream would just read it as an empty
file without any errors.

Failing early here is a good idea.