### PR TITLE
add reverse-scroll option for xworkspaces module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository.
 
 ### Added
+- `internal/xworkspaces`: `reverse-scroll` can be used to reverse the scroll
+  direction when cycling through desktops.
 - The backslash escape character (\\).
   [`#2354`](https://github.com/polybar/polybar/issues/2354)
 - Warn states for the cpu, memory, fs, and battery modules.

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -112,6 +112,7 @@ namespace modules {
     bool m_pinworkspaces{false};
     bool m_click{true};
     bool m_scroll{true};
+    bool m_revscroll{false};
     size_t m_index{0};
 
     // The following mutex is here to protect the data of this modules.

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -43,6 +43,7 @@ namespace modules {
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
     m_click = m_conf.get(name(), "enable-click", m_click);
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
+    m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
 
     // Initialize ewmh atoms
     if ((m_ewmh = ewmh_util::initialize()) == nullptr) {
@@ -376,11 +377,11 @@ namespace modules {
   }
 
   void xworkspaces_module::action_next() {
-    focus_direction(true);
+    focus_direction(m_revscroll ? false : true);
   }
 
   void xworkspaces_module::action_prev() {
-    focus_direction(false);
+    focus_direction(m_revscroll ? true : false);
   }
 
   void xworkspaces_module::focus_direction(bool next) {

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -330,8 +330,8 @@ namespace modules {
     }
 
     if (m_scroll) {
-      m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_PREV, "");
-      m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_NEXT, "");
+      m_builder->action(mousebtn::SCROLL_DOWN, *this, m_revscroll ? EVENT_NEXT : EVENT_PREV, "");
+      m_builder->action(mousebtn::SCROLL_UP, *this, m_revscroll ? EVENT_PREV : EVENT_NEXT, "");
     }
 
     m_builder->append(output);
@@ -377,11 +377,11 @@ namespace modules {
   }
 
   void xworkspaces_module::action_next() {
-    focus_direction(m_revscroll ? false : true);
+    focus_direction(true);
   }
 
   void xworkspaces_module::action_prev() {
-    focus_direction(m_revscroll ? true : false);
+    focus_direction(false);
   }
 
   void xworkspaces_module::focus_direction(bool next) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Added reverse-scroll option for xworkspaces module. The default is to set it to false, that way users do not have to change their configuration files if they want old behavior.

## Related Issues & Documents
None

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The new setting should be documented in the xworkspaces section, probably under basic settings.
