### PR TITLE
Add support for %nwin% in xworkspaces label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/network`: `interface-type` may be used in place of `interface` to
   automatically select a network interface
   ([`#2025`](https://github.com/polybar/polybar/pull/2025))
+- `internal/xworkspaces`: `%nwin%` can be used to display the number of open
+  windows per workspace
+  ([`#604`](https://github.com/polybar/polybar/issues/604))
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -99,6 +99,7 @@ namespace modules {
      * Maps an xcb window to its desktop number
      */
     map<xcb_window_t, unsigned int> m_clients;
+    map<unsigned int, unsigned int> m_windows;
     vector<unique_ptr<viewport>> m_viewports;
     map<desktop_state, label_t> m_labels;
     label_t m_monitorlabel;

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -144,9 +144,11 @@ namespace modules {
 
     // rebuild entire mapping of clients to desktops
     m_clients.clear();
+    m_windows.clear();
     for (auto&& client : newclients) {
       auto desk = ewmh_util::get_desktop_from_window(client);
       m_clients[client] = desk;
+      m_windows[desk]++;
     }
 
     rebuild_urgent_hints();
@@ -270,6 +272,7 @@ namespace modules {
         d->label->reset_tokens();
         d->label->replace_token("%index%", to_string(d->index + 1));
         d->label->replace_token("%name%", m_desktop_names[d->index]);
+        d->label->replace_token("%nwin%", to_string(m_windows[d->index]));
         d->label->replace_token("%icon%", m_icons->get(m_desktop_names[d->index], DEFAULT_ICON)->get());
       }
     }


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

In the **xworkspace** module, added %nwin% token to display the number of windows in a workspace. Affects the `label-active`, `label-occupied`, `label-urgent` and `label-empty` properties.

![image](https://user-images.githubusercontent.com/12929626/103047289-9980fe00-4550-11eb-80da-12b0dce9304f.png)

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Closes #604 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

At the **Modules: xworkspace** page, add the %nwin% as an available token for `label-active`, `label-occupied`, `label-urgent` and `label-empty` properties