### PR TITLE
fix(menu): Wrong printf token in error message

### DIFF
--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -140,7 +140,7 @@ namespace modules {
       m_log.info("%s: Opening menu level '%i'", name(), static_cast<int>(m_level));
 
       if (static_cast<size_t>(m_level) >= m_levels.size()) {
-        m_log.warn("%s: Cannot open unexisting menu level '%i'", name(), level);
+        m_log.warn("%s: Cannot open unexisting menu level '%s'", name(), level);
         m_level = -1;
       }
     } else if (action == EVENT_CLOSE) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

'level' is a string, not an integer

This targets the hotfix branch for 3.5.1. Since this isn't really an critical bug, I think we can leave the hotfix branch for a bit and see if there are other bugs in 3.5.0 that need fixing.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
