### PR TITLE
feat(xworkspaces): Persistent urgent hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IPC commands to change visibility of modules
   (`hide.<name>`, `show.<name>`, and `toggle.<name>`)
   ([`#2108`](https://github.com/polybar/polybar/issues/2108))
+- `internal/xworkspaces`: Make the urgent hint persistent
+  ([`#1081`](https://github.com/polybar/polybar/issues/1081))
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -65,7 +65,7 @@ namespace modules {
     static constexpr auto EVENT_PREV = "prev";
 
    protected:
-    void handle(const evt::property_notify& evt);
+    void handle(const evt::property_notify& evt) override;
 
     void rebuild_clientlist();
     void rebuild_desktops();
@@ -91,6 +91,7 @@ namespace modules {
     bool m_monitorsupport{true};
 
     vector<string> m_desktop_names;
+    std::unordered_map<string, bool> m_urgent_desktops;
     unsigned int m_current_desktop;
     string m_current_desktop_name;
 

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -65,12 +65,12 @@ namespace modules {
     static constexpr auto EVENT_PREV = "prev";
 
    protected:
-    void handle(const evt::property_notify& evt) override;
+    void handle(const evt::property_notify& evt);
 
     void rebuild_clientlist();
+    void rebuild_urgent_hints();
     void rebuild_desktops();
     void rebuild_desktop_states();
-    void set_desktop_urgent(xcb_window_t window);
 
     bool input(const string& action, const string& data);
 
@@ -91,7 +91,7 @@ namespace modules {
     bool m_monitorsupport{true};
 
     vector<string> m_desktop_names;
-    std::unordered_map<string, bool> m_urgent_desktops;
+    vector<bool> m_urgent_desktops;
     unsigned int m_current_desktop;
     string m_current_desktop_name;
 

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -245,6 +245,9 @@ namespace modules {
       for (auto&& d : v->desktops) {
         if (d->index == m_current_desktop) {
           d->state = desktop_state::ACTIVE;
+          m_urgent_desktops.erase(m_current_desktop_name);
+        } else if (m_urgent_desktops[m_desktop_names[d->index]]) {
+          d->state = desktop_state::URGENT;
         } else if (occupied_desks.count(d->index) > 0) {
           d->state = desktop_state::OCCUPIED;
         } else {
@@ -287,6 +290,7 @@ namespace modules {
       for (auto&& d : v->desktops) {
         if (d->index == desk && d->state != desktop_state::URGENT) {
           d->state = desktop_state::URGENT;
+          m_urgent_desktops[m_desktop_names[d->index]] = true;
 
           d->label = m_labels.at(d->state)->clone();
           d->label->reset_tokens();


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This is a continuation of @Lomadriel's work in #1693. There were some edge cases that the PR didn't handle.
Now the urgent hint should always reflect the state in the window manager. It is a bit more resource intensive because it has to go through all the windows to update the urgent hint.

## Related Issues & Documents

Fixes #1081 
Closes #1693 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

We can remove the note about the urgency hint from the xworkspaces page