### PR TITLE
Release 3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Each release should have the following subsections, if entries exist, in the
+given order: `Breaking`, `Build`, `Deprecated`, `Removed`, `Added`, `Changed`,
+`Fixed`, `Security`.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.5.3] - 2020-12-23
+### Build
+- Don't use `git` when building documentation ([`#2311`](https://github.com/polybar/polybar/issues/2309))
+### Fixed
+- Empty color values are no longer treated as invalid and no longer produce an error.
+
+[Unreleased]: https://github.com/polybar/polybar/compare/3.5.3...HEAD
+[3.5.3]: https://github.com/polybar/polybar/releases/tag/3.5.3

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,23 +20,17 @@ from docutils.nodes import Node
 from sphinx.domains.changeset import VersionChange
 import packaging.version
 
-def get_version():
+def get_version(root_path):
   """
-  Searches for the version.txt file and extracts the version from it
+  Reads the polybar version from the version.txt at the root of the repo.
+  """
+  path = Path(root_path) / "version.txt"
+  with open(path, "r") as f:
+    for line in f.readlines():
+      if not line.startswith("#"):
+        return packaging.version.parse(line)
 
-  Searches up the directory tree from the conf.py file because depending on the
-  build method, the conf.py file will be at a different location (because it is
-  configured by cmake)
-  """
-  current_path = Path(__file__).parent
-  while current_path != current_path.parent:
-    candidate = current_path / "version.txt"
-    if candidate.exists():
-      with open(candidate, "r") as f:
-        for line in f.readlines():
-          if not line.startswith("#"):
-            return packaging.version.parse(line)
-    current_path = current_path.parent
+  raise RuntimeError("No version found in {}".format(path))
 
 
 
@@ -61,11 +55,6 @@ else:
 # The full version, including alpha/beta/rc tags
 release = version
 
-# The version from the version.txt file. Since we are not always first
-# configured by cmake, we don't necessarily have access to the current version
-# number
-version_txt = get_version()
-
 # Set path to documentation
 if on_rtd:
   # On readthedocs conf.py is already in the doc folder
@@ -74,6 +63,11 @@ else:
   # In all other builds conf.py is configured with cmake and put into the
   # build folder.
   doc_path = '@doc_path@'
+
+# The version from the version.txt file. Since we are not always first
+# configured by cmake, we don't necessarily have access to the current version
+# number
+version_txt = get_version(Path(doc_path).absolute().parent)
 
 # -- General configuration ---------------------------------------------------
 

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -225,6 +225,10 @@ chrono::duration<double> config::convert(string&& value) const {
 
 template <>
 rgba config::convert(string&& value) const {
+  if (value.empty()) {
+    return rgba{};
+  }
+
   rgba ret{value};
 
   if (!ret.has_color()) {

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
 # Polybar version information
 # Update this on every release
 # This is used to create the version string if a git repo is not available
-3.5.2
+3.5.3


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: Release PR

## Description

Post-release checklist:

* [ ] Update `PKGBUILD` (remove `git` from the `polybar` package)
* [ ] Add to #1971

### Build
### Build
- Don't use `git` when building documentation ([`#2311`](https://github.com/polybar/polybar/issues/2309))
### Fixed
- Empty color values are no longer treated as invalid and no longer produce an error.


## Related Issues & Documents

Includes changes from #2311, #2312, and #2315

Draft Release: https://github.com/polybar/polybar/releases/tag/untagged-1feb0647c0889d90abb1

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
