### PR TITLE
Fix linking when built with clang++ 3.4

### DIFF
--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -48,7 +48,7 @@ namespace modules {
 
   template <typename Impl>
   string module<Impl>::type() const {
-    return string(CONST_MOD(Impl).TYPE);
+    return string(module<Impl>::TYPE);
   }
 
   template <typename Impl>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: compilation fix

## Description

This fixes building polybar with clang++ 3.4.2.

## Related Issues & Documents

An exemplar linking error, which we couldn't debug was this:

```text
libpoly.a(alsa.cpp.o): In function `polybar::modules::module<polybar::modules::alsa_module>::type() const':
/root/.ccache/tmp/alsa.stdout.host.4433.8kXOHg.ii:(.text._ZNK7polybar7modules6moduleINS0_11alsa_moduleEE4typeEv[_ZNK7polybar7modules6moduleINS0_11alsa_moduleEE4typeEv]+0xa): undefined reference to `polybar::modules::alsa_module::TYPE'
```

repeated for every compiled module.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
