### PR TITLE
fix(config): Don't treat an empty value as invalid

### DIFF
--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -225,6 +225,10 @@ chrono::duration<double> config::convert(string&& value) const {
 
 template <>
 rgba config::convert(string&& value) const {
+  if (value.empty()) {
+    return rgba{};
+  }
+
   rgba ret{value};
 
   if (!ret.has_color()) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
An empty color value in the config should be treated as if no color was
specified (explicitly). This is the same behavior as before.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes