### PR TITLE
Reduce overhead of mpd module

### DIFF
--- a/include/adapters/mpd.hpp
+++ b/include/adapters/mpd.hpp
@@ -93,6 +93,7 @@ namespace mpd {
     void idle();
     bool noidle();
     int recv_idle();
+    int try_recv_idle(int timeout);
 
     unique_ptr<mpdstatus> get_status();
     unique_ptr<mpdstatus> get_status_safe();

--- a/include/adapters/mpd.hpp
+++ b/include/adapters/mpd.hpp
@@ -91,7 +91,8 @@ namespace mpd {
 
     int get_fd();
     void idle();
-    int noidle();
+    bool noidle();
+    int recv_idle();
 
     unique_ptr<mpdstatus> get_status();
     unique_ptr<mpdstatus> get_status_safe();

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -99,7 +99,7 @@ namespace modules {
     chrono::system_clock::time_point m_lastsync{};
     float m_synctime{1.0f};
 
-    int m_quick_attempts{0};
+    int m_connect_attempts{0};
 
     // This flag is used to let thru a broadcast once every time
     // the connection state changes

--- a/src/adapters/mpd.cpp
+++ b/src/adapters/mpd.cpp
@@ -201,12 +201,21 @@ namespace mpd {
     }
   }
 
-  int mpdconnection::noidle() {
+  bool mpdconnection::noidle() {
+    check_connection(m_connection.get());
+    bool success = true;
+    if (m_idle) {
+      success = mpd_send_noidle(m_connection.get());
+    }
+    return success;
+  }
+
+  int mpdconnection::recv_idle() {
     check_connection(m_connection.get());
     int flags = 0;
-    if (m_idle && mpd_send_noidle(m_connection.get())) {
-      m_idle = false;
+    if (m_idle) {
       flags = mpd_recv_idle(m_connection.get(), true);
+      m_idle = false;
       mpd_response_finish(m_connection.get());
       check_errors(m_connection.get());
     }

--- a/src/adapters/mpd.cpp
+++ b/src/adapters/mpd.cpp
@@ -1,3 +1,5 @@
+#include <poll.h>
+
 #include <cassert>
 #include <csignal>
 #include <thread>
@@ -220,6 +222,20 @@ namespace mpd {
       check_errors(m_connection.get());
     }
     return flags;
+  }
+
+  int mpdconnection::try_recv_idle(int timeout) {
+    struct pollfd pfd = {m_fd, POLLIN, 0};
+
+    int poll_ret = poll(&pfd, 1, timeout);
+
+    if (poll_ret > 0) {
+      return recv_idle();
+    } else if (poll_ret == 0) {
+      return 0;
+    } else {
+      throw mpd_exception("poll() returned error: "s + std::strerror(errno));
+    }
   }
 
   unique_ptr<mpdstatus> mpdconnection::get_status() {

--- a/src/adapters/mpd.cpp
+++ b/src/adapters/mpd.cpp
@@ -197,7 +197,7 @@ namespace mpd {
   void mpdconnection::idle() {
     check_connection(m_connection.get());
     if (!m_idle) {
-      mpd_send_idle(m_connection.get());
+      mpd_send_idle_mask(m_connection.get(), (mpd_idle)(MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS));
       check_errors(m_connection.get());
       m_idle = true;
     }

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -152,10 +152,10 @@ namespace modules {
 
   void mpd_module::idle() {
     if (connected()) {
-      m_quick_attempts = 0;
+      m_connect_attempts = 0;
       sleep(80ms);
     } else {
-      sleep(m_quick_attempts++ < 5 ? 0.5s : 2s);
+      sleep(++m_connect_attempts < 10 ? m_connect_attempts * 0.5s : 5s);
     }
   }
 

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -160,9 +160,6 @@ namespace modules {
   }
 
   bool mpd_module::has_event() {
-    bool def =
-        (m_statebroadcasted == (connected() ? mpd::connection_state::DISCONNECTED : mpd::connection_state::CONNECTED));
-
     try {
       if (!m_mpd) {
         m_mpd = factory_util::unique<mpdconnection>(m_log, m_host, m_port, m_pass);
@@ -173,11 +170,11 @@ namespace modules {
     } catch (const mpd_exception& err) {
       m_log.err("%s: %s", name(), err.what());
       m_mpd.reset();
-      return def;
+      return true;
     }
 
-    if (!connected()) {
-      return def;
+    if (!connected() || m_statebroadcasted != mpd::connection_state::CONNECTED) {
+      return true;
     }
 
     if (!m_status) {
@@ -205,7 +202,7 @@ namespace modules {
     } catch (const mpd_exception& err) {
       m_log.err("%s: %s", name(), err.what());
       m_mpd.reset();
-      return def;
+      return false;
     }
 
     if (track_time) {
@@ -218,7 +215,7 @@ namespace modules {
       }
     }
 
-    return def;
+    return false;
   }
 
   bool mpd_module::update() {

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -160,13 +160,8 @@ namespace modules {
   }
 
   bool mpd_module::has_event() {
-    bool def = false;
-
-    if (!connected() && m_statebroadcasted == mpd::connection_state::CONNECTED) {
-      def = true;
-    } else if (connected() && m_statebroadcasted == mpd::connection_state::DISCONNECTED) {
-      def = true;
-    }
+    bool def =
+        (m_statebroadcasted == (connected() ? mpd::connection_state::DISCONNECTED : mpd::connection_state::CONNECTED));
 
     try {
       if (!m_mpd) {

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -193,7 +193,8 @@ namespace modules {
       m_mpd->idle();
 
       int idle_flags = 0;
-      if ((idle_flags = m_mpd->noidle()) != 0) {
+      m_mpd->noidle();
+      if ((idle_flags = m_mpd->recv_idle()) != 0) {
         // Update status on every event
         m_status->update(idle_flags, m_mpd.get());
         return true;


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [X] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
By default mpd module causes a lot of wakups and results in quite some network traffic even when mpd is not playing anything. This in turn results in unneeded battery use. This PR introduces proper use of idle/recv_idle along with polling on mpd socket to make sure overhead of mpd module is minimal.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [X] Does not require documentation changes
