### PR TITLE
fix(config_parser): UB in logger

### DIFF
--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -88,6 +88,11 @@ struct line_t {
 class config_parser {
  public:
   config_parser(const logger& logger, string&& file, string&& bar);
+  /**
+   * This prevents passing a temporary logger to the constructor because that would be UB, as the temporary would be
+   * destroyed once the constructor returns.
+   */
+  config_parser(logger&& logger, string&& file, string&& bar) = delete;
 
   /**
    * \brief Performs the parsing of the main config file m_file

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -33,8 +33,8 @@ class TestableConfigParser : public config_parser {
  */
 class ConfigParser : public ::testing::Test {
  protected:
-  unique_ptr<TestableConfigParser> parser =
-      make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero", "TEST");
+  const logger l = logger(loglevel::NONE);
+  unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(l, "/dev/zero", "TEST");
 };
 
 // ParseLineTest {{{


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Because we passed a temporary as the logger, it gets destroyed after the
config_parser constructor returns and when the logger is called in
config_parser it operates on a dangling reference.

## Related Issues & Documents

Ref: https://stackoverflow.com/q/35770357/5363071

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
