### PR TITLE
Add some precision in network module for MB and GB

### DIFF
--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -231,13 +231,15 @@ namespace net {
 
     vector<string> suffixes{"G", "M"};
     string suffix{"K"};
+    int precision = 0;
 
     while ((speedrate /= 1000) > 999) {
       suffix = suffixes.back();
       suffixes.pop_back();
+      precision++;
     }
 
-    return sstream() << std::setw(minwidth) << std::setfill(' ') << std::setprecision(0) << std::fixed << speedrate
+    return sstream() << std::setw(minwidth) << std::setfill(' ') << std::setprecision(precision) << std::fixed << speedrate
                      << " " << suffix << unit;
   }
 


### PR DESCRIPTION
Add 1 decimal floating precision when net speed is MB, and 2 decimals when speed is in GB.

If you want I can add a config var to enable this, but my bar looked ugly switching from 999 KB to 1 MB. Right now it switchs to 999 KB to 1.0MB, much better imho.


* [x] Does not require documentation changes
