### PR TITLE
Fix build with clang++ 3.4

### DIFF
--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -63,7 +63,7 @@ class pulseaudio {
     pa_cvolume cv;
     bool muted{false};
     // default sink name
-    static constexpr auto DEFAULT_SINK{"@DEFAULT_SINK@"};
+    static constexpr auto DEFAULT_SINK = "@DEFAULT_SINK@";
 
     pa_context* m_context{nullptr};
     pa_threaded_mainloop* m_mainloop{nullptr};


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: compilation fix

## Description

A follow-up to #2270. Likely a bug in clang.

## Related Issues & Documents

The build error it fixes is:

```text
/usr/src/polybar-3.5.0/src/adapters/pulseaudio.cpp:60:10: error: no matching function for call to 'pa_context_get_sink_info_by_name'
--
  | op = pa_context_get_sink_info_by_name(m_context, DEFAULT_SINK, sink_info_callback, this);
  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  | /usr/include/pulse/introspect.h:268:15: note: candidate function not viable: no known conversion from 'const std::initializer_list<const char *>' to 'const char *' for 2nd argument
  | pa_operation* pa_context_get_sink_info_by_name(pa_context *c, const char *name, pa_sink_info_cb_t cb, void *userdata);
  | ^
  | /usr/src/polybar-3.5.0/src/adapters/pulseaudio.cpp:134:13: error: no matching function for call to 'pa_context_get_sink_info_by_name'
  | o = pa_context_get_sink_info_by_name(m_context, DEFAULT_SINK, sink_info_callback, this);
  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  | /usr/include/pulse/introspect.h:268:15: note: candidate function not viable: no known conversion from 'const std::initializer_list<const char *>' to 'const char *' for 2nd argument
  | pa_operation* pa_context_get_sink_info_by_name(pa_context *c, const char *name, pa_sink_info_cb_t cb, void *userdata);
  | ^
  | 2 errors generated.
```

Built against PulseAudio **12.2**.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
