### PR TITLE
fix(battery): Crash when `format-low` not defined

### DIFF
--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -152,7 +152,7 @@ namespace modules {
   bool module_formatter::has(const string& tag, const string& format_name) {
     auto format = m_formats.find(format_name);
     if (format == m_formats.end()) {
-      throw undefined_format(format_name);
+      return false;
     }
     return format->second->value.find(tag) != string::npos;
   }

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -140,12 +140,14 @@ namespace modules {
   }
 
   void module_formatter::add(string name, string fallback, vector<string>&& tags, vector<string>&& whitelist) {
-    add_value(move(name), m_conf.get(m_modname, move(name), move(fallback)), forward<vector<string>>(tags), forward<vector<string>>(whitelist));
+    string value = m_conf.get(m_modname, name, move(fallback));
+    add_value(move(name), move(value), forward<vector<string>>(tags), forward<vector<string>>(whitelist));
   }
 
   void module_formatter::add_optional(string name, vector<string>&& tags, vector<string>&& whitelist) {
     if (m_conf.has(m_modname, name)) {
-      add_value(move(name), m_conf.get(m_modname, move(name)), move(tags), move(whitelist));
+      string value = m_conf.get(m_modname, name);
+      add_value(move(name), move(value), move(tags), move(whitelist));
     }
   }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

This was a backwards-incompatible change introduced in #2199, however it
was caused because `module_formatter.has` throws an exception when the
format doesn't exist instead of just returning false.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

Fixes #2262
Ref #2199

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
