### PR TITLE
feat(conf) Properties for {bottom,top}-{left,right} radius

### DIFF
--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -118,10 +118,10 @@ namespace cairo {
     context& operator<<(const rounded_corners& c) {
       double d = M_PI / 180.0;
       cairo_new_sub_path(m_c);
-      cairo_arc(m_c, c.x + c.w - c.radius.top, c.y + c.radius.top, c.radius.top, -90 * d, 0 * d);
-      cairo_arc(m_c, c.x + c.w - c.radius.bottom, c.y + c.h - c.radius.bottom, c.radius.bottom, 0 * d, 90 * d);
-      cairo_arc(m_c, c.x + c.radius.bottom, c.y + c.h - c.radius.bottom, c.radius.bottom, 90 * d, 180 * d);
-      cairo_arc(m_c, c.x + c.radius.top, c.y + c.radius.top, c.radius.top, 180 * d, 270 * d);
+      cairo_arc(m_c, c.x + c.w - c.radius.top_right, c.y + c.radius.top_right, c.radius.top_right, -90 * d, 0 * d);
+      cairo_arc(m_c, c.x + c.w - c.radius.bottom_right, c.y + c.h - c.radius.bottom_right, c.radius.bottom_right, 0 * d, 90 * d);
+      cairo_arc(m_c, c.x + c.radius.bottom_left, c.y + c.h - c.radius.bottom_left, c.radius.bottom_left, 90 * d, 180 * d);
+      cairo_arc(m_c, c.x + c.radius.top_left, c.y + c.radius.top_left, c.radius.top_left, 180 * d, 270 * d);
       cairo_close_path(m_c);
       return *this;
     }

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -98,11 +98,13 @@ struct edge_values {
 };
 
 struct radius {
-  double top{0.0};
-  double bottom{0.0};
+  double top_left{0.0};
+  double top_right{0.0};
+  double bottom_left{0.0};
+  double bottom_right{0.0};
 
   operator bool() const {
-    return top != 0.0 || bottom != 0.0;
+    return top_left != 0.0 || top_right != 0.0 || bottom_left != 0.0 || bottom_right != 0.0;
   }
 };
 

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -161,8 +161,12 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.locale = m_conf.get(bs, "locale", ""s);
 
   auto radius = m_conf.get<double>(bs, "radius", 0.0);
-  m_opts.radius.top = m_conf.get(bs, "radius-top", radius);
-  m_opts.radius.bottom = m_conf.get(bs, "radius-bottom", radius);
+  auto top = m_conf.get(bs, "radius-top", radius);
+  m_opts.radius.top_left = m_conf.get(bs, "radius-top-left", top);
+  m_opts.radius.top_right = m_conf.get(bs, "radius-top-right", top);
+  auto bottom = m_conf.get(bs, "radius-bottom", radius);
+  m_opts.radius.bottom_left = m_conf.get(bs, "radius-bottom-left", bottom);
+  m_opts.radius.bottom_right = m_conf.get(bs, "radius-bottom-right", bottom);
 
   auto padding = m_conf.get<unsigned int>(bs, "padding", 0U);
   m_opts.padding.left = m_conf.get(bs, "padding-left", padding);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

A new set of configuration options are added to allow to set corner radii
separately. For motivation see #2294.

Additionally to the already present `radius` and `radius-{bottom,top}`
`radius-{bottom,top}-{left,right}` configuration options are added. If not
present they fall back to `radius-bottom`, `radius-top` or ultimately `radius`
to preserve current semantics.

## Related Issues & Documents

This implements #2294.

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
  See provided patch below (to be applied to Home → Configuration).
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

```patch
--- configuration_old.md	2020-12-13 16:33:34.677959229 +0100
+++ configuration_new.md	2020-12-13 16:38:17.929004974 +0100
@@ -201,8 +201,10 @@
 ; Note: This shouldn't be used together with border-size because the border 
 ; doesn't get rounded. For this to work you may also need to enable 
 ; pseudo-transparency or use a compositor like compton.
-; Individual top/bottom values can be defined using:
-;   radius-{top,bottom}
+; Individual top/bottom-left/right values can be defined using:
+;   radius-{top,bottom}-{left,right}
+; In case radius-{top,bottom} is provided, it is applied to {left,right}. If
+; just radius is provided its value is used for all corners.
 radius = 0.0
 
 ; Under-/overline pixel size and argb color
