### PR TITLE
Add missing header

### DIFF
--- a/include/utils/process.hpp
+++ b/include/utils/process.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sys/types.h>
+
 #include "common.hpp"
 
 POLYBAR_NS


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: compilation fix

## Description

After upgrading from 3.4.3 to 3.5.0 I get this while building:

```text
In file included from /usr/src/polybar-3.5.0/src/utils/process.cpp:1:
/usr/src/polybar-3.5.0/include/utils/process.hpp:8:26: error: unknown type name 'pid_t'
  bool in_parent_process(pid_t pid);
                         ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:9:26: error: unknown type name 'pid_t'
  bool in_forked_process(pid_t pid);
                         ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:13:3: error: unknown type name 'pid_t'
  pid_t fork_detached(std::function<void()> const& lambda);
  ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:18:3: error: unknown type name 'pid_t'
  pid_t wait_for_completion(pid_t process_id, int* status_addr = nullptr, int waitflags = 0);
  ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:18:29: error: unknown type name 'pid_t'
  pid_t wait_for_completion(pid_t process_id, int* status_addr = nullptr, int waitflags = 0);
                            ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:19:3: error: unknown type name 'pid_t'
  pid_t wait_for_completion(int* status_addr, int waitflags = 0);
  ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:20:3: error: unknown type name 'pid_t'
  pid_t wait_for_completion_nohang(pid_t process_id, int* status);
  ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:20:36: error: unknown type name 'pid_t'
  pid_t wait_for_completion_nohang(pid_t process_id, int* status);
                                   ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:21:3: error: unknown type name 'pid_t'
  pid_t wait_for_completion_nohang(int* status);
  ^
/usr/src/polybar-3.5.0/include/utils/process.hpp:22:3: error: unknown type name 'pid_t'
  pid_t wait_for_completion_nohang();
  ^
10 errors generated.
```

But not sure where it's coming from. The appropriate header doesn't get included in `common.hpp`? I guess the one in `process.cpp` becomes redundant.

## Related Issues & Documents

N/A

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
