### PR TITLE
fix(process): fork_detached created zombie processes

### DIFF
--- a/include/utils/process.hpp
+++ b/include/utils/process.hpp
@@ -12,10 +12,13 @@ namespace process_util {
 
   void redirect_stdio_to_dev_null();
 
-  pid_t fork_detached(std::function<void()> const& lambda);
+  pid_t spawn_async(std::function<void()> const& lambda);
+  void fork_detached(std::function<void()> const& lambda);
 
   void exec(char* cmd, char** args);
   void exec_sh(const char* cmd);
+
+  int wait(pid_t pid);
 
   pid_t wait_for_completion(pid_t process_id, int* status_addr = nullptr, int waitflags = 0);
   pid_t wait_for_completion(int* status_addr, int waitflags = 0);

--- a/src/utils/command.cpp
+++ b/src/utils/command.cpp
@@ -33,7 +33,7 @@ command<output_policy::IGNORED>::~command() {
  * Execute the command
  */
 int command<output_policy::IGNORED>::exec(bool wait_for_completion) {
-  m_forkpid = process_util::fork_detached([m_cmd = m_cmd] { process_util::exec_sh(m_cmd.c_str()); });
+  m_forkpid = process_util::spawn_async([m_cmd = m_cmd] { process_util::exec_sh(m_cmd.c_str()); });
   if (wait_for_completion) {
     auto status = wait();
     m_forkpid = -1;

--- a/tests/unit_tests/utils/process.cpp
+++ b/tests/unit_tests/utils/process.cpp
@@ -12,8 +12,8 @@
 using namespace polybar;
 using namespace process_util;
 
-TEST(ForkDetached, is_detached) {
-  pid_t pid = fork_detached([] { exec_sh("sleep 0.1"); });
+TEST(SpawnAsync, is_async) {
+  pid_t pid = spawn_async([] { exec_sh("sleep 0.1"); });
   int status;
 
   pid_t res = process_util::wait_for_completion_nohang(pid, &status);
@@ -23,8 +23,8 @@ TEST(ForkDetached, is_detached) {
   EXPECT_FALSE(WIFEXITED(status));
 }
 
-TEST(ForkDetached, exit_code) {
-  pid_t pid = fork_detached([] { exec_sh("exit 42"); });
+TEST(SpawnAsync, exit_code) {
+  pid_t pid = spawn_async([] { exec_sh("exit 42"); });
   int status = 0;
   pid_t res = waitpid(pid, &status, 0);
 


### PR DESCRIPTION


<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

Since the forked processes are still our children, we need to wait on
them, otherwise they become zombie processes.

We now fork twice, let the first fork immediately return and wait on it.
This reparents the second fork, which runs the actual code, to the init
process which then collects it.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

Ref #770

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
