### PR TITLE
feat(xworkspaces) Allow to show the nwin less

### DIFF
--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -113,6 +113,7 @@ namespace modules {
     bool m_click{true};
     bool m_scroll{true};
     bool m_revscroll{false};
+    unsigned int m_nwin_threshold{0};
     size_t m_index{0};
 
     // The following mutex is here to protect the data of this modules.

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -44,6 +44,7 @@ namespace modules {
     m_click = m_conf.get(name(), "enable-click", m_click);
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
+    m_nwin_threshold = m_conf.get(name(), "window-number-threshold", m_nwin_threshold);
 
     // Initialize ewmh atoms
     if ((m_ewmh = ewmh_util::initialize()) == nullptr) {
@@ -266,6 +267,8 @@ namespace modules {
    */
   void xworkspaces_module::rebuild_desktop_states() {
     std::set<unsigned int> occupied_desks;
+    string nwin;
+
     for (auto&& c : m_clients) {
       occupied_desks.insert(c.second);
     }
@@ -282,11 +285,13 @@ namespace modules {
           d->state = desktop_state::EMPTY;
         }
 
+        nwin = (m_windows[d->index] > m_nwin_threshold) ? to_string(m_windows[d->index]) : "";
+
         d->label = m_labels.at(d->state)->clone();
         d->label->reset_tokens();
         d->label->replace_token("%index%", to_string(d->index + 1));
         d->label->replace_token("%name%", m_desktop_names[d->index]);
-        d->label->replace_token("%nwin%", to_string(m_windows[d->index]));
+        d->label->replace_token("%nwin%", nwin);
         d->label->replace_token("%icon%", m_icons->get(m_desktop_names[d->index], DEFAULT_ICON)->get());
       }
     }


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Show the number of windows only if they exceed the configured threshold.
This way, one can only the number of windows when there are multiple.
With a threshold of 1, the following behavior follows:

  0 → inactive/empty workspace
  1 → active workspace, no number
  2 or more → active workspace and number of windows

The default is 0 to match the current behavior.

The config-key is called window-number-threshold

## Notes

This is a working implementation of an idea. I can imagine several changes and improvements for this, but want to get feedback before taking a deep-dive.
- I did not touch the tests (sadly).
- I recognize the need to document this in the wiki and maybe in the example configuration.
- I am unsure about naming things (and of course cache invalidation and off-by-one errors, but mostly naming things, in this case)
- for all the above reasons, I also did not touch the CHANGELOG.

I am looking and am open for feedback. :-)

## Related Issues & Documents

none AFAIK

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
