### PR TITLE
Add initial support for an escape character #2354

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Breaking
+- We added the backslash escape character (\\) for configuration values. This
+  means that the literal backslash character now has special meaning in
+  configuration files, therefore if you want to use it in a value as a literal
+  backslash, you need to escape it with the backslash escape character. The
+  parser logs an error if any unescaped backslashes are found in a value. This
+  affects you only if you are using two consecutive backslashes in a value,
+  which will now be interpreted as a single literal backslash.
+  [`#2354`](https://github.com/polybar/polybar/issues/2354)
 - We rewrote our tag parser. This shouldn't break anything, if you experience
   any problems, please let us know.
   The new parser now gives errors for certain invalid tags where the old parser
@@ -42,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository.
 
 ### Added
+- The backslash escape character (\\).
+  [`#2354`](https://github.com/polybar/polybar/issues/2354)
 - Warn states for the cpu, memory, fs, and battery modules.
   ([`#570`](https://github.com/polybar/polybar/issues/570),
   [`#956`](https://github.com/polybar/polybar/issues/956),

--- a/doc/man/polybar.5.rst
+++ b/doc/man/polybar.5.rst
@@ -128,7 +128,22 @@ in double-quotes:
 
   name = " value "
 
-Here ``name`` has a leading and trailing whitespace.
+Here the value of the ``name`` key has a leading and trailing whitespace.
+
+To treat characters with special meaning as literal characters, you need to
+prepend them with the backslash (``\``) escape character:
+
+::
+
+  name = "value\\value\\value"
+
+Value of this key ``name`` results in ``value\value\value``.
+
+.. note::
+
+  The only character with a special meaning right now is the backslash character
+  (``\``), which serves as the escape character.
+  More will be added in the future.
 
 Empty Lines & Comments
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -191,6 +191,12 @@ class config_parser {
   std::pair<string, string> parse_key(const string& line);
 
   /**
+   * \brief Parses the given value, checks if the given value contains
+   *        one or more unescaped backslashes and logs an error if yes
+   */
+  string parse_escaped_value(string&& value, const string& key);
+
+  /**
    * \brief Name of all the files the config includes values from
    *
    * The line_t struct uses indices to this vector to map lines to their


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] Feature
* [x] Documentation Update
* [ ] Refactor
* [ ] Bug Fix
* [ ] Optimization
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

* Introduce an escape character '\\'.
* Warn users about unescaped characters (only backslashes for now).
* For now, treat a single unescaped backslash as a literal backslash character.
* Treat two consecutive backslashes as a single literal backslash character.

## Related Issues & Documents
Implements first step of #2354

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
See #2354  
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
