### PR TITLE
Fix sphinx warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          cmake -DDISABLE_ALL=ON -DBUILD_DOC=ON ..
+          cmake -DDISABLE_ALL=ON -DBUILD_DOC=ON -DSPHINX_FLAGS="-W" ..
           make doc
 
   ipc:

--- a/doc/dev/release-workflow.rst
+++ b/doc/dev/release-workflow.rst
@@ -158,7 +158,7 @@ anything.
 For all releases, a new section of the following form should be created below
 the ``Unreleased`` section:
 
-.. code-block::
+.. code-block:: md
 
   ## [X.Y.Z] - YYYY-MM-DD
 
@@ -166,7 +166,7 @@ In addition, the reference link for the release should be added and the
 reference link for the unreleased section should be updated at the bottom of the
 document:
 
-.. code-block::
+.. code-block:: md
 
   [Unreleased]: https://github.com/polybar/polybar/compare/X.Y.Z...HEAD
   [X.Y.Z]: https://github.com/polybar/polybar/releases/tag/X.Y.Z


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

The `code-blocks::` directive requires a language before sphinx 2.0. This caused a warning (but not an error) in CI and readthedocs, causing that code block to be stripped out.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
