### PR TITLE
internal/backlight - add use-actual-brightness option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#2292`](https://github.com/polybar/polybar/issues/2292))
 - Parser error if click command contained `}`
   ([`#2040`](https://github.com/polybar/polybar/issues/2040))
+- With amdgpu backlights, the brightness indicator was slightly behind.
+  ([`#2367](https://github.com/polybar/polybar/issues/2367))
 
 ## [3.5.4] - 2021-01-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#2292`](https://github.com/polybar/polybar/issues/2292))
 - Parser error if click command contained `}`
   ([`#2040`](https://github.com/polybar/polybar/issues/2040))
-- With amdgpu backlights, the brightness indicator was slightly behind.
+- `internal/backlight`: With amdgpu backlights, the brightness indicator was slightly behind.
   ([`#2367](https://github.com/polybar/polybar/issues/2367))
 
 ## [3.5.4] - 2021-01-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/xworkspaces`: `%nwin%` can be used to display the number of open
   windows per workspace
   ([`#604`](https://github.com/polybar/polybar/issues/604))
+- `internal/backlight`: added `use-actual-brightness` option
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -48,6 +48,7 @@ namespace modules {
     string m_path_backlight;
     float m_max_brightness;
     bool m_scroll{false};
+    bool m_use_actual_brightness{true};
 
     brightness_handle m_val;
     brightness_handle m_max;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -54,7 +54,10 @@ namespace modules {
      * The only sensible way is to use the 'brightness' file instead
      * Ref: https://github.com/Alexays/Waybar/issues/335
      */
-    std::string brightness_type = ((card.substr(0, 9) == "amdgpu_bl") ? "brightness" : "actual_brightness");
+    bool card_is_amdgpu = (card.substr(0, 9) == "amdgpu_bl");
+    m_use_actual_brightness = m_conf.get(name(), "use-actual-brightness", !card_is_amdgpu);
+
+    std::string brightness_type = (m_use_actual_brightness ? "actual_brightness" : "brightness");
     auto path_backlight_val = m_path_backlight + "/" + brightness_type;
 
     m_val.filepath(path_backlight_val);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Adds a `use-actual-brightness` option to `internal/backlight`, which specifies whether to use the `actual_brightness` file in `/sys/class/backlight/%card%/` or the `brightness` file. Defaults to true **unless** the card is an amdgpu card.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Fixes/closes #2367

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

https://github.com/polybar/polybar/wiki/Module:-backlight - needs the `use-actual-brightness` option documented.