### PR TITLE
feat: Module Visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added .ini extension check to the default config search.
   ([`#2323`](https://github.com/polybar/polybar/issues/2323))
 - IPC commands to change visibility of modules
+  (`hide.<name>`, `show.<name>`, and `toggle.<name>`)
   ([`#2108`](https://github.com/polybar/polybar/issues/2108))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#316`](https://github.com/polybar/polybar/issues/316))
 - Added .ini extension check to the default config search.
   ([`#2323`](https://github.com/polybar/polybar/issues/2323))
+- IPC commands to change visibility of modules
+  ([`#2108`](https://github.com/polybar/polybar/issues/2108))
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/config/config.cmake
+++ b/config/config.cmake
@@ -77,6 +77,8 @@ tray-padding = 2
 cursor-click = pointer
 cursor-scroll = ns-resize
 
+enable-ipc = true
+
 [module/xwindow]
 type = internal/xwindow
 label = %title:0:30:...%

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -76,8 +76,7 @@ class controller
   bool forward_action(const actions_util::action& cmd);
   bool try_forward_legacy_action(const string& cmd);
 
-  void switch_module_visibility(string module_name_raw, bool visible);
-  void switch_module_visibility(string module_name_raw);
+  void switch_module_visibility(string module_name_raw, int visible);
 
   connection& m_connection;
   signal_emitter& m_sig;

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -76,6 +76,9 @@ class controller
   bool forward_action(const actions_util::action& cmd);
   bool try_forward_legacy_action(const string& cmd);
 
+  void switch_module_visibility(string module_name_raw, bool visible);
+  void switch_module_visibility(string module_name_raw);
+
   connection& m_connection;
   signal_emitter& m_sig;
   const logger& m_log;

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -115,6 +115,7 @@ namespace modules {
     virtual string name() const = 0;
     virtual bool running() const = 0;
     virtual bool visible() const = 0;
+    virtual bool visible(bool value) = 0;
 
     /**
      * Handle action, possibly with data attached
@@ -146,7 +147,10 @@ namespace modules {
     string name_raw() const;
     string name() const;
     bool running() const;
+
     bool visible() const;
+    bool visible(bool value);
+
     void stop();
     void halt(string error_message);
     void teardown();

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -114,6 +114,7 @@ namespace modules {
     virtual string name_raw() const = 0;
     virtual string name() const = 0;
     virtual bool running() const = 0;
+    virtual bool visible() const = 0;
 
     /**
      * Handle action, possibly with data attached
@@ -145,6 +146,7 @@ namespace modules {
     string name_raw() const;
     string name() const;
     bool running() const;
+    bool visible() const;
     void stop();
     void halt(string error_message);
     void teardown();
@@ -184,6 +186,7 @@ namespace modules {
 
    private:
     atomic<bool> m_enabled{true};
+    atomic<bool> m_visible{true};
     atomic<bool> m_changed{true};
     string m_cache;
   };

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -115,7 +115,7 @@ namespace modules {
     virtual string name() const = 0;
     virtual bool running() const = 0;
     virtual bool visible() const = 0;
-    virtual bool visible(bool value) = 0;
+    virtual bool set_visible(bool value) = 0;
 
     /**
      * Handle action, possibly with data attached
@@ -149,7 +149,7 @@ namespace modules {
     bool running() const;
 
     bool visible() const;
-    bool visible(bool value);
+    bool set_visible(bool value);
 
     void stop();
     void halt(string error_message);

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -115,7 +115,7 @@ namespace modules {
     virtual string name() const = 0;
     virtual bool running() const = 0;
     virtual bool visible() const = 0;
-    virtual bool set_visible(bool value) = 0;
+    virtual void set_visible(bool value) = 0;
 
     /**
      * Handle action, possibly with data attached
@@ -149,7 +149,7 @@ namespace modules {
     bool running() const;
 
     bool visible() const;
-    bool set_visible(bool value);
+    void set_visible(bool value);
 
     void stop();
     void halt(string error_message);

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -62,7 +62,7 @@ namespace modules {
   }
 
   template <typename Impl>
-  bool module<Impl>::visible(bool value) {
+  bool module<Impl>::set_visible(bool value) {
     m_visible = value;
     return m_visible;
   }

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -62,6 +62,12 @@ namespace modules {
   }
 
   template <typename Impl>
+  bool module<Impl>::visible(bool value) {
+    m_visible = value;
+    return m_visible;
+  }
+
+  template <typename Impl>
   void module<Impl>::stop() {
     if (!static_cast<bool>(m_enabled)) {
       return;

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -65,6 +65,7 @@ namespace modules {
   void module<Impl>::set_visible(bool value) {
     m_log.info("%s: Visibility changed (state=%s)", m_name, value ? "shown" : "hidden");
     m_visible = value;
+    broadcast();
   }
 
   template <typename Impl>

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -62,10 +62,9 @@ namespace modules {
   }
 
   template <typename Impl>
-  bool module<Impl>::set_visible(bool value) {
+  void module<Impl>::set_visible(bool value) {
     m_log.info("%s: Visibility changed (state=%s)", m_name, value ? "shown" : "hidden");
     m_visible = value;
-    return m_visible;
   }
 
   template <typename Impl>

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -63,6 +63,7 @@ namespace modules {
 
   template <typename Impl>
   bool module<Impl>::set_visible(bool value) {
+    m_log.info("%s: Visibility changed (state=%s)", m_name, value ? "shown" : "hidden");
     m_visible = value;
     return m_visible;
   }

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -57,6 +57,11 @@ namespace modules {
   }
 
   template <typename Impl>
+  bool module<Impl>::visible() const {
+    return static_cast<bool>(m_visible);
+  }
+
+  template <typename Impl>
   void module<Impl>::stop() {
     if (!static_cast<bool>(m_enabled)) {
       return;

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -30,9 +30,7 @@ namespace modules {
     bool visible() const {                                                              \
       return false;                                                                     \
     }                                                                                   \
-    void set_visible(bool value) {                                                      \
-      (void)value;                                                                      \
-    }                                                                                   \
+    void set_visible(bool) {}                                                           \
     void start() {}                                                                     \
     void stop() {}                                                                      \
     void halt(string) {}                                                                \

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -27,6 +27,12 @@ namespace modules {
     bool running() const {                                                              \
       return false;                                                                     \
     }                                                                                   \
+    bool visible() const {                                                              \
+      return false;                                                                     \
+    }                                                                                   \
+    bool visible(bool value) {                                                          \
+      return false;                                                                     \
+    }                                                                                   \
     void start() {}                                                                     \
     void stop() {}                                                                      \
     void halt(string) {}                                                                \

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -31,6 +31,7 @@ namespace modules {
       return false;                                                                     \
     }                                                                                   \
     bool set_visible(bool value) {                                                      \
+      (void)value;                                                                      \
       return false;                                                                     \
     }                                                                                   \
     void start() {}                                                                     \

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -30,9 +30,8 @@ namespace modules {
     bool visible() const {                                                              \
       return false;                                                                     \
     }                                                                                   \
-    bool set_visible(bool value) {                                                      \
+    void set_visible(bool value) {                                                      \
       (void)value;                                                                      \
-      return false;                                                                     \
     }                                                                                   \
     void start() {}                                                                     \
     void stop() {}                                                                      \

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -30,7 +30,7 @@ namespace modules {
     bool visible() const {                                                              \
       return false;                                                                     \
     }                                                                                   \
-    bool visible(bool value) {                                                          \
+    bool set_visible(bool value) {                                                      \
       return false;                                                                     \
     }                                                                                   \
     void start() {}                                                                     \

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -530,6 +530,16 @@ bool controller::forward_action(const actions_util::action& action_triple) {
   return true;
 }
 
+void controller::switch_module_visibility(string module_name_raw, bool visible) {
+  for(auto&& mod : m_modules) {
+    if(mod->name_raw() != module_name_raw)
+      continue;
+
+    mod->visible(visible);
+    return;
+  }
+}
+
 /**
  * Process stored input data
  */
@@ -833,6 +843,8 @@ bool controller::on(const signals::ipc::command& evt) {
     return false;
   }
 
+  string hide_module{"hide."};
+
   if (command == "quit") {
     enqueue(make_quit_evt(false));
   } else if (command == "restart") {
@@ -843,6 +855,8 @@ bool controller::on(const signals::ipc::command& evt) {
     m_bar->show();
   } else if (command == "toggle") {
     m_bar->toggle();
+  } else if (command.find(hide_module) == 0) {
+    switch_module_visibility(command.substr(hide_module.length()), false);
   } else {
     m_log.warn("\"%s\" is not a valid ipc command", command);
   }

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -546,7 +546,7 @@ void controller::switch_module_visibility(string module_name_raw, int visible) {
     return;
   }
 
-  m_log.err("controller: Module '%s' not found for visibility change (state=%s)", module_name_raw, value ? "shown" : "hidden");
+  m_log.err("controller: Module '%s' not found for visibility change (state=%s)", module_name_raw, visible ? "shown" : "hidden");
 }
 
 /**

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -535,7 +535,17 @@ void controller::switch_module_visibility(string module_name_raw, bool visible) 
     if(mod->name_raw() != module_name_raw)
       continue;
 
-    mod->visible(visible);
+    mod->set_visible(visible);
+    return;
+  }
+}
+
+void controller::switch_module_visibility(string module_name_raw) {
+  for(auto&& mod : m_modules) {
+    if(mod->name_raw() != module_name_raw)
+      continue;
+
+    mod->set_visible(!mod->visible());
     return;
   }
 }
@@ -844,6 +854,8 @@ bool controller::on(const signals::ipc::command& evt) {
   }
 
   string hide_module{"hide."};
+  string show_module{"show."};
+  string toggle_module{"toggle."};
 
   if (command == "quit") {
     enqueue(make_quit_evt(false));
@@ -857,6 +869,10 @@ bool controller::on(const signals::ipc::command& evt) {
     m_bar->toggle();
   } else if (command.find(hide_module) == 0) {
     switch_module_visibility(command.substr(hide_module.length()), false);
+  } else if (command.find(show_module) == 0) {
+    switch_module_visibility(command.substr(show_module.length()), true);
+  } else if (command.find(toggle_module) == 0) {
+    switch_module_visibility(command.substr(toggle_module.length()));
   } else {
     m_log.warn("\"%s\" is not a valid ipc command", command);
   }

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -530,24 +530,23 @@ bool controller::forward_action(const actions_util::action& action_triple) {
   return true;
 }
 
-void controller::switch_module_visibility(string module_name_raw, bool visible) {
+void controller::switch_module_visibility(string module_name_raw, int visible) {
   for(auto&& mod : m_modules) {
     if(mod->name_raw() != module_name_raw)
       continue;
 
-    mod->set_visible(visible);
+    if(visible == 0) {
+      mod->set_visible(false);
+    } else if(visible == 1) {
+      mod->set_visible(true);
+    } else if(visible == 2) {
+      mod->set_visible(!mod->visible());
+    }
+
     return;
   }
-}
 
-void controller::switch_module_visibility(string module_name_raw) {
-  for(auto&& mod : m_modules) {
-    if(mod->name_raw() != module_name_raw)
-      continue;
-
-    mod->set_visible(!mod->visible());
-    return;
-  }
+  m_log.err("Module '%s' not found.", module_name_raw);
 }
 
 /**
@@ -868,11 +867,11 @@ bool controller::on(const signals::ipc::command& evt) {
   } else if (command == "toggle") {
     m_bar->toggle();
   } else if (command.find(hide_module) == 0) {
-    switch_module_visibility(command.substr(hide_module.length()), false);
+    switch_module_visibility(command.substr(hide_module.length()), 0);
   } else if (command.find(show_module) == 0) {
-    switch_module_visibility(command.substr(show_module.length()), true);
+    switch_module_visibility(command.substr(show_module.length()), 1);
   } else if (command.find(toggle_module) == 0) {
-    switch_module_visibility(command.substr(toggle_module.length()));
+    switch_module_visibility(command.substr(toggle_module.length()), 2);
   } else {
     m_log.warn("\"%s\" is not a valid ipc command", command);
   }

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -546,7 +546,7 @@ void controller::switch_module_visibility(string module_name_raw, int visible) {
     return;
   }
 
-  m_log.err("Module '%s' not found.", module_name_raw);
+  m_log.err("controller: Module '%s' not found for visibility change (state=%s)", module_name_raw, value ? "shown" : "hidden");
 }
 
 /**

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -531,15 +531,15 @@ bool controller::forward_action(const actions_util::action& action_triple) {
 }
 
 void controller::switch_module_visibility(string module_name_raw, int visible) {
-  for(auto&& mod : m_modules) {
-    if(mod->name_raw() != module_name_raw)
+  for (auto&& mod : m_modules) {
+    if (mod->name_raw() != module_name_raw)
       continue;
 
-    if(visible == 0) {
+    if (visible == 0) {
       mod->set_visible(false);
-    } else if(visible == 1) {
+    } else if (visible == 1) {
       mod->set_visible(true);
-    } else if(visible == 2) {
+    } else if (visible == 2) {
       mod->set_visible(!mod->visible());
     }
 

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -600,7 +600,7 @@ bool controller::process_update(bool force) {
     }
 
     for (const auto& module : block.second) {
-      if (!module->running()) {
+      if (!module->running() || !module->visible()) {
         continue;
       }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other

## Description
Creates new IPC commands to toggle the visibility of a specific module. End goal (as expressed in #2108) is to stop processing hidden modules, although I will probably complete an initial implementation to just hide the modules.

```sh
$ polybar-msg [-p PID] cmd hide.mymodule # Hides module mymodule
$ polybar-msg [-p PID] cmd show.mymodule # Shows module mymodule
$ polybar-msg [-p PID] cmd toggle.mymodule # Toggles visibility of mymodule
```

## Related Issues & Documents
Closes #2108

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
