### PR TITLE
Release 3.5.0

### DIFF
--- a/include/utils/color.hpp
+++ b/include/utils/color.hpp
@@ -35,8 +35,8 @@ class rgba {
   uint8_t blue_i() const;
 
   bool has_color() const;
-  rgba apply_alpha(rgba other) const;
-  rgba try_apply_alpha(rgba other) const;
+  rgba apply_alpha_to(rgba other) const;
+  rgba try_apply_alpha_to(rgba other) const;
 
  private:
   /**

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -205,11 +205,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
        * These are the base colors of the bar and cannot be alpha only
        * In that case, we just use the alpha channel on the default value.
        */
-      if (color.type() == rgba::ALPHA_ONLY) {
-        return def.apply_alpha(color);
-      } else {
-        return color;
-      }
+      return color.try_apply_alpha_to(def);
     } catch (const exception& err) {
       throw application_error(sstream() << "Failed to set " << key << " (reason: " << err.what() << ")");
     }

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -259,7 +259,7 @@ void builder::font_close() {
  * Insert tag to alter the current background color
  */
 void builder::background(rgba color) {
-  color = m_bar.background.try_apply_alpha(color);
+  color = color.try_apply_alpha_to(m_bar.background);
 
   auto hex = color_util::simplify_hex(color);
   m_colors[syntaxtag::B] = hex;
@@ -278,7 +278,7 @@ void builder::background_close() {
  * Insert tag to alter the current foreground color
  */
 void builder::color(rgba color) {
-  color = m_bar.foreground.try_apply_alpha(color);
+  color = color.try_apply_alpha_to(m_bar.foreground);
 
   auto hex = color_util::simplify_hex(color);
   m_colors[syntaxtag::F] = hex;

--- a/src/utils/color.cpp
+++ b/src/utils/color.cpp
@@ -140,21 +140,22 @@ bool rgba::has_color() const {
 }
 
 /**
- * Replaces the current alpha channel with the alpha channel of the other color
- *
- * Useful for ALPHA_ONLY colors
+ * Applies the alpha channel of this color to the given color.
  */
-rgba rgba::apply_alpha(rgba other) const {
-  uint32_t val = (m_value & 0x00FFFFFF) | (((uint32_t)other.alpha_i()) << 24);
+rgba rgba::apply_alpha_to(rgba other) const {
+  uint32_t val = (other.value() & 0x00FFFFFF) | (((uint32_t)alpha_i()) << 24);
   return rgba(val, m_type);
 }
 
 /**
- * Calls apply_alpha, if the given color is ALPHA_ONLY.
+ * If this is an ALPHA_ONLY color, applies this alpha channel to the other
+ * color, otherwise just returns this.
+ *
+ * \returns the new color if this is ALPHA_ONLY or a copy of this otherwise.
  */
-rgba rgba::try_apply_alpha(rgba other) const {
-  if (other.type() == ALPHA_ONLY) {
-    return apply_alpha(other);
+rgba rgba::try_apply_alpha_to(rgba other) const {
+  if (m_type == ALPHA_ONLY) {
+    return apply_alpha_to(other);
   }
 
   return *this;

--- a/tests/unit_tests/utils/color.cpp
+++ b/tests/unit_tests/utils/color.cpp
@@ -96,14 +96,24 @@ TEST(Rgba, channel) {
   EXPECT_EQ(0x99 / 255.0, rgba{0x88449933}.green_d());
 }
 
-TEST(Rgba, applyAlpha) {
-  rgba v{0xCC123456};
-  rgba modified = v.apply_alpha(rgba{0xAA000000, rgba::ALPHA_ONLY});
+TEST(Rgba, applyAlphaTo) {
+  rgba v{0xAA000000, rgba::ALPHA_ONLY};
+  rgba modified = v.apply_alpha_to(rgba{0xCC123456, rgba::ALPHA_ONLY});
   EXPECT_EQ(0xAA123456, modified.value());
 
-  v = rgba{0x00123456};
-  modified = v.apply_alpha(rgba{0xCC999999});
+  v = rgba{0xCC999999};
+  modified = v.apply_alpha_to(rgba{0x00123456});
   EXPECT_EQ(0xCC123456, modified.value());
+}
+
+TEST(Rgba, tryApplyAlphaTo) {
+  rgba v{0xAA000000, rgba::ALPHA_ONLY};
+  rgba modified = v.try_apply_alpha_to(rgba{0xCC123456, rgba::ALPHA_ONLY});
+  EXPECT_EQ(0xAA123456, modified.value());
+
+  v = rgba{0xCC999999};
+  modified = v.try_apply_alpha_to(rgba{0x00123456});
+  EXPECT_EQ(0xCC999999, modified.value());
 }
 
 TEST(ColorUtil, simplify) {

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
 # Polybar version information
 # Update this on every release
 # This is used to create the version string if a git repo is not available
-3.4.0
+3.5.0


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: Release PR

## Description

After almost 1.5 years, the next minor polybar release :fireworks:

I will write up a release blog post in the next few days and then we can merge this.

The drafted GitHub release can be found [here](https://github.com/polybar/polybar/releases/tag/untagged-2c9ce51665cc0c122bde) (visible to polybar team only).

Post release-checklist:

* [ ] Remove "Click Commands are not Executed" from known issues.
* [ ] Use `notice` log level in font debugging wiki page
* [ ] Add config syntax link to "Configuration" page
* [ ] Remove ["With multiple modules of the same type, actions on those modules control the leftmost module"](https://github.com/polybar/polybar/wiki/Known-Issues#with-multiple-modules-of-the-same-type-actions-on-those-modules-control-the-leftmost-module) from the known issues
* [ ] Remove the note on the menu module page that only a single menu module can exist.
* [ ] Add a note about migration to all the wiki pages that use the legacy action names:
  * [ ] i3 module
  * [ ] bspwm module
  * [ ] menu module
  * [ ] ipc (not the module)
  * [ ] (maybe others)
* [ ] Mark all deprecations in the wiki
* [ ] Remove all unreleased notes from the wiki
* [ ] Add release information to #1971
* [ ] Upload release archive
* [ ] Update PKGBUILDs
* [ ] Publish Blog Post (https://github.com/polybar/polybar.github.io/pull/17)
* [ ] Post blog post to reddit, gitter, IRC.

Breaking Changes:

* The new config parser imposes some restrictions on which characters can be
  used in section and key names. Users shouldn't be affected by this unless they
  use one of the following characters in any section or key name: `"'=;#[](){}:.$\%`
  Please consult [`man 5 polybar`](https://polybar.readthedocs.io/en/latest/man/polybar.5.html) for a full reference of the new config rules.
* `internal/temperature`: The first and last ramp element are now only used for
  `base-temperature` and below and `warn-temperature` and above respectively.
  This only slightly changes the ranges for which the different ramp levels are
  responsible for.
  (#2197)

Changelog

**Deprecations**

* `[settings]`: `throttle-input-for` has been removed. It wasn't a useful option
  and could cause certain actions (e.g. click commands) to be ignored. (#2117)

* All action names used by modules to handle click and scroll events are
  depercated (#1907).  This change mainly affects users of the menu module.
  Please read the [documentation](https://polybar.readthedocs.io/en/latest/user/actions.html) for instructions on how to migrate.

**New Config Options**

The `include-directory` key can be used the same as `include-file` and includes
all regular files in the given directory.

In labels:

* `label-NAME-minlen`, `label-NAME-alignment` can be used to pad labels with
  spaces to the right (alignment set to `left`), left (alignment set to
  `right`), and both sides (alignment set to `center`).

In `internal/backlight`:

* `enable-scroll` enables changing the brightness through scrolling.

In `internal/github`:

* `format-offline` is used when the module cannot connect to the server.
* `label-offline` can be used in `format-offline`.
* `api-url` can be used to connect to a custom github enterprise instance

In `internal/pulseaudio`:

* `click-right` and `click-middle` can be used to execute commands when
  right/middle clicking.
* `%decibels%` token can be used in `label-volume` and `label-muted` to show the
  volume in decibels.

**Changes To The Build System**

* Allow users to specify python executable when building. (polybar/xpp#27,
  #2125)
* The i3ipcpp submodule no longer rebuilds jsoncpp and just uses whatever
  version is available. (#2015, polybar/i3ipcpp#9)

**Features**

* New commandline argument: `-M` / `--list-all-monitors`.
    Will display all available monitors (even cloned ones).
* New log level: `notice`.
    Used as the default and is used for non-warning messages the user should
    nevertheless be aware of. (#2027)
* config:
    * New config parser (#1377)
    * `include-directory` key (#2196), see #1946
    * Add error message when an entire section is missing. (#2195)
    * `-minlen` and `-alignment` properties for labels. (#1546)
    * Make the `seperator` key in the bar section a label. (#1918)
    * Better color validation. (#1290)
* timer modules: Schedule module updates to be aligned with the update interval.
  For example, the date module now updates on the minute instead of in the
  middle of a minute if the interval is set to 60 seconds. (#2123), see #2064
* `custom/menu`: Multiple menu modules per bar (#1907)
* `internal/backlight`: Support for changing the brightness through scrolling.
  This may require additional changes to the system running polybar. (#1957)
* `internal/github`:
    * `format-offline` for when the module cannot connect to the server (#1825),
    see #1815
    * Support for github enterprise instances. (#1841), see #1812
* `internal/network`: Support `Gbit/s` for `%linkspeed%` token. (#2055)
* `internal/pulseaudio`:
    * `click-right` and `click-middle` keys (#1941)
    * `%decibels%` token (#1894), see #1886
* `internal/xworkspaces`: Proper implementation for `label-occupied`. (#822),
  see #874, #1444, #1033

**Fixes**

* Polybar not executing commands that produce output. (#1680), see #916
* Polybar froze until click commands finished executing (#2248)
* Polybar not properly working with mirrored monitors. (#1823), see #1192 and
  #1794
* Unstable animation framerate (#1683), see #568
* Multiple modules of the same type caused click events not to be delivered to
  the rigth one (#1907), see #1172
* config:
    * Seemingly unrelated error messages when BOM character appears in config.
    (#2166), see #2075
    * Fall back to next possible config location if config file doesn't exist
      (except if `--config` was used). (#2026), see #2016
* iconset: `fuzzy-match` chose first match, even if exact match was available.
  (#2042), see #2041
* `custom/menu`: Spacing issue (#1656)
* `internal/alsa`: Volume didn't go over 100% (#2184), see #2173
* `internal/backlight`: Use amdgpu workaround for all devices starting with
  `amdgpu_bl`. (#2122)
* `internal/battery`: Battery not marked as full if over `full-at` percent.
  (#2019), see #1622
* `internal/cpu`: More accurate cpu load calculation. (#1955)
* `internal/github`: Outdated GitHub API authentication. (#2029), see #2002
* `internal/memory`: Use the correct size prefixes (#2211), see #2023
* `internal/network`:
    * Wrong up- and downspeed values for non-integer intervals. (#2219)
    * tun/tap interfaces didn't query their IP addresses. (#1990), see #1986
    * Don't crash module if linkspeed cannot be queried. (#1772), see #1211
* `internal/temperature`:
    * `format-warn` was not used if the temperature was *exactly*
      `warn-temperature`. (#1897)
* `internal/xworkspaces`:
    * Multi-monitor issue (#1929), see #1764, #1849
    * Module sometimes showed too many workspaces (#1984), see #1983
* build:
    * xpp submodule doesn't work with python 3.9 (polybar/xpp#26)
    * CMake 3.17+ developer warnings (#2089, polybar/xpp#24, polybar/xpp#25)
    * gtest compilation failure (#1993), see google/googletest#2678
    * Compilation issue in GCC 6. (#1953)

## Related Issues & Documents

This is the first release that follows the release guidelines layed out int #2185 and #1780

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
