### PR TITLE
Add click-middle and click-right to alsa module

### DIFF
--- a/src/modules/alsa.cpp
+++ b/src/modules/alsa.cpp
@@ -196,6 +196,17 @@ namespace modules {
     string output{module::get_output()};
 
     if (m_handle_events) {
+      auto click_middle = m_conf.get(name(), "click-middle", ""s);
+      auto click_right = m_conf.get(name(), "click-right", ""s);
+
+      if (!click_middle.empty()) {
+        m_builder->action(mousebtn::MIDDLE, click_middle);
+      }
+
+      if (!click_right.empty()) {
+        m_builder->action(mousebtn::RIGHT, click_right);
+      }
+
       m_builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "");
       m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_INC, "");
       m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_DEC, "");


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Just like the `pulseaudio` module, now the `alsa` module can use `click-middle` and `click-right` as well. 
## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
(This feature is a minor change. Therefore, per [CONTRIBUTING.md](https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md), there is no need to address issues.)
## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes