### PR TITLE
fix(xworkspaces): Never swallow updates

### DIFF
--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -110,8 +110,6 @@ namespace modules {
     // The following mutex is here to protect the data of this modules.
     // This can't be achieved using m_buildlock since we "CRTP override" get_output().
     mutable mutex m_workspace_mutex;
-
-    event_timer m_timer{0L, 25L};
   };
 }  // namespace modules
 

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -126,9 +126,7 @@ namespace modules {
       return;
     }
 
-    if (m_timer.allow(evt->time)) {
-      broadcast();
-    }
+    broadcast();
   }
 
   /**


### PR DESCRIPTION


<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

If two WM events arrive withing 25ms of one-another, the second one does
not trigger a bar update.
The module state is still correct, it is just not reflected in the bar.

This somehow caused updates being swallowed in fluxbox, but only after
PR #882 was merged, even though that 25ms restriction existed long
before that.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

Fixes #2272
Ref #882

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
