### PR TITLE
Adopt "keep a changelog"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
             const fname = '${{ env.POLYBAR_ARCHIVE }}'
             const url = '${{ steps.upload_archive.outputs.browser_download_url }}'
             const hash = '${{ env.SHA256SUM }}'
-            let body = "### Download:\n\n"
+            let body = "## Download:\n\n"
             body += `[${fname}](${url}) (**sha256**: \`${hash}\`)\n\n`
             body += process.env.RELEASE_BODY;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Warn states for the cpu, memory, fs, and battery modules.
+  ([`#570`](https://github.com/polybar/polybar/issues/570),
+  [`#956`](https://github.com/polybar/polybar/issues/956),
+  [`#1871`](https://github.com/polybar/polybar/issues/1871),
+  [`#2141`](https://github.com/polybar/polybar/issues/2141))
+  - `internal/battery`: `format-low`, `label-low`, `animation-low`, `low-at =
+    10`.
+  - `internal/cpu`: `format-warn`, `label-warn`, `warn-percentage = 80`
+  - `internal/fs`: `format-warn`, `label-warn`, `warn-percentage = 90`
+  - `internal/memory`: `format-warn`, `label-warn`, `warn-percentage = 90`
+- Per-corner corner radius with `radius-{bottom,top}-{left,right}`
+  ([`#2294`](https://github.com/polybar/polybar/issues/2294))
+- `internal/network`: `speed-unit = B/s` can be used to customize how network
+  speeds are displayed.
+
+### Changed
+- Slight changes to the value ranges the different ramp levels are responsible
+  for in the cpu, memory, fs, and battery modules. The first and last level are
+  only used for everything at or below and at and above the edges of the value
+  range, respectively. The other levels are evenly distributed over the value
+  range as before.
+- `custom/script`: `interval` now defaults to 0 if `tail = true` as per the
+  documentation.
+- `internal/network`:
+  - Increased precision for upload and download speeds: 0 decimal places for
+    KB/s (as before), 1 for MB/s and 2 for GB/s.
 
 [Unreleased]: https://github.com/polybar/polybar/compare/3.5.2...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+Each release should have the following subsections, if entries exist, in the
+given order: `Breaking`, `Build`, `Deprecated`, `Removed`, `Added`, `Changed`,
+`Fixed`, `Security`.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/polybar/polybar/compare/3.5.2...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,18 @@ wiki for more information.
 Also don't hesitate to ask for help, testing isn't that mature in polybar yet
 and some things may be harder/impossible to test right now.
 
+### Changelog
+
+If your PR introduces notable changes to polybar, please add them to the top of
+the `Unreleased` section in the `CHANGELOG.md` file at the root of this
+repository.
+Notable changes are any user-visible changes, like bug fixes, new config
+options, changes to the build, etc., but not for example code cleanup that
+doesn't change polybar's behavior.
+
+If you are unsure whether something is a notable change, just add it to the
+changelog and we can determine whether it is a notable change when reviewing.
+
 ### Documentation
 
 Right now, documentation for polybar lives in two places: The GitHub wiki and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,17 @@ If your PR introduces notable changes to polybar, please add them to the top of
 the `Unreleased` section in the `CHANGELOG.md` file at the root of this
 repository.
 Notable changes are any user-visible changes, like bug fixes, new config
-options, changes to the build, etc., but not for example code cleanup that
-doesn't change polybar's behavior.
+options, changes to the build, etc., but not, for example, code cleanup that
+doesn't change polybar's behavior or minor documentation changes.
+One thing that also should not be added to the changelog are bugfixes for
+unreleased features.
+
+Also add a reference to all issues that this PR addresses in parentheses behind
+the changelog entry:
+
+```
+[`#1234`](https://github.com/polybar/polybar/issues/1234)
+```
 
 If you are unsure whether something is a notable change, just add it to the
 changelog and we can determine whether it is a notable change when reviewing.

--- a/doc/dev/release-workflow.rst
+++ b/doc/dev/release-workflow.rst
@@ -144,17 +144,40 @@ The release commit needs to update the version number in:
 
 * ``version.txt``
 
-The commit message contains the `Changelog`_ for this release.
+The release commit must also finalize the `Changelog`_ for this release.
 
 Changelog
 ~~~~~~~~~
 
-Each release should come with a changelog briefly explaining what has changed
-for the user. It should generally be separated into 'Deprecations', 'Features',
-and 'Fixes', with 'Breaking Changes' listed separately at the top.
+The ``CHANGELOG.md`` file at the root of the repo should already contain all the
+changes for the upcoming release in a format based on
+`keep a changelog <https://keepachangelog.com/en/1.0.0/>`_.
 
-See `old releases <https://github.com/polybar/polybar/releases>`_ for how to
-format the changelog.
+For each release those changes should be checked to make sure we did not miss
+anything.
+
+For all releases, a new section of the following form should be created below
+the ``Unreleased`` section:
+
+.. code-block::
+
+  ## [X.Y.Z] - YYYY-MM-DD
+
+In addition the reference link for the release should be added to the top of the
+other links at the bottom of the document:
+
+.. code-block::
+
+  [X.Y.Z]: https://github.com/polybar/polybar/releases/tag/X.Y.Z
+
+Since the release isn't published yet, this link will not exist yet.
+
+All changes from the ``Unreleased`` section that apply to this release should be
+moved into the release section.
+For regular releases this is generally the entire ``Unreleased`` while for patch
+releases it will only be a few entries.
+
+.. TODO mention link updates for the unreleased section
 
 Since major releases generally break backwards compatibility in some way, their
 changelog should also prominently feature precisely what breaking changes were
@@ -178,7 +201,6 @@ After-Release Checklist
   If this fails for some reason, it should be triggered be triggered manually.
 * Create a PR that updates the AUR ``PKGBUILD`` files for the ``polybar`` and
   ``polybar-git`` packages (push after the release archive is uploaded).
-
 
 Deprecations
 ~~~~~~~~~~~~

--- a/doc/dev/release-workflow.rst
+++ b/doc/dev/release-workflow.rst
@@ -152,7 +152,6 @@ Changelog
 The ``CHANGELOG.md`` file at the root of the repo should already contain all the
 changes for the upcoming release in a format based on
 `keep a changelog <https://keepachangelog.com/en/1.0.0/>`_.
-
 For each release those changes should be checked to make sure we did not miss
 anything.
 
@@ -163,21 +162,25 @@ the ``Unreleased`` section:
 
   ## [X.Y.Z] - YYYY-MM-DD
 
-In addition the reference link for the release should be added to the top of the
-other links at the bottom of the document:
+In addition, the reference link for the release should be added and the
+reference link for the unreleased section should be updated at the bottom of the
+document:
 
 .. code-block::
 
+  [Unreleased]: https://github.com/polybar/polybar/compare/X.Y.Z...HEAD
   [X.Y.Z]: https://github.com/polybar/polybar/releases/tag/X.Y.Z
 
-Since the release isn't published yet, this link will not exist yet.
+Since the release tag doesn't exist yet, both of these links will be invalid
+until the release is published.
 
 All changes from the ``Unreleased`` section that apply to this release should be
-moved into the release section.
-For regular releases this is generally the entire ``Unreleased`` while for patch
-releases it will only be a few entries.
+moved into the new release section.
+For regular releases this is generally the entire ``Unreleased`` section, while
+for patch releases it will only be a few entries.
 
-.. TODO mention link updates for the unreleased section
+The contents of the release section can be copied into the draft release in
+GitHub's release tool with a heading named ``## Changelog``.
 
 Since major releases generally break backwards compatibility in some way, their
 changelog should also prominently feature precisely what breaking changes were


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Right now we manually create a changelog for each release, this is quite time
consuming for larger releases because we need to go through all the commits for
that release.

With this contributors should add their changes to the changelog directly with
the PR and for a release, we can basically copy-paste the changelog with some
minor cleanup.

This has the added benefit of precise documentation for which features and bugs
have been addresses but not yet released.

## Related Issues & Documents

This follows the format and philosophy of [keep a
changelog](https://keepachangelog.com/en/1.0.0/).

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes