### PR TITLE
Use null-byte string as default workspace icon instead of empty string

### DIFF
--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -55,7 +55,7 @@ namespace modules {
     m_labelseparator = load_optional_label(m_conf, name(), "label-separator", "");
 
     m_icons = factory_util::shared<iconset>();
-    m_icons->add(DEFAULT_WS_ICON, factory_util::shared<label>(m_conf.get(name(), DEFAULT_WS_ICON, ""s)));
+    m_icons->add(DEFAULT_WS_ICON, factory_util::shared<label>(m_conf.get(name(), DEFAULT_WS_ICON, "\0"s)));
 
     for (const auto& workspace : m_conf.get_list<string>(name(), "ws-icon", {})) {
       auto vec = string_util::tokenize(workspace, ';');


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This PR fixes showing empty space when not defining an icon for a workspace. Best shown with an example:

Before:

![before](https://user-images.githubusercontent.com/6804922/101798218-2799c500-3b0b-11eb-85f1-ad72a448d2a7.png)

Afer:

![after](https://user-images.githubusercontent.com/6804922/101798505-6f205100-3b0b-11eb-9bcf-959aa9b8fc7b.png)

Note, you do need to remove the ; for unused workspace icons:

```
ws-icon-0 = 1;
ws-icon-1 = 2
ws-icon-2 = 3
ws-icon-3 = 4
ws-icon-4 = 5
ws-icon-5 = 6
ws-icon-6 = 7
ws-icon-7 = 8
ws-icon-8 = 9;
```

## Related Issues & Documents
Small fix, didn't create issue.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
