### PR TITLE
renderer: Keep Formatting State in separate component

### DIFF
--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -10,6 +10,7 @@
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
 #include "settings.hpp"
+#include "tags/context.hpp"
 #include "utils/math.hpp"
 #include "x11/types.hpp"
 #include "x11/window.hpp"
@@ -66,7 +67,8 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   static make_type make(bool only_initialize_values = false);
 
   explicit bar(connection&, signal_emitter&, const config&, const logger&, unique_ptr<screen>&&,
-      unique_ptr<tray_manager>&&, unique_ptr<tags::dispatch>&&, unique_ptr<taskqueue>&&, bool only_initialize_values);
+      unique_ptr<tray_manager>&&, unique_ptr<tags::dispatch>&&, unique_ptr<tags::action_context>&&,
+      unique_ptr<taskqueue>&&, bool only_initialize_values);
   ~bar();
 
   const bar_settings settings() const;
@@ -114,6 +116,7 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   unique_ptr<tray_manager> m_tray;
   unique_ptr<renderer> m_renderer;
   unique_ptr<tags::dispatch> m_dispatch;
+  unique_ptr<tags::action_context> m_action_ctxt;
   unique_ptr<taskqueue> m_taskqueue;
 
   bar_settings m_opts{};

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -10,7 +10,7 @@
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
 #include "settings.hpp"
-#include "tags/context.hpp"
+#include "tags/action_context.hpp"
 #include "utils/math.hpp"
 #include "x11/types.hpp"
 #include "x11/window.hpp"

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -32,13 +32,9 @@ struct alignment_block {
   double y;
 };
 
-class renderer
-    : public renderer_interface,
-      public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot, signals::parser::change_background,
-          signals::parser::change_foreground, signals::parser::change_underline, signals::parser::change_overline,
-          signals::parser::change_font, signals::parser::change_alignment, signals::parser::reverse_colors,
-          signals::parser::attribute_set, signals::parser::attribute_unset, signals::parser::attribute_toggle,
-          signals::parser::action_begin, signals::parser::action_end, signals::parser::text, signals::parser::control> {
+class renderer : public renderer_interface,
+                 public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot,
+                     signals::parser::change_alignment, signals::parser::action_begin, signals::parser::action_end> {
  public:
   using make_type = unique_ptr<renderer>;
   static make_type make(const bar_settings& bar);
@@ -58,12 +54,12 @@ class renderer
   void reserve_space(edge side, unsigned int w);
 #endif
   void fill_background();
-  void fill_overline(double x, double w);
-  void fill_underline(double x, double w);
+  void fill_overline(rgba color, double x, double w);
+  void fill_underline(rgba color, double x, double w);
   void fill_borders();
-  void draw_text(const string& contents);
 
   void render_offset(const tags::context& ctxt, int pixels) override;
+  void render_text(const tags::context& ctxt, const string&&) override;
 
  protected:
   double block_x(alignment a) const;
@@ -75,20 +71,9 @@ class renderer
   void highlight_clickable_areas();
 
   bool on(const signals::ui::request_snapshot& evt) override;
-  bool on(const signals::parser::change_background& evt) override;
-  bool on(const signals::parser::change_foreground& evt) override;
-  bool on(const signals::parser::change_underline& evt) override;
-  bool on(const signals::parser::change_overline& evt) override;
-  bool on(const signals::parser::change_font& evt) override;
   bool on(const signals::parser::change_alignment& evt) override;
-  bool on(const signals::parser::reverse_colors&) override;
-  bool on(const signals::parser::attribute_set& evt) override;
-  bool on(const signals::parser::attribute_unset& evt) override;
-  bool on(const signals::parser::attribute_toggle& evt) override;
   bool on(const signals::parser::action_begin& evt) override;
   bool on(const signals::parser::action_end& evt) override;
-  bool on(const signals::parser::text& evt) override;
-  bool on(const signals::parser::control& evt) override;
 
  protected:
   struct reserve_area {
@@ -129,12 +114,6 @@ class renderer
   bool m_pseudo_transparency{false};
 
   alignment m_align;
-  std::bitset<3> m_attr;
-  int m_font{0};
-  rgba m_bg{};
-  rgba m_fg{};
-  rgba m_ol{};
-  rgba m_ul{};
   vector<action_block> m_actions;
 
   bool m_fixedcenter;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -32,9 +32,8 @@ struct alignment_block {
   double y;
 };
 
-class renderer
-    : public renderer_interface,
-      public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot, signals::parser::change_alignment> {
+class renderer : public renderer_interface,
+                 public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot> {
  public:
   using make_type = unique_ptr<renderer>;
   static make_type make(const bar_settings& bar);
@@ -51,6 +50,8 @@ class renderer
 
   void render_offset(const tags::context& ctxt, int pixels) override;
   void render_text(const tags::context& ctxt, const string&&) override;
+
+  void change_alignment(const tags::context& ctxt) override;
 
   void action_open(const tags::context& ctxt, mousebtn btn, tags::action_t id) override;
   void action_close(const tags::context& ctxt, tags::action_t id) override;
@@ -73,7 +74,6 @@ class renderer
   void highlight_clickable_areas();
 
   bool on(const signals::ui::request_snapshot& evt) override;
-  bool on(const signals::parser::change_alignment& evt) override;
 
  protected:
   struct reserve_area {

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -7,6 +7,7 @@
 
 #include "cairo/fwd.hpp"
 #include "common.hpp"
+#include "components/renderer_interface.hpp"
 #include "components/types.hpp"
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
@@ -32,12 +33,12 @@ struct alignment_block {
 };
 
 class renderer
-    : public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot, signals::parser::change_background,
+    : public renderer_interface,
+      public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot, signals::parser::change_background,
           signals::parser::change_foreground, signals::parser::change_underline, signals::parser::change_overline,
           signals::parser::change_font, signals::parser::change_alignment, signals::parser::reverse_colors,
-          signals::parser::offset_pixel, signals::parser::attribute_set, signals::parser::attribute_unset,
-          signals::parser::attribute_toggle, signals::parser::action_begin, signals::parser::action_end,
-          signals::parser::text, signals::parser::control> {
+          signals::parser::attribute_set, signals::parser::attribute_unset, signals::parser::attribute_toggle,
+          signals::parser::action_begin, signals::parser::action_end, signals::parser::text, signals::parser::control> {
  public:
   using make_type = unique_ptr<renderer>;
   static make_type make(const bar_settings& bar);
@@ -62,6 +63,8 @@ class renderer
   void fill_borders();
   void draw_text(const string& contents);
 
+  void render_offset(const tags::context& ctxt, int pixels) override;
+
  protected:
   double block_x(alignment a) const;
   double block_y(alignment a) const;
@@ -79,7 +82,6 @@ class renderer
   bool on(const signals::parser::change_font& evt) override;
   bool on(const signals::parser::change_alignment& evt) override;
   bool on(const signals::parser::reverse_colors&) override;
-  bool on(const signals::parser::offset_pixel& evt) override;
   bool on(const signals::parser::attribute_set& evt) override;
   bool on(const signals::parser::attribute_unset& evt) override;
   bool on(const signals::parser::attribute_toggle& evt) override;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -53,8 +53,9 @@ class renderer : public renderer_interface,
 
   void change_alignment(const tags::context& ctxt) override;
 
-  void action_open(const tags::context& ctxt, tags::action_t id) override;
-  void action_close(const tags::context& ctxt, tags::action_t id) override;
+  double get_x(const tags::context& ctxt) const override;
+
+  double get_alignment_start(const alignment align) const override;
 
  protected:
   void fill_background();

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -36,10 +36,10 @@ class renderer : public renderer_interface,
                  public signal_receiver<SIGN_PRIORITY_RENDERER, signals::ui::request_snapshot> {
  public:
   using make_type = unique_ptr<renderer>;
-  static make_type make(const bar_settings& bar);
+  static make_type make(const bar_settings& bar, tags::action_context& action_ctxt);
 
   explicit renderer(connection& conn, signal_emitter& sig, const config&, const logger& logger, const bar_settings& bar,
-      background_manager& background_manager);
+      background_manager& background_manager, tags::action_context& action_ctxt);
   ~renderer();
 
   xcb_window_t window() const;
@@ -55,9 +55,6 @@ class renderer : public renderer_interface,
 
   void action_open(const tags::context& ctxt, mousebtn btn, tags::action_t id) override;
   void action_close(const tags::context& ctxt, tags::action_t id) override;
-
-  std::map<mousebtn, tags::action_t> get_actions(int x) override;
-  tags::action_t get_action(mousebtn btn, int x) override;
 
  protected:
   void fill_background();
@@ -114,7 +111,6 @@ class renderer : public renderer_interface,
   bool m_pseudo_transparency{false};
 
   alignment m_align;
-  std::unordered_map<tags::action_t, action_block> m_actions;
 
   bool m_fixedcenter;
   string m_snapshot_dst;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -53,7 +53,7 @@ class renderer : public renderer_interface,
 
   void change_alignment(const tags::context& ctxt) override;
 
-  void action_open(const tags::context& ctxt, mousebtn btn, tags::action_t id) override;
+  void action_open(const tags::context& ctxt, tags::action_t id) override;
   void action_close(const tags::context& ctxt, tags::action_t id) override;
 
  protected:

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -9,6 +9,7 @@ class renderer_interface {
  public:
   virtual void render_offset(const tags::context& ctxt, int pixels) = 0;
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
+  virtual void change_alignment(const tags::context& ctxt) = 0;
 
   virtual void action_open(const tags::context& ctxt, mousebtn btn, tags::action_t id) = 0;
   virtual void action_close(const tags::context& ctxt, tags::action_t id) = 0;

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -7,23 +7,36 @@ POLYBAR_NS
 
 class renderer_interface {
  public:
-  renderer_interface(tags::action_context& action_ctxt) : m_action_ctxt(action_ctxt){};
+  renderer_interface(const tags::action_context& action_ctxt) : m_action_ctxt(action_ctxt){};
 
   virtual void render_offset(const tags::context& ctxt, int pixels) = 0;
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
   virtual void change_alignment(const tags::context& ctxt) = 0;
 
-  virtual void action_open(const tags::context& ctxt, tags::action_t id) = 0;
-  virtual void action_close(const tags::context& ctxt, tags::action_t id) = 0;
+  /**
+   * Get the current x-coordinate of the renderer.
+   *
+   * This position denotes the coordinate where the next thing will be rendered.
+   * It is relative to the start of the current alignment because the absolute
+   * positions may not be known until after the renderer has finished.
+   */
+  virtual double get_x(const tags::context& ctxt) const = 0;
+
+  /**
+   * Get the absolute x-position of the start of an alignment block.
+   *
+   * The position is absolute in terms of the bar window.
+   *
+   * Only call this after all the rendering is finished as these values change
+   * when new things are rendered.
+   */
+  virtual double get_alignment_start(const alignment align) const = 0;
 
  protected:
   /**
-   * Stores information about actions in the current action cycle.
-   *
-   * The renderer is only responsible for updating the start and end positions
-   * of each action block.
+   * Stores information about actions in the current render cycle.
    */
-  tags::action_context& m_action_ctxt;
+  const tags::action_context& m_action_ctxt;
 };
 
 POLYBAR_NS_END

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -13,7 +13,7 @@ class renderer_interface {
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
   virtual void change_alignment(const tags::context& ctxt) = 0;
 
-  virtual void action_open(const tags::context& ctxt, mousebtn btn, tags::action_t id) = 0;
+  virtual void action_open(const tags::context& ctxt, tags::action_t id) = 0;
   virtual void action_close(const tags::context& ctxt, tags::action_t id) = 0;
 
  protected:

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -7,6 +7,8 @@ POLYBAR_NS
 
 class renderer_interface {
  public:
+  renderer_interface(tags::action_context& action_ctxt) : m_action_ctxt(action_ctxt){};
+
   virtual void render_offset(const tags::context& ctxt, int pixels) = 0;
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
   virtual void change_alignment(const tags::context& ctxt) = 0;
@@ -14,8 +16,14 @@ class renderer_interface {
   virtual void action_open(const tags::context& ctxt, mousebtn btn, tags::action_t id) = 0;
   virtual void action_close(const tags::context& ctxt, tags::action_t id) = 0;
 
-  virtual std::map<mousebtn, tags::action_t> get_actions(int x) = 0;
-  virtual tags::action_t get_action(mousebtn btn, int x) = 0;
+ protected:
+  /**
+   * Stores information about actions in the current action cycle.
+   *
+   * The renderer is only responsible for updating the start and end positions
+   * of each action block.
+   */
+  tags::action_context& m_action_ctxt;
 };
 
 POLYBAR_NS_END

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <map>
+
 #include "common.hpp"
 #include "tags/context.hpp"
 POLYBAR_NS
@@ -7,6 +9,12 @@ class renderer_interface {
  public:
   virtual void render_offset(const tags::context& ctxt, int pixels) = 0;
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
+
+  virtual void action_open(const tags::context& ctxt, mousebtn btn, tags::action_t id) = 0;
+  virtual void action_close(const tags::context& ctxt, tags::action_t id) = 0;
+
+  virtual std::map<mousebtn, tags::action_t> get_actions(int x) = 0;
+  virtual tags::action_t get_action(mousebtn btn, int x) = 0;
 };
 
 POLYBAR_NS_END

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -2,6 +2,7 @@
 #include <map>
 
 #include "common.hpp"
+#include "tags/action_context.hpp"
 #include "tags/context.hpp"
 POLYBAR_NS
 

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -6,6 +6,7 @@ POLYBAR_NS
 class renderer_interface {
  public:
   virtual void render_offset(const tags::context& ctxt, int pixels) = 0;
+  virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
 };
 
 POLYBAR_NS_END

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include "common.hpp"
+#include "tags/context.hpp"
+POLYBAR_NS
+
+class renderer_interface {
+ public:
+  virtual void render_offset(const tags::context& ctxt, int pixels) = 0;
+};
+
+POLYBAR_NS_END

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -109,21 +109,6 @@ struct action {
   string command{};
 };
 
-struct action_block {
-  mousebtn button{mousebtn::NONE};
-  alignment align{alignment::NONE};
-  double start_x{0.0};
-  double end_x{0.0};
-
-  unsigned int width() const {
-    return static_cast<unsigned int>(end_x - start_x + 0.5);
-  }
-
-  bool test(int point) const {
-    return static_cast<int>(start_x) <= point && static_cast<int>(end_x) > point;
-  }
-};
-
 struct bar_settings {
   explicit bar_settings() = default;
   bar_settings(const bar_settings& other) = default;

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -109,11 +109,11 @@ struct action {
   string command{};
 };
 
-struct action_block : public action {
+struct action_block {
+  mousebtn button{mousebtn::NONE};
   alignment align{alignment::NONE};
   double start_x{0.0};
   double end_x{0.0};
-  bool active{true};
 
   unsigned int width() const {
     return static_cast<unsigned int>(end_x - start_x + 0.5);

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -132,46 +132,13 @@ namespace signals {
   }  // namespace ui_tray
 
   namespace parser {
-    struct change_background : public detail::value_signal<change_background, rgba> {
-      using base_type::base_type;
-    };
-    struct change_foreground : public detail::value_signal<change_foreground, rgba> {
-      using base_type::base_type;
-    };
-    struct change_underline : public detail::value_signal<change_underline, rgba> {
-      using base_type::base_type;
-    };
-    struct change_overline : public detail::value_signal<change_overline, rgba> {
-      using base_type::base_type;
-    };
-    struct change_font : public detail::value_signal<change_font, int> {
-      using base_type::base_type;
-    };
     struct change_alignment : public detail::value_signal<change_alignment, alignment> {
-      using base_type::base_type;
-    };
-    struct reverse_colors : public detail::base_signal<reverse_colors> {
-      using base_type::base_type;
-    };
-    struct attribute_set : public detail::value_signal<attribute_set, tags::attribute> {
-      using base_type::base_type;
-    };
-    struct attribute_unset : public detail::value_signal<attribute_unset, tags::attribute> {
-      using base_type::base_type;
-    };
-    struct attribute_toggle : public detail::value_signal<attribute_toggle, tags::attribute> {
       using base_type::base_type;
     };
     struct action_begin : public detail::value_signal<action_begin, action> {
       using base_type::base_type;
     };
     struct action_end : public detail::value_signal<action_end, mousebtn> {
-      using base_type::base_type;
-    };
-    struct text : public detail::value_signal<text, string> {
-      using base_type::base_type;
-    };
-    struct control : public detail::value_signal<control, tags::controltag> {
       using base_type::base_type;
     };
   }  // namespace parser

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -130,12 +130,6 @@ namespace signals {
       using base_type::base_type;
     };
   }  // namespace ui_tray
-
-  namespace parser {
-    struct change_alignment : public detail::value_signal<change_alignment, alignment> {
-      using base_type::base_type;
-    };
-  }  // namespace parser
 }  // namespace signals
 
 POLYBAR_NS_END

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -135,12 +135,6 @@ namespace signals {
     struct change_alignment : public detail::value_signal<change_alignment, alignment> {
       using base_type::base_type;
     };
-    struct action_begin : public detail::value_signal<action_begin, action> {
-      using base_type::base_type;
-    };
-    struct action_end : public detail::value_signal<action_end, mousebtn> {
-      using base_type::base_type;
-    };
   }  // namespace parser
 }  // namespace signals
 

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -3,8 +3,6 @@
 #include "common.hpp"
 #include "components/ipc.hpp"
 #include "components/types.hpp"
-#include "tags/dispatch.hpp"
-#include "tags/types.hpp"
 #include "utils/functional.hpp"
 
 POLYBAR_NS

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -153,9 +153,6 @@ namespace signals {
     struct reverse_colors : public detail::base_signal<reverse_colors> {
       using base_type::base_type;
     };
-    struct offset_pixel : public detail::value_signal<offset_pixel, int> {
-      using base_type::base_type;
-    };
     struct attribute_set : public detail::value_signal<attribute_set, tags::attribute> {
       using base_type::base_type;
     };

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -46,8 +46,6 @@ namespace signals {
   }
   namespace parser {
     struct change_alignment;
-    struct action_begin;
-    struct action_end;
   }  // namespace parser
 }  // namespace signals
 

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -45,20 +45,9 @@ namespace signals {
     struct mapped_clients;
   }
   namespace parser {
-    struct change_background;
-    struct change_foreground;
-    struct change_underline;
-    struct change_overline;
-    struct change_font;
     struct change_alignment;
-    struct reverse_colors;
-    struct attribute_set;
-    struct attribute_unset;
-    struct attribute_toggle;
     struct action_begin;
     struct action_end;
-    struct text;
-    struct control;
   }  // namespace parser
 }  // namespace signals
 

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -44,9 +44,6 @@ namespace signals {
   namespace ui_tray {
     struct mapped_clients;
   }
-  namespace parser {
-    struct change_alignment;
-  }  // namespace parser
 }  // namespace signals
 
 POLYBAR_NS_END

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -52,7 +52,6 @@ namespace signals {
     struct change_font;
     struct change_alignment;
     struct reverse_colors;
-    struct offset_pixel;
     struct attribute_set;
     struct attribute_unset;
     struct attribute_toggle;

--- a/include/tags/action_context.hpp
+++ b/include/tags/action_context.hpp
@@ -67,6 +67,12 @@ namespace tags {
     }
   };
 
+  /**
+   * Stores information about all action blocks on the bar.
+   *
+   * This class is used during rendering to open and close action blocks and
+   * in between render cycles to look up actions at certain positions.
+   */
   class action_context {
    public:
     void reset();

--- a/include/tags/action_context.hpp
+++ b/include/tags/action_context.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <map>
+
+#include "common.hpp"
+#include "components/types.hpp"
+
+POLYBAR_NS
+
+namespace tags {
+  /**
+   * An identifier for an action block.
+   *
+   * A value of NO_ACTION denotes an undefined identifier and is guaranteed to
+   * be smaller (<) than any valid identifier.
+   *
+   * If two action blocks overlap, the action with the higher identifier will
+   * be above.
+   *
+   * Except for NO_ACTION, negative values are not allowed
+   */
+  using action_t = int;
+
+  static constexpr action_t NO_ACTION = -1;
+
+  /**
+   * Defines a clickable (or scrollable) action block.
+   *
+   * An action block is an area on the bar that executes some command when clicked.
+   */
+  struct action_block {
+    action_block(const string&& cmd, mousebtn button, alignment align, bool is_open)
+        : cmd(std::move(cmd)), button(button), align(align), is_open(is_open){};
+
+    string cmd;
+    /**
+     * Start position of the action block (inclusive), relative to the alignment.
+     */
+    double start_x{0};
+
+    /**
+     * End position of the action block (exclusive), relative to the alignment.
+     */
+    double end_x{0};
+    mousebtn button;
+    alignment align;
+    /**
+     * Tracks whether this block is still open or whether it already has a
+     * corresponding closing tag.
+     *
+     * After rendering, all action blocks should be closed.
+     */
+    bool is_open;
+
+    unsigned int width() const {
+      return static_cast<unsigned int>(end_x - start_x + 0.5);
+    }
+
+    /**
+     * Tests whether a given point is inside this block.
+     *
+     * This additionally needs the position of the start of the alignment
+     * because the given point is relative to the bar window.
+     */
+    bool test(double align_start, int point) const {
+      return static_cast<int>(start_x + align_start) <= point && static_cast<int>(end_x + align_start) > point;
+    }
+  };
+
+  class action_context {
+   public:
+    void reset();
+
+    action_t action_open(mousebtn btn, const string&& cmd, alignment align, double x);
+    std::pair<action_t, mousebtn> action_close(mousebtn btn, alignment align, double x);
+
+    void set_alignmnent_start(const alignment a, const double x);
+
+    std::map<mousebtn, tags::action_t> get_actions(int x) const;
+    action_t has_action(mousebtn btn, int x) const;
+
+    string get_action(action_t id) const;
+    bool has_double_click() const;
+
+    size_t num_actions() const;
+    size_t num_unclosed() const;
+
+    const std::vector<action_block>& get_blocks() const;
+
+   protected:
+    void set_start(action_t id, double x);
+    void set_end(action_t id, double x);
+
+    /**
+     * Stores all currently known action blocks.
+     *
+     * The action_t type is an index into this vector.
+     */
+    std::vector<action_block> m_action_blocks;
+
+    /**
+     * Stores the x-coordinate for the start of all the alignment blocks.
+     *
+     * This is needed because the action block coordinates are relative to the
+     * alignment blocks and thus need the alignment block coordinates for
+     * intersection tests.
+     */
+    std::map<alignment, double> m_align_start{
+        {alignment::NONE, 0}, {alignment::LEFT, 0}, {alignment::CENTER, 0}, {alignment::RIGHT, 0}};
+  };
+
+}  // namespace tags
+
+POLYBAR_NS_END

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <map>
-
 #include "common.hpp"
 #include "components/types.hpp"
 #include "tags/types.hpp"
@@ -82,108 +80,6 @@ namespace tags {
    private:
     const bar_settings& m_settings;
   };
-
-  /**
-   * An identifier for an action block.
-   *
-   * A value of NO_ACTION denotes an undefined identifier and is guaranteed to
-   * be smaller (<) than any valid identifier.
-   *
-   * If two action blocks overlap, the action with the higher identifier will
-   * be above.
-   *
-   * Except for NO_ACTION, negative values are not allowed
-   */
-  using action_t = int;
-
-  static constexpr action_t NO_ACTION = -1;
-
-  /**
-   * Defines a clickable (or scrollable) action block.
-   *
-   * An action block is an area on the bar that executes some command when clicked.
-   */
-  struct action_block {
-    action_block(const string&& cmd, mousebtn button, alignment align, bool is_open)
-        : cmd(std::move(cmd)), button(button), align(align), is_open(is_open){};
-
-    string cmd;
-    /**
-     * Start position of the action block (inclusive), relative to the alignment.
-     */
-    double start_x{0};
-
-    /**
-     * End position of the action block (exclusive), relative to the alignment.
-     */
-    double end_x{0};
-    mousebtn button;
-    alignment align;
-    /**
-     * Tracks whether this block is still open or whether it already has a
-     * corresponding closing tag.
-     *
-     * After rendering, all action blocks should be closed.
-     */
-    bool is_open;
-
-    unsigned int width() const {
-      return static_cast<unsigned int>(end_x - start_x + 0.5);
-    }
-
-    /**
-     * Tests whether a given point is inside this block.
-     *
-     * This additionally needs the position of the start of the alignment
-     * because the given point is relative to the bar window.
-     */
-    bool test(double align_start, int point) const {
-      return static_cast<int>(start_x + align_start) <= point && static_cast<int>(end_x + align_start) > point;
-    }
-  };
-
-  class action_context {
-   public:
-    void reset();
-
-    action_t action_open(mousebtn btn, const string&& cmd, alignment align, double x);
-    std::pair<action_t, mousebtn> action_close(mousebtn btn, alignment align, double x);
-
-    void set_alignmnent_start(const alignment a, const double x);
-
-    std::map<mousebtn, tags::action_t> get_actions(int x) const;
-    action_t has_action(mousebtn btn, int x) const;
-
-    string get_action(action_t id) const;
-    bool has_double_click() const;
-
-    size_t num_actions() const;
-    size_t num_unclosed() const;
-
-    const std::vector<action_block>& get_blocks() const;
-
-   protected:
-    void set_start(action_t id, double x);
-    void set_end(action_t id, double x);
-
-    /**
-     * Stores all currently known action blocks.
-     *
-     * The action_t type is an index into this vector.
-     */
-    std::vector<action_block> m_action_blocks;
-
-    /**
-     * Stores the x-coordinate for the start of all the alignment blocks.
-     *
-     * This is needed because the action block coordinates are relative to the
-     * alignment blocks and thus need the alignment block coordinates for
-     * intersection tests.
-     */
-    std::map<alignment, double> m_align_start{
-        {alignment::NONE, 0}, {alignment::LEFT, 0}, {alignment::CENTER, 0}, {alignment::RIGHT, 0}};
-  };
-
 }  // namespace tags
 
 POLYBAR_NS_END

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -98,23 +98,47 @@ namespace tags {
 
   static constexpr action_t NO_ACTION = -1;
 
+  /**
+   * Defines a clickable (or scrollable) action block.
+   *
+   * An action block is an area on the bar that executes some command when clicked.
+   */
   struct action_block {
     action_block(const string&& cmd, mousebtn button, alignment align, bool is_open)
         : cmd(std::move(cmd)), button(button), align(align), is_open(is_open){};
 
     string cmd;
+    /**
+     * Start position of the action block (inclusive), relative to the alignment.
+     */
     double start_x{0};
+
+    /**
+     * End position of the action block (exclusive), relative to the alignment.
+     */
     double end_x{0};
     mousebtn button;
     alignment align;
+    /**
+     * Tracks whether this block is still open or whether it already has a
+     * corresponding closing tag.
+     *
+     * After rendering, all action blocks should be closed.
+     */
     bool is_open;
 
     unsigned int width() const {
       return static_cast<unsigned int>(end_x - start_x + 0.5);
     }
 
-    bool test(int point) const {
-      return static_cast<int>(start_x) <= point && static_cast<int>(end_x) > point;
+    /**
+     * Tests whether a given point is inside this block.
+     *
+     * This additionally needs the position of the start of the alignment
+     * because the given point is relative to the bar window.
+     */
+    bool test(double align_start, int point) const {
+      return static_cast<int>(start_x + align_start) <= point && static_cast<int>(end_x + align_start) > point;
     }
   };
 
@@ -122,11 +146,10 @@ namespace tags {
    public:
     void reset();
 
-    action_t action_open(mousebtn btn, const string&& cmd, alignment align);
-    std::pair<action_t, mousebtn> action_close(mousebtn btn, alignment align);
+    action_t action_open(mousebtn btn, const string&& cmd, alignment align, double x);
+    std::pair<action_t, mousebtn> action_close(mousebtn btn, alignment align, double x);
 
-    void set_start(action_t id, double x);
-    void set_end(action_t id, double x);
+    void set_alignmnent_start(const alignment a, const double x);
 
     std::map<mousebtn, tags::action_t> get_actions(int x) const;
     action_t has_action(mousebtn btn, int x) const;
@@ -137,15 +160,28 @@ namespace tags {
     size_t num_actions() const;
 
     // TODO provide better interface for adjusting the start positions of actions
-    std::vector<action_block>& get_blocks();
+    const std::vector<action_block>& get_blocks() const;
 
    protected:
+    void set_start(action_t id, double x);
+    void set_end(action_t id, double x);
+
     /**
      * Stores all currently known action blocks.
      *
-     * The action_t type is meant as an index into this vector.
+     * The action_t type is an index into this vector.
      */
     std::vector<action_block> m_action_blocks;
+
+    /**
+     * Stores the x-coordinate for the start of all the alignment blocks.
+     *
+     * This is needed because the action block coordinates are relative to the
+     * alignment blocks and thus need the alignment block coordinates for
+     * intersection tests.
+     */
+    std::map<alignment, double> m_align_start{
+        {alignment::NONE, 0}, {alignment::LEFT, 0}, {alignment::CENTER, 0}, {alignment::RIGHT, 0}};
   };
 
 }  // namespace tags

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -1,11 +1,87 @@
 #pragma once
 
 #include "common.hpp"
+#include "components/types.hpp"
+#include "tags/types.hpp"
+#include "utils/color.hpp"
 
 POLYBAR_NS
 
 namespace tags {
-  class context {};
+  /**
+   * Stores all the formatting data which comes from formatting tags needed to
+   * render a formatting string.
+   */
+  class context {
+   public:
+    context() = delete;
+    context(const bar_settings& settings);
+
+    /**
+     * Resets to the initial state.
+     *
+     * The initial state depends on the colors set on the bar itself.
+     */
+    void reset();
+
+    void apply_bg(color_value c);
+    void apply_fg(color_value c);
+    void apply_ol(color_value c);
+    void apply_ul(color_value c);
+    void apply_font(int font);
+    void apply_reverse();
+    void apply_alignment(alignment align);
+    void apply_attr(attr_activation act, attribute attr);
+    void apply_reset();
+
+    rgba get_bg() const;
+    rgba get_fg() const;
+    rgba get_ol() const;
+    rgba get_ul() const;
+    int get_font() const;
+    bool has_overline() const;
+    bool has_underline() const;
+    alignment get_alignment() const;
+
+   protected:
+    rgba get_color(color_value c, rgba fallback) const;
+
+    /**
+     * Background color
+     */
+    rgba m_bg;
+    /**
+     * Foreground color
+     */
+    rgba m_fg;
+    /**
+     * Overline color
+     */
+    rgba m_ol;
+    /**
+     * Underline color
+     */
+    rgba m_ul;
+    /**
+     * Font index (1-based)
+     */
+    int m_font;
+    /**
+     * Is overline enabled?
+     */
+    bool m_attr_overline;
+    /**
+     * Is underline enabled?
+     */
+    bool m_attr_underline;
+    /**
+     * Alignment block
+     */
+    alignment m_align;
+
+   private:
+    const bar_settings& m_settings;
+  };
 }  // namespace tags
 
 POLYBAR_NS_END

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -44,8 +44,6 @@ namespace tags {
     alignment get_alignment() const;
 
    protected:
-    rgba get_color(color_value c, rgba fallback) const;
-
     /**
      * Background color
      */
@@ -82,6 +80,53 @@ namespace tags {
    private:
     const bar_settings& m_settings;
   };
+
+  /**
+   * An identifier for an action block.
+   *
+   * A value of NO_ACTION denotes an undefined identifier and is guaranteed to
+   * be smaller (<) than any valid identifier.
+   *
+   * If two action blocks overlap, the action with the higher identifier will
+   * be above.
+   *
+   * Except for NO_ACTION, negative values are not allowed
+   */
+  using action_t = int;
+
+  static constexpr action_t NO_ACTION = -1;
+
+  class action_context {
+   public:
+    void reset();
+
+    action_t action_open(mousebtn btn, const string&& cmd, alignment align);
+    std::pair<action_t, mousebtn> action_close(mousebtn btn, alignment align);
+
+    string get_action(action_t id) const;
+    bool has_double_click() const;
+
+    size_t num_actions() const;
+
+   protected:
+    struct action_block {
+      action_block(const string&& cmd, mousebtn button, alignment align, bool is_open)
+          : cmd(std::move(cmd)), button(button), align(align), is_open(is_open){};
+
+      string cmd;
+      mousebtn button;
+      alignment align;
+      bool is_open;
+    };
+
+    /**
+     * Stores all currently known action blocks.
+     *
+     * The action_t type is meant as an index into this vector.
+     */
+    std::vector<action_block> m_action_blocks;
+  };
+
 }  // namespace tags
 
 POLYBAR_NS_END

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -136,6 +136,7 @@ namespace tags {
 
     size_t num_actions() const;
 
+    // TODO provide better interface for adjusting the start positions of actions
     std::vector<action_block>& get_blocks();
 
    protected:

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <map>
+
 #include "common.hpp"
 #include "components/types.hpp"
 #include "tags/types.hpp"
@@ -96,6 +98,26 @@ namespace tags {
 
   static constexpr action_t NO_ACTION = -1;
 
+  struct action_block {
+    action_block(const string&& cmd, mousebtn button, alignment align, bool is_open)
+        : cmd(std::move(cmd)), button(button), align(align), is_open(is_open){};
+
+    string cmd;
+    double start_x{0};
+    double end_x{0};
+    mousebtn button;
+    alignment align;
+    bool is_open;
+
+    unsigned int width() const {
+      return static_cast<unsigned int>(end_x - start_x + 0.5);
+    }
+
+    bool test(int point) const {
+      return static_cast<int>(start_x) <= point && static_cast<int>(end_x) > point;
+    }
+  };
+
   class action_context {
    public:
     void reset();
@@ -103,22 +125,20 @@ namespace tags {
     action_t action_open(mousebtn btn, const string&& cmd, alignment align);
     std::pair<action_t, mousebtn> action_close(mousebtn btn, alignment align);
 
+    void set_start(action_t id, double x);
+    void set_end(action_t id, double x);
+
+    std::map<mousebtn, tags::action_t> get_actions(int x) const;
+    action_t has_action(mousebtn btn, int x) const;
+
     string get_action(action_t id) const;
     bool has_double_click() const;
 
     size_t num_actions() const;
 
+    std::vector<action_block>& get_blocks();
+
    protected:
-    struct action_block {
-      action_block(const string&& cmd, mousebtn button, alignment align, bool is_open)
-          : cmd(std::move(cmd)), button(button), align(align), is_open(is_open){};
-
-      string cmd;
-      mousebtn button;
-      alignment align;
-      bool is_open;
-    };
-
     /**
      * Stores all currently known action blocks.
      *

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "common.hpp"
+
+POLYBAR_NS
+
+namespace tags {
+  class context {};
+}  // namespace tags
+
+POLYBAR_NS_END

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -158,8 +158,8 @@ namespace tags {
     bool has_double_click() const;
 
     size_t num_actions() const;
+    size_t num_unclosed() const;
 
-    // TODO provide better interface for adjusting the start positions of actions
     const std::vector<action_block>& get_blocks() const;
 
    protected:

--- a/include/tags/dispatch.hpp
+++ b/include/tags/dispatch.hpp
@@ -25,7 +25,7 @@ namespace tags {
     using make_type = unique_ptr<dispatch>;
     static make_type make(action_context& action_ctxt);
 
-    explicit dispatch(signal_emitter& emitter, const logger& logger, action_context& action_ctxt);
+    explicit dispatch(const logger& logger, action_context& action_ctxt);
     void parse(const bar_settings& bar, renderer_interface&, const string&& data);
 
    protected:
@@ -34,7 +34,6 @@ namespace tags {
     void handle_control(controltag ctrl);
 
    private:
-    signal_emitter& m_sig;
     vector<mousebtn> m_actions;
     const logger& m_log;
 

--- a/include/tags/dispatch.hpp
+++ b/include/tags/dispatch.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "components/renderer_interface.hpp"
 #include "errors.hpp"
 
 POLYBAR_NS
@@ -25,7 +26,7 @@ namespace tags {
     static make_type make();
 
     explicit dispatch(signal_emitter& emitter, const logger& logger);
-    void parse(const bar_settings& bar, string data);
+    void parse(const bar_settings& bar, renderer_interface&, string data);
 
    protected:
     void text(string&& data);

--- a/include/tags/dispatch.hpp
+++ b/include/tags/dispatch.hpp
@@ -29,8 +29,9 @@ namespace tags {
     void parse(const bar_settings& bar, renderer_interface&, string data);
 
    protected:
-    void text(string&& data);
+    void handle_text(renderer_interface& renderer, context& ctxt, string&& data);
     void handle_action(mousebtn btn, bool closing, const string&& cmd);
+    void handle_control(context& ctxt, controltag ctrl);
 
    private:
     signal_emitter& m_sig;

--- a/include/tags/dispatch.hpp
+++ b/include/tags/dispatch.hpp
@@ -34,7 +34,6 @@ namespace tags {
     void handle_control(controltag ctrl);
 
    private:
-    vector<mousebtn> m_actions;
     const logger& m_log;
 
     unique_ptr<context> m_ctxt;

--- a/include/tags/dispatch.hpp
+++ b/include/tags/dispatch.hpp
@@ -23,20 +23,23 @@ namespace tags {
   class dispatch {
    public:
     using make_type = unique_ptr<dispatch>;
-    static make_type make();
+    static make_type make(action_context& action_ctxt);
 
-    explicit dispatch(signal_emitter& emitter, const logger& logger);
-    void parse(const bar_settings& bar, renderer_interface&, string data);
+    explicit dispatch(signal_emitter& emitter, const logger& logger, action_context& action_ctxt);
+    void parse(const bar_settings& bar, renderer_interface&, const string&& data);
 
    protected:
-    void handle_text(renderer_interface& renderer, context& ctxt, string&& data);
-    void handle_action(mousebtn btn, bool closing, const string&& cmd);
-    void handle_control(context& ctxt, controltag ctrl);
+    void handle_text(renderer_interface& renderer, string&& data);
+    void handle_action(renderer_interface& renderer, mousebtn btn, bool closing, const string&& cmd);
+    void handle_control(controltag ctrl);
 
    private:
     signal_emitter& m_sig;
     vector<mousebtn> m_actions;
     const logger& m_log;
+
+    unique_ptr<context> m_ctxt;
+    action_context& m_action_ctxt;
   };
 }  // namespace tags
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ if(BUILD_LIBPOLY)
     ${src_dir}/modules/xwindow.cpp
     ${src_dir}/modules/xworkspaces.cpp
 
+    ${src_dir}/tags/action_context.cpp
     ${src_dir}/tags/context.cpp
     ${src_dir}/tags/dispatch.cpp
     ${src_dir}/tags/parser.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ if(BUILD_LIBPOLY)
     ${src_dir}/modules/xwindow.cpp
     ${src_dir}/modules/xworkspaces.cpp
 
+    ${src_dir}/tags/context.cpp
     ${src_dir}/tags/dispatch.cpp
     ${src_dir}/tags/parser.cpp
 

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -361,7 +361,7 @@ void bar::parse(string&& data, bool force) {
   m_renderer->begin(rect);
 
   try {
-    m_dispatch->parse(settings(), data);
+    m_dispatch->parse(settings(), *m_renderer, data);
   } catch (const exception& err) {
     m_log.err("Failed to parse contents (reason: %s)", err.what());
   }

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -741,7 +741,6 @@ void bar::handle(const evt::button_press& evt) {
 
   const auto deferred_fn = [&](size_t) {
     tags::action_t action = m_action_ctxt->has_action(m_buttonpress_btn, m_buttonpress_pos);
-    ;
 
     if (action != tags::NO_ACTION) {
       m_log.trace("Found matching input area");

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -649,10 +649,9 @@ void bar::handle(const evt::motion_notify& evt) {
   // scroll cursor is less important than click cursor, so we shouldn't return until we are sure there is no click
   // action
   bool found_scroll = false;
-  const auto& actions = m_renderer->get_actions(m_motion_pos);
   const auto has_action = [&](const vector<mousebtn>& buttons) -> bool {
     for (auto btn : buttons) {
-      if (actions.at(btn) != tags::NO_ACTION) {
+      if (m_action_ctxt->has_action(btn, m_motion_pos) != tags::NO_ACTION) {
         return true;
       }
     }
@@ -741,7 +740,8 @@ void bar::handle(const evt::button_press& evt) {
   m_buttonpress_pos = evt->event_x;
 
   const auto deferred_fn = [&](size_t) {
-    tags::action_t action = m_renderer->get_action(m_buttonpress_btn, m_buttonpress_pos);
+    tags::action_t action = m_action_ctxt->has_action(m_buttonpress_btn, m_buttonpress_pos);
+    ;
 
     if (action != tags::NO_ACTION) {
       m_log.trace("Found matching input area");
@@ -830,7 +830,7 @@ void bar::handle(const evt::configure_notify&) {
 
 bool bar::on(const signals::eventqueue::start&) {
   m_log.trace("bar: Create renderer");
-  m_renderer = renderer::make(m_opts);
+  m_renderer = renderer::make(m_opts, *m_action_ctxt);
   m_opts.window = m_renderer->window();
 
   // Subscribe to window enter and leave events

--- a/src/components/ipc.cpp
+++ b/src/components/ipc.cpp
@@ -1,8 +1,10 @@
+#include "components/ipc.hpp"
+
 #include <fcntl.h>
 #include <sys/stat.h>
 
-#include "components/ipc.hpp"
 #include "components/logger.hpp"
+#include "errors.hpp"
 #include "events/signal.hpp"
 #include "events/signal_emitter.hpp"
 #include "utils/factory.hpp"

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -734,7 +734,7 @@ void renderer::highlight_clickable_areas() {
     double h = m_rect.height;
 
     m_context->save();
-    *m_context << CAIRO_OPERATOR_DIFFERENCE << (n % 2 ? 0xFF00FF00 : 0xFFFF0000);
+    *m_context << CAIRO_OPERATOR_DIFFERENCE << (n % 2 ? rgba{0xFF00FF00} :rgba{0xFFFF0000});
     *m_context << cairo::rect{x, y, w, h};
     m_context->fill();
     m_context->restore();

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -251,19 +251,6 @@ void renderer::begin(xcb_rectangle_t rect) {
 void renderer::end() {
   m_log.trace_x("renderer: end");
 
-  /*
-   * Finalize the positions of the action blocks.
-   * Up until this point, the positions were relative to the start of the
-   * alignment block the action was located in.
-   * Here we add the start position of the block as well as the start position
-   * of the bar itself (without borders or tray) to create positions relative to
-   * the bar window.
-   */
-  for (auto& a : m_action_ctxt.get_blocks()) {
-    a.start_x += block_x(a.align) + m_rect.x;
-    a.end_x += block_x(a.align) + m_rect.x;
-  }
-
   if (m_align != alignment::NONE) {
     m_log.trace_x("renderer: pop(%i)", static_cast<int>(m_align));
     m_context->pop(&m_blocks[m_align].pattern);
@@ -706,12 +693,12 @@ void renderer::change_alignment(const tags::context& ctxt) {
   }
 }
 
-void renderer::action_open(const tags::context&, tags::action_t id) {
-  m_action_ctxt.set_start(id, m_blocks.at(m_align).x);
+double renderer::get_x(const tags::context& ctxt) const {
+  return m_blocks.at(ctxt.get_alignment()).x;
 }
 
-void renderer::action_close(const tags::context&, tags::action_t id) {
-  m_action_ctxt.set_end(id, m_blocks.at(m_align).x);
+double renderer::get_alignment_start(const alignment align) const {
+  return block_x(align) + m_rect.x;
 }
 
 /**

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -251,6 +251,14 @@ void renderer::begin(xcb_rectangle_t rect) {
 void renderer::end() {
   m_log.trace_x("renderer: end");
 
+  /*
+   * Finalize the positions of the action blocks.
+   * Up until this point, the positions were relative to the start of the
+   * alignment block the action was located in.
+   * Here we add the start position of the block as well as the start position
+   * of the bar itself (without borders or tray) to create positions relative to
+   * the bar window.
+   */
   for (auto& a : m_action_ctxt.get_blocks()) {
     a.start_x += block_x(a.align) + m_rect.x;
     a.end_x += block_x(a.align) + m_rect.x;

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -711,6 +711,11 @@ void renderer::draw_text(const string& contents) {
   }
 }
 
+void renderer::render_offset(const tags::context&, int pixels) {
+  m_log.trace_x("renderer: offset_pixel(%f)", pixels);
+  m_blocks[m_align].x += pixels;
+}
+
 /**
  * Colorize the bounding box of created action blocks
  */
@@ -810,12 +815,6 @@ bool renderer::on(const signals::parser::change_alignment& evt) {
 bool renderer::on(const signals::parser::reverse_colors&) {
   m_log.trace_x("renderer: reverse_colors");
   std::swap(m_fg, m_bg);
-  return true;
-}
-
-bool renderer::on(const signals::parser::offset_pixel& evt) {
-  m_log.trace_x("renderer: offset_pixel(%f)", evt.cast());
-  m_blocks[m_align].x += evt.cast();
   return true;
 }
 

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -706,8 +706,7 @@ void renderer::change_alignment(const tags::context& ctxt) {
   }
 }
 
-void renderer::action_open(const tags::context&, mousebtn btn, tags::action_t id) {
-  assert(btn != mousebtn::NONE);
+void renderer::action_open(const tags::context&, tags::action_t id) {
   m_action_ctxt.set_start(id, m_blocks.at(m_align).x);
 }
 

--- a/src/tags/action_context.cpp
+++ b/src/tags/action_context.cpp
@@ -65,7 +65,6 @@ namespace tags {
   }
 
   action_t action_context::has_action(mousebtn btn, int x) const {
-    // TODO optimize
     return get_actions(x)[btn];
   }
 

--- a/src/tags/action_context.cpp
+++ b/src/tags/action_context.cpp
@@ -1,0 +1,110 @@
+#include "tags/action_context.hpp"
+
+#include <cassert>
+
+POLYBAR_NS
+
+namespace tags {
+
+  void action_context::reset() {
+    m_action_blocks.clear();
+  }
+
+  action_t action_context::action_open(mousebtn btn, const string&& cmd, alignment align, double x) {
+    action_t id = m_action_blocks.size();
+    m_action_blocks.emplace_back(std::move(cmd), btn, align, true);
+    set_start(id, x);
+    return id;
+  }
+
+  std::pair<action_t, mousebtn> action_context::action_close(mousebtn btn, alignment align, double x) {
+    for (auto it = m_action_blocks.rbegin(); it != m_action_blocks.rend(); it++) {
+      if (it->is_open && it->align == align && (btn == mousebtn::NONE || it->button == btn)) {
+        it->is_open = false;
+
+        // Converts a reverse iterator into an index
+        action_t id = std::distance(m_action_blocks.begin(), it.base()) - 1;
+        set_end(id, x);
+        return {id, it->button};
+      }
+    }
+
+    return {NO_ACTION, mousebtn::NONE};
+  }
+
+  void action_context::set_start(action_t id, double x) {
+    m_action_blocks[id].start_x = x;
+  }
+
+  void action_context::set_end(action_t id, double x) {
+    m_action_blocks[id].end_x = x;
+  }
+
+  void action_context::set_alignmnent_start(const alignment a, const double x) {
+    m_align_start[a] = x;
+  }
+
+  std::map<mousebtn, tags::action_t> action_context::get_actions(int x) const {
+    std::map<mousebtn, tags::action_t> buttons;
+
+    for (int i = static_cast<int>(mousebtn::NONE); i < static_cast<int>(mousebtn::BTN_COUNT); i++) {
+      buttons[static_cast<mousebtn>(i)] = tags::NO_ACTION;
+    }
+
+    for (action_t id = 0; (unsigned)id < m_action_blocks.size(); id++) {
+      auto action = m_action_blocks[id];
+      mousebtn btn = action.button;
+
+      // Higher IDs are higher in the action stack.
+      if (id > buttons[btn] && action.test(m_align_start.at(action.align), x)) {
+        buttons[action.button] = id;
+      }
+    }
+
+    return buttons;
+  }
+
+  action_t action_context::has_action(mousebtn btn, int x) const {
+    // TODO optimize
+    return get_actions(x)[btn];
+  }
+
+  string action_context::get_action(action_t id) const {
+    assert(id >= 0 && (unsigned)id < num_actions());
+
+    return m_action_blocks[id].cmd;
+  }
+
+  bool action_context::has_double_click() const {
+    for (auto&& a : m_action_blocks) {
+      if (a.button == mousebtn::DOUBLE_LEFT || a.button == mousebtn::DOUBLE_MIDDLE ||
+          a.button == mousebtn::DOUBLE_RIGHT) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  size_t action_context::num_actions() const {
+    return m_action_blocks.size();
+  }
+
+  size_t action_context::num_unclosed() const {
+    size_t num = 0;
+
+    for (const auto& a : m_action_blocks) {
+      if (a.is_open) {
+        num++;
+      }
+    }
+
+    return num;
+  }
+
+  const std::vector<action_block>& action_context::get_blocks() const {
+    return m_action_blocks;
+  }
+}  // namespace tags
+
+POLYBAR_NS_END

--- a/src/tags/context.cpp
+++ b/src/tags/context.cpp
@@ -137,6 +137,39 @@ namespace tags {
     return {NO_ACTION, mousebtn::NONE};
   }
 
+  void action_context::set_start(action_t id, double x) {
+    m_action_blocks[id].start_x = x;
+  }
+
+  void action_context::set_end(action_t id, double x) {
+    m_action_blocks[id].end_x = x;
+  }
+
+  std::map<mousebtn, tags::action_t> action_context::get_actions(int x) const {
+    std::map<mousebtn, tags::action_t> buttons;
+
+    for (int i = static_cast<int>(mousebtn::NONE); i < static_cast<int>(mousebtn::BTN_COUNT); i++) {
+      buttons[static_cast<mousebtn>(i)] = tags::NO_ACTION;
+    }
+
+    for (action_t id = 0; (unsigned)id < m_action_blocks.size(); id++) {
+      auto action = m_action_blocks[id];
+      mousebtn btn = action.button;
+
+      // Higher IDs are higher in the action stack.
+      if (id > buttons[btn] && action.test(x)) {
+        buttons[action.button] = id;
+      }
+    }
+
+    return buttons;
+  }
+
+  action_t action_context::has_action(mousebtn btn, int x) const {
+    // TODO optimize
+    return get_actions(x)[btn];
+  }
+
   string action_context::get_action(action_t id) const {
     assert(id >= 0 && (unsigned)id < num_actions());
 
@@ -156,6 +189,10 @@ namespace tags {
 
   size_t action_context::num_actions() const {
     return m_action_blocks.size();
+  }
+
+  std::vector<action_block>& action_context::get_blocks() {
+    return m_action_blocks;
   }
 
 }  // namespace tags

--- a/src/tags/context.cpp
+++ b/src/tags/context.cpp
@@ -198,6 +198,18 @@ namespace tags {
     return m_action_blocks.size();
   }
 
+  size_t action_context::num_unclosed() const {
+    size_t num = 0;
+
+    for (const auto& a : m_action_blocks) {
+      if (a.is_open) {
+        num++;
+      }
+    }
+
+    return num;
+  }
+
   const std::vector<action_block>& action_context::get_blocks() const {
     return m_action_blocks;
   }

--- a/src/tags/context.cpp
+++ b/src/tags/context.cpp
@@ -1,7 +1,5 @@
 #include "tags/context.hpp"
 
-#include <cassert>
-
 POLYBAR_NS
 
 namespace tags {
@@ -113,107 +111,6 @@ namespace tags {
   alignment context::get_alignment() const {
     return m_align;
   }
-
-  void action_context::reset() {
-    m_action_blocks.clear();
-  }
-
-  action_t action_context::action_open(mousebtn btn, const string&& cmd, alignment align, double x) {
-    action_t id = m_action_blocks.size();
-    m_action_blocks.emplace_back(std::move(cmd), btn, align, true);
-    set_start(id, x);
-    return id;
-  }
-
-  std::pair<action_t, mousebtn> action_context::action_close(mousebtn btn, alignment align, double x) {
-    for (auto it = m_action_blocks.rbegin(); it != m_action_blocks.rend(); it++) {
-      if (it->is_open && it->align == align && (btn == mousebtn::NONE || it->button == btn)) {
-        it->is_open = false;
-
-        // Converts a reverse iterator into an index
-        action_t id = std::distance(m_action_blocks.begin(), it.base()) - 1;
-        set_end(id, x);
-        return {id, it->button};
-      }
-    }
-
-    return {NO_ACTION, mousebtn::NONE};
-  }
-
-  void action_context::set_start(action_t id, double x) {
-    m_action_blocks[id].start_x = x;
-  }
-
-  void action_context::set_end(action_t id, double x) {
-    m_action_blocks[id].end_x = x;
-  }
-
-  void action_context::set_alignmnent_start(const alignment a, const double x) {
-    m_align_start[a] = x;
-  }
-
-  std::map<mousebtn, tags::action_t> action_context::get_actions(int x) const {
-    std::map<mousebtn, tags::action_t> buttons;
-
-    for (int i = static_cast<int>(mousebtn::NONE); i < static_cast<int>(mousebtn::BTN_COUNT); i++) {
-      buttons[static_cast<mousebtn>(i)] = tags::NO_ACTION;
-    }
-
-    for (action_t id = 0; (unsigned)id < m_action_blocks.size(); id++) {
-      auto action = m_action_blocks[id];
-      mousebtn btn = action.button;
-
-      // Higher IDs are higher in the action stack.
-      if (id > buttons[btn] && action.test(m_align_start.at(action.align), x)) {
-        buttons[action.button] = id;
-      }
-    }
-
-    return buttons;
-  }
-
-  action_t action_context::has_action(mousebtn btn, int x) const {
-    // TODO optimize
-    return get_actions(x)[btn];
-  }
-
-  string action_context::get_action(action_t id) const {
-    assert(id >= 0 && (unsigned)id < num_actions());
-
-    return m_action_blocks[id].cmd;
-  }
-
-  bool action_context::has_double_click() const {
-    for (auto&& a : m_action_blocks) {
-      if (a.button == mousebtn::DOUBLE_LEFT || a.button == mousebtn::DOUBLE_MIDDLE ||
-          a.button == mousebtn::DOUBLE_RIGHT) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  size_t action_context::num_actions() const {
-    return m_action_blocks.size();
-  }
-
-  size_t action_context::num_unclosed() const {
-    size_t num = 0;
-
-    for (const auto& a : m_action_blocks) {
-      if (a.is_open) {
-        num++;
-      }
-    }
-
-    return num;
-  }
-
-  const std::vector<action_block>& action_context::get_blocks() const {
-    return m_action_blocks;
-  }
-
 }  // namespace tags
 
 POLYBAR_NS_END

--- a/src/tags/context.cpp
+++ b/src/tags/context.cpp
@@ -1,0 +1,116 @@
+#include "tags/context.hpp"
+
+POLYBAR_NS
+
+namespace tags {
+  context::context(const bar_settings& settings) : m_settings(settings) {
+    reset();
+  }
+
+  void context::reset() {
+    apply_reset();
+    m_align = alignment::NONE;
+  }
+
+  void context::apply_bg(color_value c) {
+    m_bg = get_color(c, m_settings.background);
+  }
+
+  void context::apply_fg(color_value c) {
+    m_fg = get_color(c, m_settings.foreground);
+  }
+
+  void context::apply_ol(color_value c) {
+    m_ol = get_color(c, m_settings.overline.color);
+  }
+
+  void context::apply_ul(color_value c) {
+    m_ul = get_color(c, m_settings.underline.color);
+  }
+
+  void context::apply_font(int font) {
+    m_font = std::max(font, 0);
+  }
+
+  void context::apply_reverse() {
+    std::swap(m_bg, m_fg);
+  }
+
+  void context::apply_alignment(alignment align) {
+    m_align = align;
+  }
+
+  void context::apply_attr(attr_activation act, attribute attr) {
+    if (attr == attribute::NONE) {
+      return;
+    }
+
+    bool& current = attr == attribute::OVERLINE ? m_attr_overline : m_attr_underline;
+
+    switch (act) {
+      case attr_activation::ON:
+        current = true;
+        break;
+      case attr_activation::OFF:
+        current = false;
+        break;
+      case attr_activation::TOGGLE:
+        current = !current;
+        break;
+      default:
+        break;
+    }
+  }
+
+  void context::apply_reset() {
+    m_bg = m_settings.background;
+    m_fg = m_settings.foreground;
+    m_ul = m_settings.underline.color;
+    m_ol = m_settings.overline.color;
+    m_font = 0;
+    m_attr_overline = false;
+    m_attr_underline = false;
+  }
+
+  rgba context::get_bg() const {
+    return m_bg;
+  }
+
+  rgba context::get_fg() const {
+    return m_fg;
+  }
+
+  rgba context::get_ol() const {
+    return m_ol;
+  }
+
+  rgba context::get_ul() const {
+    return m_ul;
+  }
+
+  int context::get_font() const {
+    return m_font;
+  }
+
+  bool context::has_overline() const {
+    return m_attr_overline;
+  }
+
+  bool context::has_underline() const {
+    return m_attr_underline;
+  }
+
+  alignment context::get_alignment() const {
+    return m_align;
+  }
+
+  rgba context::get_color(color_value c, rgba fallback) const {
+    if (c.type == color_type::RESET) {
+      return fallback;
+    } else {
+      return c.val;
+    }
+  }
+}  // namespace tags
+
+POLYBAR_NS_END

--- a/src/tags/dispatch.cpp
+++ b/src/tags/dispatch.cpp
@@ -11,21 +11,18 @@
 
 POLYBAR_NS
 
-using namespace signals::parser;
-
 namespace tags {
   /**
    * Create instance
    */
   dispatch::make_type dispatch::make(action_context& action_ctxt) {
-    return factory_util::unique<dispatch>(signal_emitter::make(), logger::make(), action_ctxt);
+    return factory_util::unique<dispatch>(logger::make(), action_ctxt);
   }
 
   /**
    * Construct parser instance
    */
-  dispatch::dispatch(signal_emitter& emitter, const logger& logger, action_context& action_ctxt)
-      : m_sig(emitter), m_log(logger), m_action_ctxt(action_ctxt) {}
+  dispatch::dispatch(const logger& logger, action_context& action_ctxt) : m_log(logger), m_action_ctxt(action_ctxt) {}
 
   /**
    * Process input string
@@ -79,15 +76,15 @@ namespace tags {
                 break;
               case tags::syntaxtag::l:
                 m_ctxt->apply_alignment(alignment::LEFT);
-                m_sig.emit(change_alignment{alignment::LEFT});
+                renderer.change_alignment(*m_ctxt);
                 break;
               case tags::syntaxtag::r:
                 m_ctxt->apply_alignment(alignment::RIGHT);
-                m_sig.emit(change_alignment{alignment::RIGHT});
+                renderer.change_alignment(*m_ctxt);
                 break;
               case tags::syntaxtag::c:
                 m_ctxt->apply_alignment(alignment::CENTER);
-                m_sig.emit(change_alignment{alignment::CENTER});
+                renderer.change_alignment(*m_ctxt);
                 break;
               default:
                 throw runtime_error(
@@ -129,7 +126,6 @@ namespace tags {
       std::tie(id, btn) = m_action_ctxt.action_close(btn, m_ctxt->get_alignment());
       renderer.action_close(*m_ctxt, id);
     } else {
-      string tmp = cmd;
       action_t id = m_action_ctxt.action_open(btn, std::move(cmd), m_ctxt->get_alignment());
       renderer.action_open(*m_ctxt, btn, id);
     }

--- a/src/tags/dispatch.cpp
+++ b/src/tags/dispatch.cpp
@@ -37,7 +37,7 @@ namespace tags {
   /**
    * Process input string
    */
-  void dispatch::parse(const bar_settings& bar, string data) {
+  void dispatch::parse(const bar_settings& bar, renderer_interface& renderer, string data) {
     tags::parser p;
     p.set(std::move(data));
 
@@ -67,7 +67,7 @@ namespace tags {
                 m_sig.emit(change_font{el.tag_data.font});
                 break;
               case tags::syntaxtag::O:
-                m_sig.emit(offset_pixel{el.tag_data.offset});
+                renderer.render_offset(tags::context{}, el.tag_data.offset);
                 break;
               case tags::syntaxtag::R:
                 m_sig.emit(reverse_colors{});

--- a/src/tags/dispatch.cpp
+++ b/src/tags/dispatch.cpp
@@ -100,6 +100,10 @@ namespace tags {
       }
     }
 
+    for (auto a : {alignment::LEFT, alignment::CENTER, alignment::RIGHT}) {
+      m_action_ctxt.set_alignmnent_start(a, renderer.get_alignment_start(a));
+    }
+
     // TODO handle unclosed action tags in ctxt
     /* if (!m_actions.empty()) { */
     /*   throw runtime_error(to_string(m_actions.size()) + " unclosed action block(s)"); */
@@ -122,12 +126,9 @@ namespace tags {
 
   void dispatch::handle_action(renderer_interface& renderer, mousebtn btn, bool closing, const string&& cmd) {
     if (closing) {
-      action_t id;
-      std::tie(id, btn) = m_action_ctxt.action_close(btn, m_ctxt->get_alignment());
-      renderer.action_close(*m_ctxt, id);
+      m_action_ctxt.action_close(btn, m_ctxt->get_alignment(), renderer.get_x(*m_ctxt));
     } else {
-      action_t id = m_action_ctxt.action_open(btn, std::move(cmd), m_ctxt->get_alignment());
-      renderer.action_open(*m_ctxt, id);
+      m_action_ctxt.action_open(btn, std::move(cmd), m_ctxt->get_alignment(), renderer.get_x(*m_ctxt));
     }
   }
 

--- a/src/tags/dispatch.cpp
+++ b/src/tags/dispatch.cpp
@@ -127,7 +127,7 @@ namespace tags {
       renderer.action_close(*m_ctxt, id);
     } else {
       action_t id = m_action_ctxt.action_open(btn, std::move(cmd), m_ctxt->get_alignment());
-      renderer.action_open(*m_ctxt, btn, id);
+      renderer.action_open(*m_ctxt, id);
     }
   }
 

--- a/src/tags/dispatch.cpp
+++ b/src/tags/dispatch.cpp
@@ -17,23 +17,25 @@ namespace tags {
   /**
    * Create instance
    */
-  dispatch::make_type dispatch::make() {
-    return factory_util::unique<dispatch>(signal_emitter::make(), logger::make());
+  dispatch::make_type dispatch::make(action_context& action_ctxt) {
+    return factory_util::unique<dispatch>(signal_emitter::make(), logger::make(), action_ctxt);
   }
 
   /**
    * Construct parser instance
    */
-  dispatch::dispatch(signal_emitter& emitter, const logger& logger) : m_sig(emitter), m_log(logger) {}
+  dispatch::dispatch(signal_emitter& emitter, const logger& logger, action_context& action_ctxt)
+      : m_sig(emitter), m_log(logger), m_action_ctxt(action_ctxt) {}
 
   /**
    * Process input string
    */
-  void dispatch::parse(const bar_settings& bar, renderer_interface& renderer, string data) {
+  void dispatch::parse(const bar_settings& bar, renderer_interface& renderer, const string&& data) {
     tags::parser p;
     p.set(std::move(data));
 
-    context ctxt(bar);
+    m_action_ctxt.reset();
+    m_ctxt = make_unique<context>(bar);
 
     while (p.has_next_element()) {
       tags::element el;
@@ -49,42 +51,42 @@ namespace tags {
           case tags::tag_type::FORMAT:
             switch (el.tag_data.subtype.format) {
               case tags::syntaxtag::A:
-                handle_action(el.tag_data.action.btn, el.tag_data.action.closing, std::move(el.data));
+                handle_action(renderer, el.tag_data.action.btn, el.tag_data.action.closing, std::move(el.data));
                 break;
               case tags::syntaxtag::B:
-                ctxt.apply_bg(el.tag_data.color);
+                m_ctxt->apply_bg(el.tag_data.color);
                 break;
               case tags::syntaxtag::F:
-                ctxt.apply_fg(el.tag_data.color);
+                m_ctxt->apply_fg(el.tag_data.color);
                 break;
               case tags::syntaxtag::T:
-                ctxt.apply_font(el.tag_data.font);
+                m_ctxt->apply_font(el.tag_data.font);
                 break;
               case tags::syntaxtag::O:
-                renderer.render_offset(ctxt, el.tag_data.offset);
+                renderer.render_offset(*m_ctxt, el.tag_data.offset);
                 break;
               case tags::syntaxtag::R:
-                ctxt.apply_reverse();
+                m_ctxt->apply_reverse();
                 break;
               case tags::syntaxtag::o:
-                ctxt.apply_ol(el.tag_data.color);
+                m_ctxt->apply_ol(el.tag_data.color);
                 break;
               case tags::syntaxtag::u:
-                ctxt.apply_ul(el.tag_data.color);
+                m_ctxt->apply_ul(el.tag_data.color);
                 break;
               case tags::syntaxtag::P:
-                handle_control(ctxt, el.tag_data.ctrl);
+                handle_control(el.tag_data.ctrl);
                 break;
               case tags::syntaxtag::l:
-                ctxt.apply_alignment(alignment::LEFT);
+                m_ctxt->apply_alignment(alignment::LEFT);
                 m_sig.emit(change_alignment{alignment::LEFT});
                 break;
               case tags::syntaxtag::r:
-                ctxt.apply_alignment(alignment::RIGHT);
+                m_ctxt->apply_alignment(alignment::RIGHT);
                 m_sig.emit(change_alignment{alignment::RIGHT});
                 break;
               case tags::syntaxtag::c:
-                ctxt.apply_alignment(alignment::CENTER);
+                m_ctxt->apply_alignment(alignment::CENTER);
                 m_sig.emit(change_alignment{alignment::CENTER});
                 break;
               default:
@@ -93,23 +95,24 @@ namespace tags {
             }
             break;
           case tags::tag_type::ATTR:
-            ctxt.apply_attr(el.tag_data.subtype.activation, el.tag_data.attr);
+            m_ctxt->apply_attr(el.tag_data.subtype.activation, el.tag_data.attr);
             break;
         }
       } else {
-        handle_text(renderer, ctxt, std::move(el.data));
+        handle_text(renderer, std::move(el.data));
       }
     }
 
-    if (!m_actions.empty()) {
-      throw runtime_error(to_string(m_actions.size()) + " unclosed action block(s)");
-    }
+    // TODO handle unclosed action tags in ctxt
+    /* if (!m_actions.empty()) { */
+    /*   throw runtime_error(to_string(m_actions.size()) + " unclosed action block(s)"); */
+    /* } */
   }
 
   /**
    * Process text contents
    */
-  void dispatch::handle_text(renderer_interface& renderer, context& ctxt, string&& data) {
+  void dispatch::handle_text(renderer_interface& renderer, string&& data) {
 #ifdef DEBUG_WHITESPACE
     string::size_type p;
     while ((p = data.find(' ')) != string::npos) {
@@ -117,43 +120,25 @@ namespace tags {
     }
 #endif
 
-    renderer.render_text(ctxt, std::move(data));
+    renderer.render_text(*m_ctxt, std::move(data));
   }
 
-  void dispatch::handle_action(mousebtn btn, bool closing, const string&& cmd) {
+  void dispatch::handle_action(renderer_interface& renderer, mousebtn btn, bool closing, const string&& cmd) {
     if (closing) {
-      if (btn == mousebtn::NONE) {
-        if (!m_actions.empty()) {
-          btn = m_actions.back();
-          m_actions.pop_back();
-        } else {
-          m_log.err("parser: Closing action tag without matching tag");
-        }
-      } else {
-        auto it = std::find(m_actions.crbegin(), m_actions.crend(), btn);
-
-        if (it == m_actions.rend()) {
-          m_log.err("parser: Closing action tag for button %d without matching opening tag", static_cast<int>(btn));
-        } else {
-          /*
-           * We can't erase with a reverse iterator, we have to get
-           * the forward iterator first
-           * https://stackoverflow.com/a/1830240/5363071
-           */
-          m_actions.erase(std::next(it).base());
-        }
-      }
-      m_sig.emit(action_end{btn});
+      action_t id;
+      std::tie(id, btn) = m_action_ctxt.action_close(btn, m_ctxt->get_alignment());
+      renderer.action_close(*m_ctxt, id);
     } else {
-      m_actions.push_back(btn);
-      m_sig.emit(action_begin{action{btn, std::move(cmd)}});
+      string tmp = cmd;
+      action_t id = m_action_ctxt.action_open(btn, std::move(cmd), m_ctxt->get_alignment());
+      renderer.action_open(*m_ctxt, btn, id);
     }
   }
 
-  void dispatch::handle_control(context& ctxt, controltag ctrl) {
+  void dispatch::handle_control(controltag ctrl) {
     switch (ctrl) {
       case controltag::R:
-        ctxt.reset();
+        m_ctxt->apply_reset();
         break;
       default:
         throw runtime_error("Unrecognized polybar control tag: " + to_string(static_cast<int>(ctrl)));

--- a/src/tags/dispatch.cpp
+++ b/src/tags/dispatch.cpp
@@ -100,14 +100,19 @@ namespace tags {
       }
     }
 
+    /*
+     * After rendering, we need to tell the action context about the position
+     * of the alignment blocks so that it can do intersection tests.
+     */
     for (auto a : {alignment::LEFT, alignment::CENTER, alignment::RIGHT}) {
       m_action_ctxt.set_alignmnent_start(a, renderer.get_alignment_start(a));
     }
 
-    // TODO handle unclosed action tags in ctxt
-    /* if (!m_actions.empty()) { */
-    /*   throw runtime_error(to_string(m_actions.size()) + " unclosed action block(s)"); */
-    /* } */
+    auto num_unclosed = m_action_ctxt.num_unclosed();
+
+    if (num_unclosed != 0) {
+      throw runtime_error(to_string(num_unclosed) + " unclosed action block(s)");
+    }
   }
 
   /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_unit_test(drawtypes/ramp)
 add_unit_test(drawtypes/iconset)
 add_unit_test(tags/parser)
 add_unit_test(tags/dispatch)
+add_unit_test(tags/action_context)
 
 # Run make check to build and run all unit tests
 add_custom_target(check

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ add_unit_test(drawtypes/label)
 add_unit_test(drawtypes/ramp)
 add_unit_test(drawtypes/iconset)
 add_unit_test(tags/parser)
+add_unit_test(tags/dispatch)
 
 # Run make check to build and run all unit tests
 add_custom_target(check

--- a/tests/unit_tests/tags/action_context.cpp
+++ b/tests/unit_tests/tags/action_context.cpp
@@ -1,0 +1,137 @@
+#include "tags/context.hpp"
+
+#include "common/test.hpp"
+#include "components/logger.hpp"
+
+using namespace polybar;
+using namespace std;
+using namespace tags;
+
+TEST(ActionCtxtTest, dblClick) {
+  action_context ctxt;
+
+  ctxt.action_open(mousebtn::DOUBLE_LEFT, "", alignment::LEFT);
+  ctxt.action_close(mousebtn::DOUBLE_LEFT, alignment::LEFT);
+
+  ASSERT_TRUE(ctxt.has_double_click());
+
+  ctxt.reset();
+
+  ctxt.action_open(mousebtn::DOUBLE_MIDDLE, "", alignment::LEFT);
+  ctxt.action_close(mousebtn::DOUBLE_MIDDLE, alignment::LEFT);
+
+  ASSERT_TRUE(ctxt.has_double_click());
+
+  ctxt.action_open(mousebtn::DOUBLE_RIGHT, "", alignment::LEFT);
+  ctxt.action_close(mousebtn::DOUBLE_RIGHT, alignment::LEFT);
+
+  ASSERT_TRUE(ctxt.has_double_click());
+}
+
+TEST(ActionCtxtTest, closing) {
+  action_context ctxt;
+
+  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
+  auto id2 = ctxt.action_open(mousebtn::RIGHT, "", alignment::CENTER);
+  auto id3 = ctxt.action_open(mousebtn::RIGHT, "", alignment::LEFT);
+  auto id4 = ctxt.action_open(mousebtn::MIDDLE, "", alignment::LEFT);
+
+  EXPECT_NE(NO_ACTION, id1);
+  EXPECT_NE(NO_ACTION, id2);
+  EXPECT_NE(NO_ACTION, id3);
+  EXPECT_NE(NO_ACTION, id4);
+
+  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::LEFT, alignment::LEFT));
+  EXPECT_EQ(make_pair(id4, mousebtn::MIDDLE), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
+  EXPECT_EQ(make_pair(id3, mousebtn::RIGHT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
+  EXPECT_EQ(make_pair(id2, mousebtn::RIGHT), ctxt.action_close(mousebtn::NONE, alignment::CENTER));
+
+  EXPECT_EQ(4, ctxt.num_actions());
+}
+
+TEST(ActionCtxtTest, overlapping) {
+  action_context ctxt;
+
+  /*
+   * clang-format off
+   *
+   * Sets up the following overlapping of actions:
+   *    0123456
+   * 1: [--)     (LEFT)
+   * 2:  [----)  (MIDDLE)
+   * 3:   [--)   (RIGHT)
+   * clang-format on
+   */
+
+  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
+  auto id2 = ctxt.action_open(mousebtn::MIDDLE, "", alignment::LEFT);
+  auto id3 = ctxt.action_open(mousebtn::RIGHT, "", alignment::LEFT);
+  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::LEFT, alignment::LEFT));
+  EXPECT_EQ(make_pair(id3, mousebtn::RIGHT), ctxt.action_close(mousebtn::RIGHT, alignment::LEFT));
+  EXPECT_EQ(make_pair(id2, mousebtn::MIDDLE), ctxt.action_close(mousebtn::MIDDLE, alignment::LEFT));
+
+  ctxt.set_start(id1, 0);
+  ctxt.set_end(id1, 3);
+  ctxt.set_start(id2, 1);
+  ctxt.set_end(id2, 6);
+  ctxt.set_start(id3, 2);
+  ctxt.set_end(id3, 5);
+
+  auto actions = ctxt.get_actions(2);
+
+  EXPECT_EQ(id1, actions[mousebtn::LEFT]);
+  EXPECT_EQ(id2, actions[mousebtn::MIDDLE]);
+  EXPECT_EQ(id3, actions[mousebtn::RIGHT]);
+
+  EXPECT_EQ(3, ctxt.num_actions());
+}
+
+TEST(ActionCtxtTest, stacking) {
+  action_context ctxt;
+
+  /*
+   * clang-format off
+   *
+   * Sets up the following stacked actions:
+   *    012345678
+   * 1: [-------)
+   * 2:  [-----)
+   * 3:    [--)
+   * clang-format on
+   */
+
+  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
+  auto id2 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
+  auto id3 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
+  EXPECT_EQ(make_pair(id3, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
+  EXPECT_EQ(make_pair(id2, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
+  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
+
+  ctxt.set_start(id1, 0);
+  ctxt.set_end(id1, 8);
+  ctxt.set_start(id2, 1);
+  ctxt.set_end(id2, 7);
+  ctxt.set_start(id3, 3);
+  ctxt.set_end(id3, 6);
+
+  EXPECT_EQ(id1, ctxt.has_action(mousebtn::LEFT, 0));
+  EXPECT_EQ(id2, ctxt.has_action(mousebtn::LEFT, 1));
+  EXPECT_EQ(id2, ctxt.has_action(mousebtn::LEFT, 2));
+  EXPECT_EQ(id3, ctxt.has_action(mousebtn::LEFT, 3));
+  EXPECT_EQ(id3, ctxt.has_action(mousebtn::LEFT, 4));
+  EXPECT_EQ(id3, ctxt.has_action(mousebtn::LEFT, 5));
+  EXPECT_EQ(id2, ctxt.has_action(mousebtn::LEFT, 6));
+  EXPECT_EQ(id1, ctxt.has_action(mousebtn::LEFT, 7));
+
+  EXPECT_EQ(3, ctxt.num_actions());
+}
+
+TEST(ActionCtxtTest, cmd) {
+  action_context ctxt;
+
+  string cmd = "foobar";
+
+  auto id = ctxt.action_open(mousebtn::DOUBLE_RIGHT, cmd.substr(), alignment::RIGHT);
+
+  ASSERT_EQ(cmd, ctxt.get_action(id));
+}

--- a/tests/unit_tests/tags/action_context.cpp
+++ b/tests/unit_tests/tags/action_context.cpp
@@ -1,6 +1,7 @@
+#include "tags/action_context.hpp"
+
 #include "common/test.hpp"
 #include "components/logger.hpp"
-#include "tags/context.hpp"
 
 using namespace polybar;
 using namespace std;

--- a/tests/unit_tests/tags/action_context.cpp
+++ b/tests/unit_tests/tags/action_context.cpp
@@ -1,7 +1,6 @@
-#include "tags/context.hpp"
-
 #include "common/test.hpp"
 #include "components/logger.hpp"
+#include "tags/context.hpp"
 
 using namespace polybar;
 using namespace std;
@@ -10,20 +9,20 @@ using namespace tags;
 TEST(ActionCtxtTest, dblClick) {
   action_context ctxt;
 
-  ctxt.action_open(mousebtn::DOUBLE_LEFT, "", alignment::LEFT);
-  ctxt.action_close(mousebtn::DOUBLE_LEFT, alignment::LEFT);
+  ctxt.action_open(mousebtn::DOUBLE_LEFT, "", alignment::LEFT, 0);
+  ctxt.action_close(mousebtn::DOUBLE_LEFT, alignment::LEFT, 1);
 
   ASSERT_TRUE(ctxt.has_double_click());
 
   ctxt.reset();
 
-  ctxt.action_open(mousebtn::DOUBLE_MIDDLE, "", alignment::LEFT);
-  ctxt.action_close(mousebtn::DOUBLE_MIDDLE, alignment::LEFT);
+  ctxt.action_open(mousebtn::DOUBLE_MIDDLE, "", alignment::LEFT, 0);
+  ctxt.action_close(mousebtn::DOUBLE_MIDDLE, alignment::LEFT, 1);
 
   ASSERT_TRUE(ctxt.has_double_click());
 
-  ctxt.action_open(mousebtn::DOUBLE_RIGHT, "", alignment::LEFT);
-  ctxt.action_close(mousebtn::DOUBLE_RIGHT, alignment::LEFT);
+  ctxt.action_open(mousebtn::DOUBLE_RIGHT, "", alignment::LEFT, 0);
+  ctxt.action_close(mousebtn::DOUBLE_RIGHT, alignment::LEFT, 1);
 
   ASSERT_TRUE(ctxt.has_double_click());
 }
@@ -31,20 +30,20 @@ TEST(ActionCtxtTest, dblClick) {
 TEST(ActionCtxtTest, closing) {
   action_context ctxt;
 
-  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
-  auto id2 = ctxt.action_open(mousebtn::RIGHT, "", alignment::CENTER);
-  auto id3 = ctxt.action_open(mousebtn::RIGHT, "", alignment::LEFT);
-  auto id4 = ctxt.action_open(mousebtn::MIDDLE, "", alignment::LEFT);
+  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT, 0);
+  auto id2 = ctxt.action_open(mousebtn::RIGHT, "", alignment::CENTER, 0);
+  auto id3 = ctxt.action_open(mousebtn::RIGHT, "", alignment::LEFT, 0);
+  auto id4 = ctxt.action_open(mousebtn::MIDDLE, "", alignment::LEFT, 0);
 
   EXPECT_NE(NO_ACTION, id1);
   EXPECT_NE(NO_ACTION, id2);
   EXPECT_NE(NO_ACTION, id3);
   EXPECT_NE(NO_ACTION, id4);
 
-  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::LEFT, alignment::LEFT));
-  EXPECT_EQ(make_pair(id4, mousebtn::MIDDLE), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
-  EXPECT_EQ(make_pair(id3, mousebtn::RIGHT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
-  EXPECT_EQ(make_pair(id2, mousebtn::RIGHT), ctxt.action_close(mousebtn::NONE, alignment::CENTER));
+  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::LEFT, alignment::LEFT, 1));
+  EXPECT_EQ(make_pair(id4, mousebtn::MIDDLE), ctxt.action_close(mousebtn::NONE, alignment::LEFT, 1));
+  EXPECT_EQ(make_pair(id3, mousebtn::RIGHT), ctxt.action_close(mousebtn::NONE, alignment::LEFT, 1));
+  EXPECT_EQ(make_pair(id2, mousebtn::RIGHT), ctxt.action_close(mousebtn::NONE, alignment::CENTER, 1));
 
   EXPECT_EQ(4, ctxt.num_actions());
 }
@@ -63,19 +62,12 @@ TEST(ActionCtxtTest, overlapping) {
    * clang-format on
    */
 
-  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
-  auto id2 = ctxt.action_open(mousebtn::MIDDLE, "", alignment::LEFT);
-  auto id3 = ctxt.action_open(mousebtn::RIGHT, "", alignment::LEFT);
-  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::LEFT, alignment::LEFT));
-  EXPECT_EQ(make_pair(id3, mousebtn::RIGHT), ctxt.action_close(mousebtn::RIGHT, alignment::LEFT));
-  EXPECT_EQ(make_pair(id2, mousebtn::MIDDLE), ctxt.action_close(mousebtn::MIDDLE, alignment::LEFT));
-
-  ctxt.set_start(id1, 0);
-  ctxt.set_end(id1, 3);
-  ctxt.set_start(id2, 1);
-  ctxt.set_end(id2, 6);
-  ctxt.set_start(id3, 2);
-  ctxt.set_end(id3, 5);
+  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT, 0);
+  auto id2 = ctxt.action_open(mousebtn::MIDDLE, "", alignment::LEFT, 1);
+  auto id3 = ctxt.action_open(mousebtn::RIGHT, "", alignment::LEFT, 2);
+  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::LEFT, alignment::LEFT, 3));
+  EXPECT_EQ(make_pair(id3, mousebtn::RIGHT), ctxt.action_close(mousebtn::RIGHT, alignment::LEFT, 6));
+  EXPECT_EQ(make_pair(id2, mousebtn::MIDDLE), ctxt.action_close(mousebtn::MIDDLE, alignment::LEFT, 5));
 
   auto actions = ctxt.get_actions(2);
 
@@ -100,19 +92,12 @@ TEST(ActionCtxtTest, stacking) {
    * clang-format on
    */
 
-  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
-  auto id2 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
-  auto id3 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT);
-  EXPECT_EQ(make_pair(id3, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
-  EXPECT_EQ(make_pair(id2, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
-  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT));
-
-  ctxt.set_start(id1, 0);
-  ctxt.set_end(id1, 8);
-  ctxt.set_start(id2, 1);
-  ctxt.set_end(id2, 7);
-  ctxt.set_start(id3, 3);
-  ctxt.set_end(id3, 6);
+  auto id1 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT, 0);
+  auto id2 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT, 1);
+  auto id3 = ctxt.action_open(mousebtn::LEFT, "", alignment::LEFT, 3);
+  EXPECT_EQ(make_pair(id3, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT, 6));
+  EXPECT_EQ(make_pair(id2, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT, 7));
+  EXPECT_EQ(make_pair(id1, mousebtn::LEFT), ctxt.action_close(mousebtn::NONE, alignment::LEFT, 8));
 
   EXPECT_EQ(id1, ctxt.has_action(mousebtn::LEFT, 0));
   EXPECT_EQ(id2, ctxt.has_action(mousebtn::LEFT, 1));
@@ -131,7 +116,7 @@ TEST(ActionCtxtTest, cmd) {
 
   string cmd = "foobar";
 
-  auto id = ctxt.action_open(mousebtn::DOUBLE_RIGHT, cmd.substr(), alignment::RIGHT);
+  auto id = ctxt.action_open(mousebtn::DOUBLE_RIGHT, cmd.substr(), alignment::RIGHT, 0);
 
   ASSERT_EQ(cmd, ctxt.get_action(id));
 }

--- a/tests/unit_tests/tags/action_context.cpp
+++ b/tests/unit_tests/tags/action_context.cpp
@@ -46,6 +46,7 @@ TEST(ActionCtxtTest, closing) {
   EXPECT_EQ(make_pair(id2, mousebtn::RIGHT), ctxt.action_close(mousebtn::NONE, alignment::CENTER, 1));
 
   EXPECT_EQ(4, ctxt.num_actions());
+  EXPECT_EQ(0, ctxt.num_unclosed());
 }
 
 TEST(ActionCtxtTest, overlapping) {
@@ -76,6 +77,7 @@ TEST(ActionCtxtTest, overlapping) {
   EXPECT_EQ(id3, actions[mousebtn::RIGHT]);
 
   EXPECT_EQ(3, ctxt.num_actions());
+  EXPECT_EQ(0, ctxt.num_unclosed());
 }
 
 TEST(ActionCtxtTest, stacking) {
@@ -109,6 +111,7 @@ TEST(ActionCtxtTest, stacking) {
   EXPECT_EQ(id1, ctxt.has_action(mousebtn::LEFT, 7));
 
   EXPECT_EQ(3, ctxt.num_actions());
+  EXPECT_EQ(0, ctxt.num_unclosed());
 }
 
 TEST(ActionCtxtTest, cmd) {

--- a/tests/unit_tests/tags/dispatch.cpp
+++ b/tests/unit_tests/tags/dispatch.cpp
@@ -1,0 +1,47 @@
+#include "tags/dispatch.hpp"
+
+#include "common/test.hpp"
+#include "components/logger.hpp"
+#include "gmock/gmock.h"
+
+using namespace polybar;
+using namespace std;
+using namespace tags;
+
+using ::testing::InSequence;
+using ::testing::_;
+
+class MockRenderer : public renderer_interface {
+ public:
+  MockRenderer(action_context& action_ctxt) : renderer_interface(action_ctxt){};
+
+  MOCK_METHOD(void, render_offset, (const context& ctxt, int pixels), (override));
+  MOCK_METHOD(void, render_text, (const context& ctxt, const string&& str), (override));
+  MOCK_METHOD(void, change_alignment, (const context& ctxt), (override));
+  MOCK_METHOD(void, action_open, (const context& ctxt, mousebtn btn, action_t id), (override));
+  MOCK_METHOD(void, action_close, (const context& ctxt, action_t id), (override));
+};
+
+class TestableDispatch : public dispatch {};
+
+class Dispatch : public ::testing::Test {
+ protected:
+  unique_ptr<action_context> action_ctxt = make_unique<action_context>();
+
+  unique_ptr<dispatch> parser = make_unique<dispatch>(logger(loglevel::NONE), *action_ctxt);
+};
+
+TEST_F(Dispatch, ignoreFormatting) {
+  MockRenderer r(*action_ctxt);
+
+  {
+    InSequence seq;
+    EXPECT_CALL(r, render_offset(_, 10)).Times(1);
+    EXPECT_CALL(r, render_text(_, string{"abc"})).Times(1);
+    EXPECT_CALL(r, render_text(_, string{"foo"})).Times(1);
+  }
+
+  bar_settings settings;
+
+  parser->parse(settings, r, "%{O10}abc%{F-}foo");
+}

--- a/tests/unit_tests/tags/dispatch.cpp
+++ b/tests/unit_tests/tags/dispatch.cpp
@@ -9,7 +9,11 @@ using namespace std;
 using namespace tags;
 
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::InSequence;
+using ::testing::Property;
+using ::testing::Return;
+using ::testing::Truly;
 
 class MockRenderer : public renderer_interface {
  public:
@@ -22,6 +26,19 @@ class MockRenderer : public renderer_interface {
   MOCK_METHOD(double, get_alignment_start, (const alignment align), (const, override));
 };
 
+static auto match_fg = [](rgba c) { return Property("get_fg", &context::get_fg, c); };
+static auto match_bg = [](rgba c) { return Property("get_bg", &context::get_bg, c); };
+static auto match_ol = [](rgba c) { return Property("get_ol", &context::get_ol, c); };
+static auto match_ul = [](rgba c) { return Property("get_ul", &context::get_ul, c); };
+static auto match_font = [](int font) { return Property("get_font", &context::get_font, font); };
+static auto match_overline = [](bool has) { return Property("has_overline", &context::has_overline, has); };
+static auto match_underline = [](bool has) { return Property("has_underline", &context::has_underline, has); };
+
+static auto match_align = [](alignment align) { return Property("get_alignment", &context::get_alignment, align); };
+static auto match_left_align = match_align(alignment::LEFT);
+static auto match_center_align = match_align(alignment::CENTER);
+static auto match_right_align = match_align(alignment::RIGHT);
+
 class TestableDispatch : public dispatch {};
 
 class DispatchTest : public ::testing::Test {
@@ -29,11 +46,11 @@ class DispatchTest : public ::testing::Test {
   unique_ptr<action_context> m_action_ctxt = make_unique<action_context>();
 
   unique_ptr<dispatch> m_dispatch = make_unique<dispatch>(logger(loglevel::NONE), *m_action_ctxt);
+
+  MockRenderer r{*m_action_ctxt};
 };
 
 TEST_F(DispatchTest, ignoreFormatting) {
-  MockRenderer r(*m_action_ctxt);
-
   {
     InSequence seq;
     EXPECT_CALL(r, render_offset(_, 10)).Times(1);
@@ -42,6 +59,60 @@ TEST_F(DispatchTest, ignoreFormatting) {
   }
 
   bar_settings settings;
+  m_dispatch->parse(settings, r, "%{O10}%{F#ff0000}abc%{F-}foo");
+}
 
-  m_dispatch->parse(settings, r, "%{O10}abc%{F-}foo");
+TEST_F(DispatchTest, formatting) {
+  rgba bar_fg{"#000000"};
+
+  {
+    InSequence seq;
+    EXPECT_CALL(r, render_offset(match_underline(true), 10)).Times(1);
+    EXPECT_CALL(r, render_text(match_fg(rgba{"#ff0000"}), string{"abc"})).Times(1);
+    EXPECT_CALL(r, render_text(match_fg(bar_fg), string{"foo"})).Times(1);
+    EXPECT_CALL(r, change_alignment(match_left_align)).Times(1);
+    EXPECT_CALL(r, render_text(AllOf(match_left_align, match_bg(rgba{"#00ff00"}), match_overline(true)), string{"bar"}))
+        .Times(1);
+    EXPECT_CALL(r, change_alignment(match_center_align)).Times(1);
+    EXPECT_CALL(r, render_text(AllOf(match_center_align, match_ul(rgba{"#0000ff"})), string{"baz"})).Times(1);
+    EXPECT_CALL(r, change_alignment(match_right_align)).Times(1);
+    EXPECT_CALL(r, render_text(AllOf(match_right_align, match_ol(rgba{"#f0f0f0"}), match_font(123)), string{"def"}))
+        .Times(1);
+  }
+
+  bar_settings settings;
+  settings.foreground = bar_fg;
+
+  m_dispatch->parse(settings, r,
+      "%{+u}%{O10}%{F#ff0000}abc%{F-}foo%{l}%{+o}%{B#00ff00}bar%{c}%{u#0000ff}baz%{r}%{o#f0f0f0}%{T123}def");
+}
+
+TEST_F(DispatchTest, unclosedActions) {
+  { InSequence seq; }
+
+  bar_settings settings;
+  EXPECT_THROW(m_dispatch->parse(settings, r, "%{A1:cmd:}foo"), runtime_error);
+}
+
+TEST_F(DispatchTest, actions) {
+  {
+    InSequence seq;
+    EXPECT_CALL(r, get_x(_)).WillOnce(Return(3));
+    EXPECT_CALL(r, get_x(_)).WillOnce(Return(6));
+  }
+
+  bar_settings settings;
+  m_dispatch->parse(settings, r, "%{l}foo%{A1:cmd:}bar%{A}");
+
+  const auto& actions = m_action_ctxt->get_blocks();
+
+  ASSERT_EQ(1, actions.size());
+
+  const auto& blk = actions[0];
+
+  EXPECT_EQ(3, blk.start_x);
+  EXPECT_EQ(6, blk.end_x);
+  EXPECT_EQ(alignment::LEFT, blk.align);
+  EXPECT_EQ(mousebtn::LEFT, blk.button);
+  EXPECT_EQ("cmd", blk.cmd);
 }

--- a/tests/unit_tests/tags/dispatch.cpp
+++ b/tests/unit_tests/tags/dispatch.cpp
@@ -8,8 +8,8 @@ using namespace polybar;
 using namespace std;
 using namespace tags;
 
-using ::testing::InSequence;
 using ::testing::_;
+using ::testing::InSequence;
 
 class MockRenderer : public renderer_interface {
  public:
@@ -18,8 +18,8 @@ class MockRenderer : public renderer_interface {
   MOCK_METHOD(void, render_offset, (const context& ctxt, int pixels), (override));
   MOCK_METHOD(void, render_text, (const context& ctxt, const string&& str), (override));
   MOCK_METHOD(void, change_alignment, (const context& ctxt), (override));
-  MOCK_METHOD(void, action_open, (const context& ctxt, action_t id), (override));
-  MOCK_METHOD(void, action_close, (const context& ctxt, action_t id), (override));
+  MOCK_METHOD(double, get_x, (const context& ctxt), (const, override));
+  MOCK_METHOD(double, get_alignment_start, (const alignment align), (const, override));
 };
 
 class TestableDispatch : public dispatch {};

--- a/tests/unit_tests/tags/dispatch.cpp
+++ b/tests/unit_tests/tags/dispatch.cpp
@@ -18,7 +18,7 @@ class MockRenderer : public renderer_interface {
   MOCK_METHOD(void, render_offset, (const context& ctxt, int pixels), (override));
   MOCK_METHOD(void, render_text, (const context& ctxt, const string&& str), (override));
   MOCK_METHOD(void, change_alignment, (const context& ctxt), (override));
-  MOCK_METHOD(void, action_open, (const context& ctxt, mousebtn btn, action_t id), (override));
+  MOCK_METHOD(void, action_open, (const context& ctxt, action_t id), (override));
   MOCK_METHOD(void, action_close, (const context& ctxt, action_t id), (override));
 };
 

--- a/tests/unit_tests/tags/dispatch.cpp
+++ b/tests/unit_tests/tags/dispatch.cpp
@@ -24,15 +24,15 @@ class MockRenderer : public renderer_interface {
 
 class TestableDispatch : public dispatch {};
 
-class Dispatch : public ::testing::Test {
+class DispatchTest : public ::testing::Test {
  protected:
-  unique_ptr<action_context> action_ctxt = make_unique<action_context>();
+  unique_ptr<action_context> m_action_ctxt = make_unique<action_context>();
 
-  unique_ptr<dispatch> parser = make_unique<dispatch>(logger(loglevel::NONE), *action_ctxt);
+  unique_ptr<dispatch> m_dispatch = make_unique<dispatch>(logger(loglevel::NONE), *m_action_ctxt);
 };
 
-TEST_F(Dispatch, ignoreFormatting) {
-  MockRenderer r(*action_ctxt);
+TEST_F(DispatchTest, ignoreFormatting) {
+  MockRenderer r(*m_action_ctxt);
 
   {
     InSequence seq;
@@ -43,5 +43,5 @@ TEST_F(Dispatch, ignoreFormatting) {
 
   bar_settings settings;
 
-  parser->parse(settings, r, "%{O10}abc%{F-}foo");
+  m_dispatch->parse(settings, r, "%{O10}abc%{F-}foo");
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other:

## Description

This is a first proof of concept for #2344

Right now only the current colors, font and attribute activations are stored.
But the plan is to also keep track of all action areas and alignment so that the
renderer is completely independent from the actual formatting tags.

## Related Issues & Documents

Closes #2344

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes

Maybe we want to write a page about the architecture.