### PR TITLE
fix: Module type always empty string

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -148,8 +148,6 @@ namespace modules {
 
     bool input(const string& action, const string& data);
 
-    static constexpr auto TYPE = "";
-
    protected:
     void broadcast();
     void idle();

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -48,7 +48,7 @@ namespace modules {
 
   template <typename Impl>
   string module<Impl>::type() const {
-    return string(module<Impl>::TYPE);
+    return string(Impl::TYPE);
   }
 
   template <typename Impl>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
The change in #2270 accidentally broke how we access module types.
module<Impl>::TYPE always points to the module superclass and it thus
accesses its empty TYPE field.

This mainly broke legacy action handling.

@vaygr Can you check if this still works in clang 3.4.2?

## Related Issues & Documents
Ref #2270

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes