### PR TITLE
fix(timer_module): Ensure that interval > 0

### DIFF
--- a/include/modules/meta/timer_module.hpp
+++ b/include/modules/meta/timer_module.hpp
@@ -17,6 +17,20 @@ namespace modules {
     }
 
    protected:
+    /**
+     * Loads and sets the interval for this module.
+     *
+     * Will throw an exception if a non-positive (<= 0) number is given.
+     */
+    void set_interval(interval_t def) {
+      m_interval = this->m_conf.template get<decltype(m_interval)>(this->name(), "interval", def);
+
+      if (m_interval <= 0s) {
+        throw module_error(
+            this->name() + ": 'interval' must be larger than 0 (got '" + to_string(m_interval.count()) + "s')");
+      }
+    }
+
     void runner() {
       this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
 

--- a/src/modules/counter.cpp
+++ b/src/modules/counter.cpp
@@ -9,7 +9,7 @@ namespace modules {
 
   counter_module::counter_module(const bar_settings& bar, string name_)
       : timer_module<counter_module>(bar, move(name_)) {
-    m_interval = m_conf.get(name(), "interval", m_interval);
+    set_interval(1s);
     m_formatter->add(DEFAULT_FORMAT, TAG_COUNTER, {TAG_COUNTER});
   }
 
@@ -25,6 +25,6 @@ namespace modules {
     }
     return false;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -16,7 +16,7 @@ namespace modules {
   template class module<cpu_module>;
 
   cpu_module::cpu_module(const bar_settings& bar, string name_) : timer_module<cpu_module>(bar, move(name_)) {
-    m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
+    set_interval(1s);
 
     m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-coreload-spacing", 1);
 

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -22,7 +22,7 @@ namespace modules {
       throw module_error("No date or time format specified");
     }
 
-    m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
+    set_interval(1s);
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_DATE});
 

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -30,7 +30,7 @@ namespace modules {
     m_remove_unmounted = m_conf.get(name(), "remove-unmounted", m_remove_unmounted);
     m_fixed = m_conf.get(name(), "fixed-values", m_fixed);
     m_spacing = m_conf.get(name(), "spacing", m_spacing);
-    m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 30s);
+    set_interval(30s);
 
     // Add formats and elements
     m_formatter->add(

--- a/src/modules/github.cpp
+++ b/src/modules/github.cpp
@@ -23,7 +23,7 @@ namespace modules {
       m_api_url += '/';
     }
 
-    m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 60s);
+    set_interval(60s);
     m_empty_notifications = m_conf.get(name(), "empty-notifications", m_empty_notifications);
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL});

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -16,7 +16,7 @@ namespace modules {
   template class module<memory_module>;
 
   memory_module::memory_module(const bar_settings& bar, string name_) : timer_module<memory_module>(bar, move(name_)) {
-    m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
+    set_interval(1s);
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_USED, TAG_BAR_FREE, TAG_RAMP_USED, TAG_RAMP_FREE,
                                                  TAG_BAR_SWAP_USED, TAG_BAR_SWAP_FREE, TAG_RAMP_SWAP_USED, TAG_RAMP_SWAP_FREE});

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -19,7 +19,7 @@ namespace modules {
     m_ping_nth_update = m_conf.get(name(), "ping-interval", m_ping_nth_update);
     m_udspeed_minwidth = m_conf.get(name(), "udspeed-minwidth", m_udspeed_minwidth);
     m_accumulate = m_conf.get(name(), "accumulate-stats", m_accumulate);
-    m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
+    set_interval(1s);
     m_unknown_up = m_conf.get<bool>(name(), "unknown-as-up", false);
 
     m_conf.warn_deprecated(name(), "udspeed-minwidth", "%downspeed:min:max% and %upspeed:min:max%");

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -19,7 +19,7 @@ namespace modules {
     m_path = m_conf.get(name(), "hwmon-path", ""s);
     m_tempbase = m_conf.get(name(), "base-temperature", 0);
     m_tempwarn = m_conf.get(name(), "warn-temperature", 80);
-    m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
+    set_interval(1s);
     m_units = m_conf.get(name(), "units", m_units);
 
     if (m_path.empty()) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

Since 3.5.0, we use m_interval for a modulo operation, this crashes the
bar if the interval is 0. A non-positive interval shouldn't be allowed
anyway, so we now throw an exception in that case.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

Fixes #2273

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
