### PR TITLE
feat: Rounded bar border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `internal/cpu`: `format-warn`, `label-warn`, `warn-percentage = 80`
   - `internal/fs`: `format-warn`, `label-warn`, `warn-percentage = 90`
   - `internal/memory`: `format-warn`, `label-warn`, `warn-percentage = 90`
+- `radius` now affects the bar border as well
+  ([`#1566`](https://github.com/polybar/polybar/issues/1566))  
 - Per-corner corner radius with `radius-{bottom,top}-{left,right}`
   ([`#2294`](https://github.com/polybar/polybar/issues/2294))
 - `internal/network`: `speed-unit = B/s` can be used to customize how network

--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -127,8 +127,6 @@ namespace cairo {
     }
 
     context& operator<<(const circle_segment& segment) {
-      // cairo_arc(m_c, arc.x, arc.y, arc.radius, 0, 2 * M_PI);
-
       double degree = M_PI / 180.0;
 
       cairo_new_sub_path(m_c);

--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -278,15 +278,6 @@ namespace cairo {
       return *this;
     }
 
-    context& stroke(bool preserve = false) {
-      if (preserve) {
-        cairo_stroke_preserve(m_c);
-      } else {
-        cairo_stroke(m_c);
-      }
-      return *this;
-    }
-
     context& mask(cairo_pattern_t* pattern) {
       cairo_mask(m_c, pattern);
       return *this;

--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -126,6 +126,24 @@ namespace cairo {
       return *this;
     }
 
+    context& operator<<(const circle_segment& segment) {
+      // cairo_arc(m_c, arc.x, arc.y, arc.radius, 0, 2 * M_PI);
+
+      double degree = M_PI / 180.0;
+
+      cairo_new_sub_path(m_c);
+
+      cairo_arc(m_c, segment.x, segment.y, segment.radius, segment.angle_from * degree, segment.angle_to * degree);
+      cairo_line_to(m_c, segment.x, segment.y);
+
+      cairo_arc(m_c, segment.x, segment.y, segment.radius, segment.angle_from * degree, segment.angle_to * degree);
+      cairo_line_to(m_c, segment.x, segment.y);
+
+      cairo_close_path(m_c);
+
+      return *this;
+    }
+
     context& operator<<(const textblock& t) {
       double x, y;
       position(&x, &y);
@@ -258,6 +276,15 @@ namespace cairo {
         cairo_fill_preserve(m_c);
       } else {
         cairo_fill(m_c);
+      }
+      return *this;
+    }
+
+    context& stroke(bool preserve = false) {
+      if (preserve) {
+        cairo_stroke_preserve(m_c);
+      } else {
+        cairo_stroke(m_c);
       }
       return *this;
     }

--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -116,26 +116,20 @@ namespace cairo {
     }
 
     context& operator<<(const rounded_corners& c) {
-      double d = M_PI / 180.0;
       cairo_new_sub_path(m_c);
-      cairo_arc(m_c, c.x + c.w - c.radius.top_right, c.y + c.radius.top_right, c.radius.top_right, -90 * d, 0 * d);
-      cairo_arc(m_c, c.x + c.w - c.radius.bottom_right, c.y + c.h - c.radius.bottom_right, c.radius.bottom_right, 0 * d, 90 * d);
-      cairo_arc(m_c, c.x + c.radius.bottom_left, c.y + c.h - c.radius.bottom_left, c.radius.bottom_left, 90 * d, 180 * d);
-      cairo_arc(m_c, c.x + c.radius.top_left, c.y + c.radius.top_left, c.radius.top_left, 180 * d, 270 * d);
+      cairo_arc(m_c, c.x + c.w - c.radius.top_right, c.y + c.radius.top_right, c.radius.top_right, -90 * degree, 0 * degree);
+      cairo_arc(m_c, c.x + c.w - c.radius.bottom_right, c.y + c.h - c.radius.bottom_right, c.radius.bottom_right, 0 * degree, 90 * degree);
+      cairo_arc(m_c, c.x + c.radius.bottom_left, c.y + c.h - c.radius.bottom_left, c.radius.bottom_left, 90 * degree, 180 * degree);
+      cairo_arc(m_c, c.x + c.radius.top_left, c.y + c.radius.top_left, c.radius.top_left, 180 * degree, 270 * degree);
       cairo_close_path(m_c);
       return *this;
     }
 
     context& operator<<(const circle_segment& segment) {
-      double degree = M_PI / 180.0;
-
       cairo_new_sub_path(m_c);
-
       cairo_arc(m_c, segment.x, segment.y, segment.radius, segment.angle_from * degree, segment.angle_to * degree);
       cairo_line_to(m_c, segment.x, segment.y);
-
       cairo_close_path(m_c);
-
       return *this;
     }
 
@@ -351,6 +345,9 @@ namespace cairo {
     vector<shared_ptr<font>> m_fonts;
     std::deque<pair<double, double>> m_points;
     int m_activegroups{0};
+
+    private:
+      const double degree = M_PI / 180.0;
   };
 }  // namespace cairo
 

--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -134,9 +134,6 @@ namespace cairo {
       cairo_arc(m_c, segment.x, segment.y, segment.radius, segment.angle_from * degree, segment.angle_to * degree);
       cairo_line_to(m_c, segment.x, segment.y);
 
-      cairo_arc(m_c, segment.x, segment.y, segment.radius, segment.angle_from * degree, segment.angle_to * degree);
-      cairo_line_to(m_c, segment.x, segment.y);
-
       cairo_close_path(m_c);
 
       return *this;

--- a/include/cairo/types.hpp
+++ b/include/cairo/types.hpp
@@ -54,6 +54,13 @@ namespace cairo {
     double h;
     struct radius radius;
   };
+  struct circle_segment {
+    double x;
+    double y;
+    double angle_from;
+    double angle_to;
+    double radius;
+  };
   struct textblock {
     alignment align;
     string contents;

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -644,7 +644,7 @@ void renderer::fill_borders() {
     cairo::circle_segment borderBL;
     borderBL.radius = m_bar.borders.at(edge::LEFT).size + m_bar.radius.bottom_left;
     borderBL.x = m_bar.borders.at(edge::LEFT).size + m_bar.radius.bottom_left;
-    borderBL.y = m_bar.size.h - (m_bar.borders.at(edge::LEFT).size + m_bar.radius.bottom_left);
+    borderBL.y = m_bar.size.h - (m_bar.borders.at(edge::BOTTOM).size + m_bar.radius.bottom_left);
     borderBL.angle_from = 90;
     borderBL.angle_to = 180;
     (*m_context << borderBL << m_bar.borders.at(edge::LEFT).color).fill();
@@ -654,7 +654,7 @@ void renderer::fill_borders() {
     cairo::circle_segment borderTR;
     borderTR.radius = m_bar.borders.at(edge::RIGHT).size + m_bar.radius.top_right;
     borderTR.x = m_bar.size.w - (m_bar.borders.at(edge::RIGHT).size + m_bar.radius.top_right);
-    borderTR.y = m_bar.borders.at(edge::RIGHT).size + m_bar.radius.top_right;
+    borderTR.y = m_bar.borders.at(edge::TOP).size + m_bar.radius.top_right;
     borderTR.angle_from = -90;
     borderTR.angle_to = 0;
     (*m_context << borderTR << m_bar.borders.at(edge::RIGHT).color).fill();
@@ -664,7 +664,7 @@ void renderer::fill_borders() {
     cairo::circle_segment borderBR;
     borderBR.radius = m_bar.borders.at(edge::RIGHT).size + m_bar.radius.bottom_right;
     borderBR.x = m_bar.size.w - (m_bar.borders.at(edge::RIGHT).size + m_bar.radius.bottom_right);
-    borderBR.y = m_bar.size.h - (m_bar.borders.at(edge::RIGHT).size + m_bar.radius.bottom_right);
+    borderBR.y = m_bar.size.h - (m_bar.borders.at(edge::BOTTOM).size + m_bar.radius.bottom_right);
     borderBR.angle_from = 0;
     borderBR.angle_to = 90;
     (*m_context << borderBR << m_bar.borders.at(edge::RIGHT).color).fill();

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -628,40 +628,50 @@ void renderer::fill_borders() {
   m_context->save();
   *m_context << m_comp_border;
 
-  if (m_bar.borders.at(edge::TOP).size) {
-    cairo::rect top{0.0, 0.0, 0.0, 0.0};
-    top.x += m_bar.borders.at(edge::LEFT).size;
-    top.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
-    top.h += m_bar.borders.at(edge::TOP).size;
-    m_log.trace_x("renderer: border T(%.0f, #%08x)", top.h, m_bar.borders.at(edge::TOP).color);
-    (*m_context << top << m_bar.borders.at(edge::TOP).color).fill();
-  }
+  if (m_bar.radius && m_bar.borders.at(edge::TOP).size) {
+    cairo::rounded_corners border;
+    border.x = 0;
+    border.y = 0;
+    border.w = m_bar.size.w;
+    border.h = m_bar.size.h;
+    border.radius = m_bar.radius;
+    (*m_context << border << m_bar.borders.at(edge::TOP).color).fill();
+  } else {
+    if (m_bar.borders.at(edge::TOP).size) {
+      cairo::rect top{0.0, 0.0, 0.0, 0.0};
+      top.x += m_bar.borders.at(edge::LEFT).size;
+      top.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
+      top.h += m_bar.borders.at(edge::TOP).size;
+      m_log.trace_x("renderer: border T(%.0f, #%08x)", top.h, m_bar.borders.at(edge::TOP).color);
+      (*m_context << top << m_bar.borders.at(edge::TOP).color).fill();
+    }
 
-  if (m_bar.borders.at(edge::BOTTOM).size) {
-    cairo::rect bottom{0.0, 0.0, 0.0, 0.0};
-    bottom.x += m_bar.borders.at(edge::LEFT).size;
-    bottom.y += m_bar.size.h - m_bar.borders.at(edge::BOTTOM).size;
-    bottom.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
-    bottom.h += m_bar.borders.at(edge::BOTTOM).size;
-    m_log.trace_x("renderer: border B(%.0f, #%08x)", bottom.h, m_bar.borders.at(edge::BOTTOM).color);
-    (*m_context << bottom << m_bar.borders.at(edge::BOTTOM).color).fill();
-  }
+    if (m_bar.borders.at(edge::BOTTOM).size) {
+      cairo::rect bottom{0.0, 0.0, 0.0, 0.0};
+      bottom.x += m_bar.borders.at(edge::LEFT).size;
+      bottom.y += m_bar.size.h - m_bar.borders.at(edge::BOTTOM).size;
+      bottom.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
+      bottom.h += m_bar.borders.at(edge::BOTTOM).size;
+      m_log.trace_x("renderer: border B(%.0f, #%08x)", bottom.h, m_bar.borders.at(edge::BOTTOM).color);
+      (*m_context << bottom << m_bar.borders.at(edge::BOTTOM).color).fill();
+    }
 
-  if (m_bar.borders.at(edge::LEFT).size) {
-    cairo::rect left{0.0, 0.0, 0.0, 0.0};
-    left.w += m_bar.borders.at(edge::LEFT).size;
-    left.h += m_bar.size.h;
-    m_log.trace_x("renderer: border L(%.0f, #%08x)", left.w, m_bar.borders.at(edge::LEFT).color);
-    (*m_context << left << m_bar.borders.at(edge::LEFT).color).fill();
-  }
+    if (m_bar.borders.at(edge::LEFT).size) {
+      cairo::rect left{0.0, 0.0, 0.0, 0.0};
+      left.w += m_bar.borders.at(edge::LEFT).size;
+      left.h += m_bar.size.h;
+      m_log.trace_x("renderer: border L(%.0f, #%08x)", left.w, m_bar.borders.at(edge::LEFT).color);
+      (*m_context << left << m_bar.borders.at(edge::LEFT).color).fill();
+    }
 
-  if (m_bar.borders.at(edge::RIGHT).size) {
-    cairo::rect right{0.0, 0.0, 0.0, 0.0};
-    right.x += m_bar.size.w - m_bar.borders.at(edge::RIGHT).size;
-    right.w += m_bar.borders.at(edge::RIGHT).size;
-    right.h += m_bar.size.h;
-    m_log.trace_x("renderer: border R(%.0f, #%08x)", right.w, m_bar.borders.at(edge::RIGHT).color);
-    (*m_context << right << m_bar.borders.at(edge::RIGHT).color).fill();
+    if (m_bar.borders.at(edge::RIGHT).size) {
+      cairo::rect right{0.0, 0.0, 0.0, 0.0};
+      right.x += m_bar.size.w - m_bar.borders.at(edge::RIGHT).size;
+      right.w += m_bar.borders.at(edge::RIGHT).size;
+      right.h += m_bar.size.h;
+      m_log.trace_x("renderer: border R(%.0f, #%08x)", right.w, m_bar.borders.at(edge::RIGHT).color);
+      (*m_context << right << m_bar.borders.at(edge::RIGHT).color).fill();
+    }
   }
 
   m_context->restore();

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -628,50 +628,124 @@ void renderer::fill_borders() {
   m_context->save();
   *m_context << m_comp_border;
 
-  if (m_bar.radius && m_bar.borders.at(edge::TOP).size) {
-    cairo::rounded_corners border;
-    border.x = 0;
-    border.y = 0;
-    border.w = m_bar.size.w;
-    border.h = m_bar.size.h;
-    border.radius = m_bar.radius;
-    (*m_context << border << m_bar.borders.at(edge::TOP).color).fill();
-  } else {
-    if (m_bar.borders.at(edge::TOP).size) {
-      cairo::rect top{0.0, 0.0, 0.0, 0.0};
-      top.x += m_bar.borders.at(edge::LEFT).size;
-      top.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
-      top.h += m_bar.borders.at(edge::TOP).size;
-      m_log.trace_x("renderer: border T(%.0f, #%08x)", top.h, m_bar.borders.at(edge::TOP).color);
-      (*m_context << top << m_bar.borders.at(edge::TOP).color).fill();
+  // Draw round border corners
+
+  if (m_bar.radius.top_left) {
+    cairo::circle_segment borderTL;
+    borderTL.radius = m_bar.borders.at(edge::LEFT).size + m_bar.radius.top_left;
+    borderTL.x = m_bar.borders.at(edge::LEFT).size + m_bar.radius.top_left;
+    borderTL.y = m_bar.borders.at(edge::TOP).size + m_bar.radius.top_left;
+    borderTL.angle_from = 180;
+    borderTL.angle_to = 270;
+    (*m_context << borderTL << m_bar.borders.at(edge::LEFT).color).fill();
+  }
+
+  if (m_bar.radius.bottom_left) {
+    cairo::circle_segment borderBL;
+    borderBL.radius = m_bar.borders.at(edge::LEFT).size + m_bar.radius.bottom_left;
+    borderBL.x = m_bar.borders.at(edge::LEFT).size + m_bar.radius.bottom_left;
+    borderBL.y = m_bar.size.h - (m_bar.borders.at(edge::LEFT).size + m_bar.radius.bottom_left);
+    borderBL.angle_from = 90;
+    borderBL.angle_to = 180;
+    (*m_context << borderBL << m_bar.borders.at(edge::LEFT).color).fill();
+  }
+
+  if (m_bar.radius.top_right) {
+    cairo::circle_segment borderTR;
+    borderTR.radius = m_bar.borders.at(edge::RIGHT).size + m_bar.radius.top_right;
+    borderTR.x = m_bar.size.w - (m_bar.borders.at(edge::RIGHT).size + m_bar.radius.top_right);
+    borderTR.y = m_bar.borders.at(edge::RIGHT).size + m_bar.radius.top_right;
+    borderTR.angle_from = -90;
+    borderTR.angle_to = 0;
+    (*m_context << borderTR << m_bar.borders.at(edge::RIGHT).color).fill();
+  }
+
+  if (m_bar.radius.bottom_right) {
+    cairo::circle_segment borderBR;
+    borderBR.radius = m_bar.borders.at(edge::RIGHT).size + m_bar.radius.bottom_right;
+    borderBR.x = m_bar.size.w - (m_bar.borders.at(edge::RIGHT).size + m_bar.radius.bottom_right);
+    borderBR.y = m_bar.size.h - (m_bar.borders.at(edge::RIGHT).size + m_bar.radius.bottom_right);
+    borderBR.angle_from = 0;
+    borderBR.angle_to = 90;
+    (*m_context << borderBR << m_bar.borders.at(edge::RIGHT).color).fill();
+  }
+
+  // Draw straight horizontal / vertical borders
+
+  if (m_bar.borders.at(edge::TOP).size) {
+    cairo::rect top{0.0, 0.0, 0.0, 0.0};
+    top.x += m_bar.borders.at(edge::LEFT).size;
+    top.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
+    top.h += m_bar.borders.at(edge::TOP).size;
+
+    if (m_bar.radius.top_left) {
+      top.x += m_bar.radius.top_left;
+      top.w -= m_bar.radius.top_left;
     }
 
-    if (m_bar.borders.at(edge::BOTTOM).size) {
-      cairo::rect bottom{0.0, 0.0, 0.0, 0.0};
-      bottom.x += m_bar.borders.at(edge::LEFT).size;
-      bottom.y += m_bar.size.h - m_bar.borders.at(edge::BOTTOM).size;
-      bottom.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
-      bottom.h += m_bar.borders.at(edge::BOTTOM).size;
-      m_log.trace_x("renderer: border B(%.0f, #%08x)", bottom.h, m_bar.borders.at(edge::BOTTOM).color);
-      (*m_context << bottom << m_bar.borders.at(edge::BOTTOM).color).fill();
+    if (m_bar.radius.top_right) {
+      top.w -= m_bar.radius.top_right;
     }
 
-    if (m_bar.borders.at(edge::LEFT).size) {
-      cairo::rect left{0.0, 0.0, 0.0, 0.0};
-      left.w += m_bar.borders.at(edge::LEFT).size;
-      left.h += m_bar.size.h;
-      m_log.trace_x("renderer: border L(%.0f, #%08x)", left.w, m_bar.borders.at(edge::LEFT).color);
-      (*m_context << left << m_bar.borders.at(edge::LEFT).color).fill();
+    m_log.trace_x("renderer: border T(%.0f, #%08x)", top.h, m_bar.borders.at(edge::TOP).color);
+    (*m_context << top << m_bar.borders.at(edge::TOP).color).fill();
+  }
+
+  if (m_bar.borders.at(edge::BOTTOM).size) {
+    cairo::rect bottom{0.0, 0.0, 0.0, 0.0};
+    bottom.x += m_bar.borders.at(edge::LEFT).size;
+    bottom.y += m_bar.size.h - m_bar.borders.at(edge::BOTTOM).size;
+    bottom.w += m_bar.size.w - m_bar.borders.at(edge::LEFT).size - m_bar.borders.at(edge::RIGHT).size;
+    bottom.h += m_bar.borders.at(edge::BOTTOM).size;
+
+    if (m_bar.radius.bottom_left) {
+      bottom.x += m_bar.radius.bottom_left;
+      bottom.w -= m_bar.radius.bottom_left;
     }
 
-    if (m_bar.borders.at(edge::RIGHT).size) {
-      cairo::rect right{0.0, 0.0, 0.0, 0.0};
-      right.x += m_bar.size.w - m_bar.borders.at(edge::RIGHT).size;
-      right.w += m_bar.borders.at(edge::RIGHT).size;
-      right.h += m_bar.size.h;
-      m_log.trace_x("renderer: border R(%.0f, #%08x)", right.w, m_bar.borders.at(edge::RIGHT).color);
-      (*m_context << right << m_bar.borders.at(edge::RIGHT).color).fill();
+    if (m_bar.radius.bottom_right) {
+      bottom.w -= m_bar.radius.bottom_right;
     }
+
+    m_log.trace_x("renderer: border B(%.0f, #%08x)", bottom.h, m_bar.borders.at(edge::BOTTOM).color);
+    (*m_context << bottom << m_bar.borders.at(edge::BOTTOM).color).fill();
+  }
+
+  if (m_bar.borders.at(edge::LEFT).size) {
+    cairo::rect left{0.0, 0.0, 0.0, 0.0};
+    left.w += m_bar.borders.at(edge::LEFT).size;
+    left.h += m_bar.size.h;
+
+    if (m_bar.radius.top_left) {
+      left.y += m_bar.radius.top_left + m_bar.borders.at(edge::TOP).size;
+      left.h -= m_bar.radius.top_left + m_bar.borders.at(edge::TOP).size;
+    }
+
+    if (m_bar.radius.bottom_left) {
+      left.h -= m_bar.radius.bottom_left + m_bar.borders.at(edge::BOTTOM).size;
+    }
+
+    m_log.trace_x("renderer: border L(%.0f, #%08x)", left.w, m_bar.borders.at(edge::LEFT).color);
+    (*m_context << left << m_bar.borders.at(edge::LEFT).color).fill();
+  }
+
+  if (m_bar.borders.at(edge::RIGHT).size) {
+    cairo::rect right{0.0, 0.0, 0.0, 0.0};
+    right.x += m_bar.size.w - m_bar.borders.at(edge::RIGHT).size;
+    right.w += m_bar.borders.at(edge::RIGHT).size;
+    right.h += m_bar.size.h;
+
+    if (m_bar.radius.top_right) {
+      right.y += m_bar.radius.top_right + m_bar.borders.at(edge::TOP).size;
+      right.h -= m_bar.radius.top_right + m_bar.borders.at(edge::TOP).size;
+    }
+
+    if (m_bar.radius.bottom_right) {
+      right.h -= m_bar.radius.bottom_right + m_bar.borders.at(edge::BOTTOM).size;
+    }
+
+    m_log.trace_x("renderer: border R(%.0f, #%08x)", right.w, m_bar.borders.at(edge::RIGHT).color);
+    (*m_context << right << m_bar.borders.at(edge::RIGHT).color).fill();
   }
 
   m_context->restore();


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This PR exists to change the behaviour when applying a `radius` together with `border-size` with a minimal amount of code changes. Polybar is now able to display a round border (also supporting the functionality added in https://github.com/polybar/polybar/pull/2297) :tada: 

In order to avoid bigger changes, I've implemented it so that the rounded border gets its size and color from the top border configuration (`border-size` / `border-top-size` and `border-color` / `border-top-color` respectively). 
While I am not sure how to implement the configuration in a more user-friendly way without changing the current configuration options, I would be glad to add any changes you suggest.

## Related Issues & Documents
While the idea to implement this came up whilst styling my system, this issue is a good representation: https://github.com/polybar/polybar/issues/1566

Several quick screenshots as visual demonstration (with and without compositor) can be found [here](https://short.sgruber.at/scr_git_polybar_roundedborder)

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

It would be necessary to remove the incompatibility notice regarding the `radius` and `border-size` configuration options.
