### PR TITLE
Add compiler warning for missing override specifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,12 @@ jobs:
           make check
           cd $POLYBAR_DIR
           bash <(curl -s https://codecov.io/bash) -F unittests -a "-ap" -Z
+      - name: Upload Logs
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: cmake
+          path: |
+            build/CMakeFiles/CMakeError.log
+            build/CMakeFiles/CMakeOutput.log
+          retention-days: 5

--- a/cmake/cxx.cmake
+++ b/cmake/cxx.cmake
@@ -25,6 +25,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
 
 if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   # Need dprintf() for FreeBSD 11.1 and older

--- a/cmake/cxx.cmake
+++ b/cmake/cxx.cmake
@@ -22,10 +22,15 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 # Compiler flags
+include(CheckCXXCompilerFlag)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpedantic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+check_cxx_compiler_flag("-Wsuggest-override" HAS_SUGGEST_OVERRIDE)
+if (HAS_SUGGEST_OVERRIDE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+endif()
+unset(HAS_SUGGEST_OVERRIDE)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   # Need dprintf() for FreeBSD 11.1 and older

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -86,23 +86,23 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   void reconfigure_wm_hints();
   void broadcast_visibility();
 
-  void handle(const evt::client_message& evt);
-  void handle(const evt::destroy_notify& evt);
-  void handle(const evt::enter_notify& evt);
-  void handle(const evt::leave_notify& evt);
-  void handle(const evt::motion_notify& evt);
-  void handle(const evt::button_press& evt);
-  void handle(const evt::expose& evt);
-  void handle(const evt::property_notify& evt);
-  void handle(const evt::configure_notify& evt);
+  void handle(const evt::client_message& evt) override;
+  void handle(const evt::destroy_notify& evt) override;
+  void handle(const evt::enter_notify& evt) override;
+  void handle(const evt::leave_notify& evt) override;
+  void handle(const evt::motion_notify& evt) override;
+  void handle(const evt::button_press& evt) override;
+  void handle(const evt::expose& evt) override;
+  void handle(const evt::property_notify& evt) override;
+  void handle(const evt::configure_notify& evt) override;
 
-  bool on(const signals::eventqueue::start&);
-  bool on(const signals::ui::unshade_window&);
-  bool on(const signals::ui::shade_window&);
-  bool on(const signals::ui::tick&);
-  bool on(const signals::ui::dim_window&);
+  bool on(const signals::eventqueue::start&) override;
+  bool on(const signals::ui::unshade_window&) override;
+  bool on(const signals::ui::shade_window&) override;
+  bool on(const signals::ui::tick&) override;
+  bool on(const signals::ui::dim_window&) override;
 #if WITH_XCURSOR
-  bool on(const signals::ui::cursor_change&);
+  bool on(const signals::ui::cursor_change&) override;
 #endif
 
  private:

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -58,17 +58,17 @@ class controller
   void process_inputdata();
   bool process_update(bool force);
 
-  bool on(const signals::eventqueue::notify_change& evt);
-  bool on(const signals::eventqueue::notify_forcechange& evt);
-  bool on(const signals::eventqueue::exit_terminate& evt);
-  bool on(const signals::eventqueue::exit_reload& evt);
-  bool on(const signals::eventqueue::check_state& evt);
-  bool on(const signals::ui::ready& evt);
-  bool on(const signals::ui::button_press& evt);
-  bool on(const signals::ipc::action& evt);
-  bool on(const signals::ipc::command& evt);
-  bool on(const signals::ipc::hook& evt);
-  bool on(const signals::ui::update_background& evt);
+  bool on(const signals::eventqueue::notify_change& evt) override;
+  bool on(const signals::eventqueue::notify_forcechange& evt) override;
+  bool on(const signals::eventqueue::exit_terminate& evt) override;
+  bool on(const signals::eventqueue::exit_reload& evt) override;
+  bool on(const signals::eventqueue::check_state& evt) override;
+  bool on(const signals::ui::ready& evt) override;
+  bool on(const signals::ui::button_press& evt) override;
+  bool on(const signals::ipc::action& evt) override;
+  bool on(const signals::ipc::command& evt) override;
+  bool on(const signals::ipc::hook& evt) override;
+  bool on(const signals::ui::update_background& evt) override;
 
  private:
   size_t setup_modules(alignment align);

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -71,22 +71,22 @@ class renderer
   void flush(alignment a);
   void highlight_clickable_areas();
 
-  bool on(const signals::ui::request_snapshot& evt);
-  bool on(const signals::parser::change_background& evt);
-  bool on(const signals::parser::change_foreground& evt);
-  bool on(const signals::parser::change_underline& evt);
-  bool on(const signals::parser::change_overline& evt);
-  bool on(const signals::parser::change_font& evt);
-  bool on(const signals::parser::change_alignment& evt);
-  bool on(const signals::parser::reverse_colors&);
-  bool on(const signals::parser::offset_pixel& evt);
-  bool on(const signals::parser::attribute_set& evt);
-  bool on(const signals::parser::attribute_unset& evt);
-  bool on(const signals::parser::attribute_toggle& evt);
-  bool on(const signals::parser::action_begin& evt);
-  bool on(const signals::parser::action_end& evt);
-  bool on(const signals::parser::text& evt);
-  bool on(const signals::parser::control& evt);
+  bool on(const signals::ui::request_snapshot& evt) override;
+  bool on(const signals::parser::change_background& evt) override;
+  bool on(const signals::parser::change_foreground& evt) override;
+  bool on(const signals::parser::change_underline& evt) override;
+  bool on(const signals::parser::change_overline& evt) override;
+  bool on(const signals::parser::change_font& evt) override;
+  bool on(const signals::parser::change_alignment& evt) override;
+  bool on(const signals::parser::reverse_colors&) override;
+  bool on(const signals::parser::offset_pixel& evt) override;
+  bool on(const signals::parser::attribute_set& evt) override;
+  bool on(const signals::parser::attribute_unset& evt) override;
+  bool on(const signals::parser::attribute_toggle& evt) override;
+  bool on(const signals::parser::action_begin& evt) override;
+  bool on(const signals::parser::action_end& evt) override;
+  bool on(const signals::parser::text& evt) override;
+  bool on(const signals::parser::control& evt) override;
 
  protected:
   struct reserve_area {

--- a/include/components/screen.hpp
+++ b/include/components/screen.hpp
@@ -45,7 +45,9 @@ class screen : public xpp::event::sink<evt::randr_screen_change_notify> {
   xcb_window_t m_proxy{XCB_NONE};
 
   vector<monitor_t> m_monitors;
-  struct size m_size {0U, 0U};
+  struct size m_size {
+    0U, 0U
+  };
   bool m_sigraised{false};
 
   bool have_monitors_changed() const;

--- a/include/components/screen.hpp
+++ b/include/components/screen.hpp
@@ -33,7 +33,7 @@ class screen : public xpp::event::sink<evt::randr_screen_change_notify> {
   }
 
  protected:
-  void handle(const evt::randr_screen_change_notify& evt);
+  void handle(const evt::randr_screen_change_notify& evt) override;
 
  private:
   connection& m_connection;

--- a/include/events/signal_receiver.hpp
+++ b/include/events/signal_receiver.hpp
@@ -42,7 +42,7 @@ class signal_receiver : public signal_receiver_interface,
                         public signal_receiver_impl<Signal>,
                         public signal_receiver_impl<Signals>... {
  public:
-  prio priority() const {
+  prio priority() const override {
     return Priority;
   }
 };

--- a/include/events/signal_receiver.hpp
+++ b/include/events/signal_receiver.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <map>
-#include <unordered_map>
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
 
 #include "common.hpp"
 

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -48,7 +48,7 @@ namespace modules {
    public:
     explicit battery_module(const bar_settings&, string);
 
-    void start();
+    void start() override;
     void teardown();
     void idle();
     bool on_event(inotify_event* event);

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -41,7 +41,7 @@ namespace modules {
    public:
     explicit bspwm_module(const bar_settings&, string);
 
-    void stop();
+    void stop() override;
     bool has_event();
     bool update();
     string get_output();

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -46,7 +46,7 @@ namespace modules {
    public:
     explicit i3_module(const bar_settings&, string);
 
-    void stop();
+    void stop() override;
     bool has_event();
     bool update();
     bool build(builder* builder, const string& tag) const;

--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -26,7 +26,7 @@ namespace modules {
    public:
     explicit ipc_module(const bar_settings&, string);
 
-    void start();
+    void start() override;
     void update() {}
     string get_output();
     bool build(builder* builder, const string& tag) const;

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -145,21 +145,21 @@ namespace modules {
     module(const bar_settings bar, string name);
     ~module() noexcept;
 
-    string type() const;
+    string type() const override;
 
-    string name_raw() const;
-    string name() const;
-    bool running() const;
+    string name_raw() const override;
+    string name() const override;
+    bool running() const override;
 
-    bool visible() const;
-    void set_visible(bool value);
+    bool visible() const override;
+    void set_visible(bool value) override;
 
-    void stop();
-    void halt(string error_message);
+    void stop() override;
+    void halt(string error_message) override;
     void teardown();
-    string contents();
+    string contents() override;
 
-    bool input(const string& action, const string& data) final;
+    bool input(const string& action, const string& data) final override;
 
    protected:
     void broadcast();

--- a/include/modules/meta/event_module.hpp
+++ b/include/modules/meta/event_module.hpp
@@ -10,7 +10,7 @@ namespace modules {
    public:
     using module<Impl>::module;
 
-    void start() {
+    void start() override {
       this->m_mainthread = thread(&event_module::runner, this);
     }
 

--- a/include/modules/meta/event_module.hpp
+++ b/include/modules/meta/event_module.hpp
@@ -40,6 +40,6 @@ namespace modules {
       }
     }
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/inotify_module.hpp
+++ b/include/modules/meta/inotify_module.hpp
@@ -88,6 +88,6 @@ namespace modules {
    private:
     map<string, int> m_watchlist;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/inotify_module.hpp
+++ b/include/modules/meta/inotify_module.hpp
@@ -11,7 +11,7 @@ namespace modules {
    public:
     using module<Impl>::module;
 
-    void start() {
+    void start() override {
       this->m_mainthread = thread(&inotify_module::runner, this);
     }
 

--- a/include/modules/meta/static_module.hpp
+++ b/include/modules/meta/static_module.hpp
@@ -22,6 +22,6 @@ namespace modules {
       return true;
     }
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/static_module.hpp
+++ b/include/modules/meta/static_module.hpp
@@ -10,7 +10,7 @@ namespace modules {
    public:
     using module<Impl>::module;
 
-    void start() {
+    void start() override {
       this->m_mainthread = thread([&] {
         this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
         CAST_MOD(Impl)->update();

--- a/include/modules/meta/timer_module.hpp
+++ b/include/modules/meta/timer_module.hpp
@@ -12,7 +12,7 @@ namespace modules {
    public:
     using module<Impl>::module;
 
-    void start() {
+    void start() override {
       this->m_mainthread = thread(&timer_module::runner, this);
     }
 

--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -12,8 +12,8 @@ namespace modules {
     explicit script_module(const bar_settings&, string);
     ~script_module() {}
 
-    void start();
-    void stop();
+    void start() override;
+    void stop() override;
 
     string get_output();
     bool build(builder* builder, const string& tag) const;

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -15,29 +15,29 @@ namespace modules {
       throw application_error("No built-in support for '" + string{MODULE_TYPE} + "'"); \
     }                                                                                   \
     static constexpr auto TYPE = MODULE_TYPE;                                           \
-    string type() const {                                                               \
+    string type() const override {                                                      \
       return "";                                                                        \
     }                                                                                   \
-    string name_raw() const {                                                           \
+    string name_raw() const override {                                                  \
       return "";                                                                        \
     }                                                                                   \
-    string name() const {                                                               \
+    string name() const override {                                                      \
       return "";                                                                        \
     }                                                                                   \
-    bool running() const {                                                              \
+    bool running() const override {                                                     \
       return false;                                                                     \
     }                                                                                   \
-    bool visible() const {                                                              \
+    bool visible() const override {                                                     \
       return false;                                                                     \
     }                                                                                   \
-    void set_visible(bool) {}                                                           \
-    void start() {}                                                                     \
-    void stop() {}                                                                      \
-    void halt(string) {}                                                                \
-    string contents() {                                                                 \
+    void set_visible(bool) override {}                                                  \
+    void start() override {}                                                            \
+    void stop() override {}                                                             \
+    void halt(string) override {}                                                       \
+    string contents() override {                                                        \
       return "";                                                                        \
     }                                                                                   \
-    bool input(const string&, const string&) {                                          \
+    bool input(const string&, const string&) override {                                 \
       return false;                                                                     \
     }                                                                                   \
   }

--- a/include/modules/xbacklight.hpp
+++ b/include/modules/xbacklight.hpp
@@ -36,7 +36,7 @@ namespace modules {
     static constexpr const char* EVENT_DEC = "dec";
 
    protected:
-    void handle(const evt::randr_notify& evt);
+    void handle(const evt::randr_notify& evt) override;
 
     void action_inc();
     void action_dec();

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -34,9 +34,9 @@ namespace modules {
     bool query_keyboard();
     bool blacklisted(const string& indicator_name);
 
-    void handle(const evt::xkb_new_keyboard_notify& evt);
-    void handle(const evt::xkb_state_notify& evt);
-    void handle(const evt::xkb_indicator_state_notify& evt);
+    void handle(const evt::xkb_new_keyboard_notify& evt) override;
+    void handle(const evt::xkb_state_notify& evt) override;
+    void handle(const evt::xkb_indicator_state_notify& evt) override;
 
     void action_switch();
 

--- a/include/modules/xwindow.hpp
+++ b/include/modules/xwindow.hpp
@@ -39,7 +39,7 @@ namespace modules {
     static constexpr auto TYPE = "internal/xwindow";
 
    protected:
-    void handle(const evt::property_notify& evt);
+    void handle(const evt::property_notify& evt) override;
 
    private:
     static constexpr const char* TAG_LABEL{"<label>"};

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -65,7 +65,7 @@ namespace modules {
     static constexpr auto EVENT_PREV = "prev";
 
    protected:
-    void handle(const evt::property_notify& evt);
+    void handle(const evt::property_notify& evt) override;
 
     void rebuild_clientlist();
     void rebuild_urgent_hints();

--- a/include/tags/parser.hpp
+++ b/include/tags/parser.hpp
@@ -24,7 +24,7 @@ namespace tags {
       msg.append(" (Context: '" + ctxt + "')");
     }
 
-    virtual const char* what() const noexcept {
+    virtual const char* what() const noexcept override {
       return msg.c_str();
     }
 

--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -67,9 +67,9 @@ class fd_streambuf : public std::streambuf {
   void close();
 
  protected:
-  int sync();
-  int overflow(int c);
-  int underflow();
+  int sync() override;
+  int overflow(int c) override;
+  int underflow() override;
 
  private:
   file_descriptor m_fd;

--- a/include/x11/background_manager.hpp
+++ b/include/x11/background_manager.hpp
@@ -17,7 +17,7 @@ class logger;
 namespace cairo {
   class surface;
   class xcb_surface;
-}
+}  // namespace cairo
 
 class bg_slice {
  public:
@@ -65,8 +65,7 @@ class bg_slice {
  * so this class takes a rectangle that limits what part of the background is stored.
  */
 class background_manager : public signal_receiver<SIGN_PRIORITY_SCREEN, signals::ui::update_geometry>,
-                           public xpp::event::sink<evt::property_notify>
-{
+                           public xpp::event::sink<evt::property_notify> {
  public:
   using make_type = background_manager&;
   static make_type make();
@@ -98,6 +97,7 @@ class background_manager : public signal_receiver<SIGN_PRIORITY_SCREEN, signals:
 
   void handle(const evt::property_notify& evt) override;
   bool on(const signals::ui::update_geometry&) override;
+
  private:
   void activate();
   void deactivate();
@@ -119,7 +119,6 @@ class background_manager : public signal_receiver<SIGN_PRIORITY_SCREEN, signals:
   void allocate_resources();
   void free_resources();
   void fetch_root_pixmap();
-
 };
 
 POLYBAR_NS_END

--- a/include/x11/background_manager.hpp
+++ b/include/x11/background_manager.hpp
@@ -96,8 +96,8 @@ class background_manager : public signal_receiver<SIGN_PRIORITY_SCREEN, signals:
    */
   std::shared_ptr<bg_slice> observe(xcb_rectangle_t rect, xcb_window_t window);
 
-  void handle(const evt::property_notify& evt);
-  bool on(const signals::ui::update_geometry&);
+  void handle(const evt::property_notify& evt) override;
+  bool on(const signals::ui::update_geometry&) override;
  private:
   void activate();
   void deactivate();

--- a/include/x11/connection.hpp
+++ b/include/x11/connection.hpp
@@ -44,7 +44,7 @@ namespace detail {
 
     virtual ~connection_base() {}
 
-    void operator()(const shared_ptr<xcb_generic_error_t>& error) const {
+    void operator()(const shared_ptr<xcb_generic_error_t>& error) const override {
       check<xpp::x::extension, Extensions...>(error);
     }
 
@@ -59,7 +59,7 @@ namespace detail {
       return make()(*this, m_root_window);
     }
 
-    shared_ptr<xcb_generic_event_t> wait_for_event() const {
+    shared_ptr<xcb_generic_event_t> wait_for_event() const override {
       try {
         return core::wait_for_event();
       } catch (const shared_ptr<xcb_generic_error_t>& error) {
@@ -68,7 +68,7 @@ namespace detail {
       throw;  // re-throw exception
     }
 
-    shared_ptr<xcb_generic_event_t> wait_for_special_event(xcb_special_event_t* se) const {
+    shared_ptr<xcb_generic_event_t> wait_for_special_event(xcb_special_event_t* se) const override {
       try {
         return core::wait_for_special_event(se);
       } catch (const shared_ptr<xcb_generic_error_t>& error) {

--- a/include/x11/connection.hpp
+++ b/include/x11/connection.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <xcb/xcb.h>
+
 #include <cstdlib>
 #include <xpp/core.hpp>
 #include <xpp/generic/factory.hpp>
@@ -93,7 +94,7 @@ namespace detail {
       dispatcher(error);
     }
   };
-}
+}  // namespace detail
 
 class connection : public detail::connection_base<connection&, XPP_EXTENSION_LIST> {
  public:

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -120,21 +120,21 @@ class tray_manager : public xpp::event::sink<evt::expose, evt::visibility_notify
   void remove_client(xcb_window_t win, bool reconfigure = true);
   unsigned int mapped_clients() const;
 
-  void handle(const evt::expose& evt);
-  void handle(const evt::visibility_notify& evt);
-  void handle(const evt::client_message& evt);
-  void handle(const evt::configure_request& evt);
-  void handle(const evt::resize_request& evt);
-  void handle(const evt::selection_clear& evt);
-  void handle(const evt::property_notify& evt);
-  void handle(const evt::reparent_notify& evt);
-  void handle(const evt::destroy_notify& evt);
-  void handle(const evt::map_notify& evt);
-  void handle(const evt::unmap_notify& evt);
+  void handle(const evt::expose& evt) override;
+  void handle(const evt::visibility_notify& evt) override;
+  void handle(const evt::client_message& evt) override;
+  void handle(const evt::configure_request& evt) override;
+  void handle(const evt::resize_request& evt) override;
+  void handle(const evt::selection_clear& evt) override;
+  void handle(const evt::property_notify& evt) override;
+  void handle(const evt::reparent_notify& evt) override;
+  void handle(const evt::destroy_notify& evt) override;
+  void handle(const evt::map_notify& evt) override;
+  void handle(const evt::unmap_notify& evt) override;
 
-  bool on(const signals::ui::visibility_change& evt);
-  bool on(const signals::ui::dim_window& evt);
-  bool on(const signals::ui::update_background& evt);
+  bool on(const signals::ui::visibility_change& evt) override;
+  bool on(const signals::ui::dim_window& evt) override;
+  bool on(const signals::ui::update_background& evt) override;
 
  private:
   connection& m_connection;

--- a/tests/unit_tests/components/command_line.cpp
+++ b/tests/unit_tests/components/command_line.cpp
@@ -1,31 +1,31 @@
-#include "common/test.hpp"
 #include "components/command_line.hpp"
+
+#include "common/test.hpp"
 #include "utils/string.hpp"
 
 using namespace polybar;
 
 class CommandLine : public ::testing::Test {
-  protected:
-    virtual void SetUp() override {
-      set_cli();
-    }
+ protected:
+  virtual void SetUp() override {
+    set_cli();
+  }
 
-    virtual void set_cli() {
-      cli = command_line::parser::make("cmd", get_opts());
-    }
+  virtual void set_cli() {
+    cli = command_line::parser::make("cmd", get_opts());
+  }
 
-    command_line::options get_opts()  {
-      // clang-format off
+  command_line::options get_opts() {
+    // clang-format off
       return command_line::options {
         command_line::option{"-f", "--flag", "Flag description"},
         command_line::option{"-o", "--option", "Option description", "OPTION", {"foo", "bar", "baz"}},
       };
-      // clang-format on
-    };
+    // clang-format on
+  };
 
-    command_line::parser::make_type cli;
+  command_line::parser::make_type cli;
 };
-
 
 TEST_F(CommandLine, hasShort) {
   cli->process_input(string_util::split("-f", ' '));

--- a/tests/unit_tests/components/command_line.cpp
+++ b/tests/unit_tests/components/command_line.cpp
@@ -6,7 +6,7 @@ using namespace polybar;
 
 class CommandLine : public ::testing::Test {
   protected:
-    virtual void SetUp() {
+    virtual void SetUp() override {
       set_cli();
     }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [x] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

When implementing the action router (#2336), I mistakenly created a `stop` function in the mpd module for the stop action. This completely broke the module and the bar and was quite difficult to debug.

With this compiler warning, this error would have been caught earlier.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
