### PR TITLE
feat(conf) always show urgent workspaces in i3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository.
 
 ### Added
+- Option to always show urgent windows in i3 module when `pin-workspace` is active
+  ([`2374`](https://github.com/polybar/polybar/issues/2374))
 - `internal/xworkspaces`: `reverse-scroll` can be used to reverse the scroll
   direction when cycling through desktops.
 - The backslash escape character (\\).

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -93,6 +93,7 @@ namespace modules {
     bool m_wrap{true};
     bool m_indexsort{false};
     bool m_pinworkspaces{false};
+    bool m_show_urgent{false};
     bool m_strip_wsnumbers{false};
     bool m_fuzzy_match{false};
 

--- a/include/utils/i3.hpp
+++ b/include/utils/i3.hpp
@@ -15,7 +15,7 @@ namespace i3_util {
 
   const auto ws_numsort = [](shared_ptr<workspace_t> a, shared_ptr<workspace_t> b) { return a->num < b->num; };
 
-  vector<shared_ptr<workspace_t>> workspaces(const connection_t& conn, const string& output = "");
+  vector<shared_ptr<workspace_t>> workspaces(const connection_t& conn, const string& output = "", const bool show_urgent = false);
   shared_ptr<workspace_t> focused_workspace(const connection_t&);
 
   vector<xcb_window_t> root_windows(connection& conn, const string& output_name = "");

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -33,6 +33,7 @@ namespace modules {
     m_wrap = m_conf.get(name(), "wrapping-scroll", m_wrap);
     m_indexsort = m_conf.get(name(), "index-sort", m_indexsort);
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
+    m_show_urgent = m_conf.get(name(), "show-urgent", m_show_urgent);
     m_strip_wsnumbers = m_conf.get(name(), "strip-wsnumbers", m_strip_wsnumbers);
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
 
@@ -132,7 +133,7 @@ namespace modules {
       vector<shared_ptr<i3_util::workspace_t>> workspaces;
 
       if (m_pinworkspaces) {
-        workspaces = i3_util::workspaces(ipc, m_bar.monitor->name);
+        workspaces = i3_util::workspaces(ipc, m_bar.monitor->name, m_show_urgent);
       } else {
         workspaces = i3_util::workspaces(ipc);
       }

--- a/src/utils/i3.cpp
+++ b/src/utils/i3.cpp
@@ -16,10 +16,10 @@ namespace i3_util {
   /**
    * Get all workspaces for given output
    */
-  vector<shared_ptr<workspace_t>> workspaces(const connection_t& conn, const string& output) {
+  vector<shared_ptr<workspace_t>> workspaces(const connection_t& conn, const string& output, const bool show_urgent) {
     vector<shared_ptr<workspace_t>> result;
     for (auto&& ws : conn.get_workspaces()) {
-      if (output.empty() || ws->output == output) {
+      if (output.empty() || ws->output == output || (show_urgent && ws->urgent)) {
         result.emplace_back(forward<decltype(ws)>(ws));
       }
     }


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Given `pin-workspaces = true`, setting `show-urgent = true` will show urgent workspaces on the current bar even when the workspace is not associated with the current monitor. If `pin-workspaces = false`, this option has no effect.

## Related Issues & Documents

Closes #2374 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

```patch
--- wiki.old	2021-02-14 05:34:34.898430279 +0100
+++ wiki.new	2021-02-14 05:37:25.829103300 +0100
@@ -34,6 +34,16 @@
 ; Default: false
 pin-workspaces = true
 
+; Show workspaces having the urgent hint set in the bar
+; regardless of the workspace being on the current output
+; or not.
+;
+; This option only makes sense in when pin-workspaces is
+; enabled.
+;
+; Default: false
+show-urgent = true
+
 ; This will split the workspace name on ':'
 ; Default: false
 strip-wsnumbers = true
```
