### PR TITLE
Fix compilation on older versions

### DIFF
--- a/cmake/common/utils.cmake
+++ b/cmake/common/utils.cmake
@@ -117,8 +117,8 @@ function(create_imported_target library_name includes libraries)
   add_library(${library_name} INTERFACE IMPORTED)
   set_target_properties(${library_name} PROPERTIES
     INTERFACE_LINK_LIBRARIES "${libraries}"
+    INTERFACE_INCLUDE_DIRECTORIES "${includes}"
   )
-  target_include_directories(${library_name} SYSTEM INTERFACE ${includes})
 endfunction()
 # }}}
 # checklib {{{

--- a/cmake/libpoly.cmake
+++ b/cmake/libpoly.cmake
@@ -50,12 +50,10 @@ find_package(CairoFC REQUIRED)
 
 if (ENABLE_ALSA)
   find_package(ALSA REQUIRED)
-  set(ALSA_VERSION ${ALSA_VERSION_STRING})
 endif()
 
 if (ENABLE_CURL)
   find_package(CURL REQUIRED)
-  set(CURL_VERSION ${CURL_VERSION_STRING})
 endif()
 
 if (ENABLE_MPD)

--- a/cmake/modules/FindALSA.cmake
+++ b/cmake/modules/FindALSA.cmake
@@ -1,0 +1,14 @@
+# This module defines an imported target `ALSA::ALSA` if alsa is found
+#
+# Defines the following Variables (see find_package_impl for more info):
+# ALSA_FOUND
+# ALSA_INCLUDE_DIR
+# ALSA_INCLUDE_DIRS
+# ALSA_LIBRARY
+# ALSA_LIBRARIES
+# ALSA_VERSION
+find_package_impl("alsa" "ALSA" "alsa/asoundlib.h")
+
+if(ALSA_FOUND AND NOT TARGET ALSA::ALSA)
+  create_imported_target("ALSA::ALSA" "${ALSA_INCLUDE_DIR}" "${ALSA_LIBRARY}")
+endif()

--- a/cmake/modules/FindCURL.cmake
+++ b/cmake/modules/FindCURL.cmake
@@ -1,0 +1,14 @@
+# This module defines an imported target `CURL::libcurl` if libcurl is found
+#
+# Defines the following Variables (see find_package_impl for more info):
+# CURL_FOUND
+# CURL_INCLUDE_DIR
+# CURL_INCLUDE_DIRS
+# CURL_LIBRARY
+# CURL_LIBRARIES
+# CURL_VERSION
+find_package_impl("libcurl" "CURL" "curl/curl.h")
+
+if(CURL_FOUND AND NOT TARGET CURL::libcurl)
+  create_imported_target("CURL::libcurl" "${CURL_INCLUDE_DIR}" "${CURL_LIBRARY}")
+endif()

--- a/include/utils/color.hpp
+++ b/include/utils/color.hpp
@@ -22,7 +22,7 @@ class rgba {
   bool operator==(const rgba& other) const;
 
   uint32_t value() const;
-  type type() const;
+  type get_type() const;
 
   double alpha_d() const;
   double red_d() const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,20 +151,59 @@ if(BUILD_LIBPOLY)
     Cairo::CairoFC
     moodycamel
     xpp
-    $<$<TARGET_EXISTS:i3ipc++>:i3ipc++>
-    $<$<TARGET_EXISTS:ALSA::ALSA>:ALSA::ALSA>
-    $<$<TARGET_EXISTS:CURL::libcurl>:CURL::libcurl>
-    $<$<TARGET_EXISTS:LibMPDClient::LibMPDClient>:LibMPDClient::LibMPDClient>
-    $<$<TARGET_EXISTS:LibNlGenl3::LibNlGenl3>:LibNlGenl3::LibNlGenl3>
-    $<$<TARGET_EXISTS:Libiw::Libiw>:Libiw::Libiw>
-    $<$<TARGET_EXISTS:LibPulse::LibPulse>:LibPulse::LibPulse>
-    $<$<TARGET_EXISTS:Xcb::RANDR>:Xcb::RANDR>
-    $<$<TARGET_EXISTS:Xcb::COMPOSITE>:Xcb::COMPOSITE>
-    $<$<TARGET_EXISTS:Xcb::XKB>:Xcb::XKB>
-    $<$<TARGET_EXISTS:Xcb::CURSOR>:Xcb::CURSOR>
-    $<$<TARGET_EXISTS:Xcb::XRM>:Xcb::XRM>
-    $<$<TARGET_EXISTS:LibInotify::LibInotify>:LibInotify::LibInotify>
     )
+
+  if (TARGET i3ipc++)
+    target_link_libraries(poly PUBLIC i3ipc++)
+  endif()
+
+  if (TARGET ALSA::ALSA)
+    target_link_libraries(poly PUBLIC ALSA::ALSA)
+  endif()
+
+  if (TARGET CURL::libcurl)
+    target_link_libraries(poly PUBLIC CURL::libcurl)
+  endif()
+
+  if (TARGET LibMPDClient::LibMPDClient)
+    target_link_libraries(poly PUBLIC LibMPDClient::LibMPDClient)
+  endif()
+
+  if (TARGET LibNlGenl3::LibNlGenl3)
+    target_link_libraries(poly PUBLIC LibNlGenl3::LibNlGenl3)
+  endif()
+
+  if (TARGET Libiw::Libiw)
+    target_link_libraries(poly PUBLIC Libiw::Libiw)
+  endif()
+
+  if (TARGET LibPulse::LibPulse)
+    target_link_libraries(poly PUBLIC LibPulse::LibPulse)
+  endif()
+
+  if (TARGET Xcb::RANDR)
+    target_link_libraries(poly PUBLIC Xcb::RANDR)
+  endif()
+
+  if (TARGET Xcb::COMPOSITE)
+    target_link_libraries(poly PUBLIC Xcb::COMPOSITE)
+  endif()
+
+  if (TARGET Xcb::XKB)
+    target_link_libraries(poly PUBLIC Xcb::XKB)
+  endif()
+
+  if (TARGET Xcb::CURSOR)
+    target_link_libraries(poly PUBLIC Xcb::CURSOR)
+  endif()
+
+  if (TARGET Xcb::XRM)
+    target_link_libraries(poly PUBLIC Xcb::XRM)
+  endif()
+
+  if (TARGET LibInotify::LibInotify)
+    target_link_libraries(poly PUBLIC LibInotify::LibInotify)
+  endif()
 
   target_compile_options(poly PUBLIC $<$<CXX_COMPILER_ID:GNU>:$<$<CONFIG:MinSizeRel>:-flto>>)
   set_target_properties(poly PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/libs)

--- a/src/utils/color.cpp
+++ b/src/utils/color.cpp
@@ -106,7 +106,7 @@ uint32_t rgba::value() const {
   return this->m_value;
 }
 
-enum rgba::type rgba::type() const {
+enum rgba::type rgba::get_type() const {
   return m_type;
 }
 

--- a/tests/unit_tests/utils/color.cpp
+++ b/tests/unit_tests/utils/color.cpp
@@ -12,7 +12,7 @@ TEST(Rgba, constructor) {
   EXPECT_FALSE(rgba("#-abc").has_color());
   EXPECT_FALSE(rgba("#xyz").has_color());
 
-  EXPECT_EQ(rgba::type::ALPHA_ONLY, rgba{"#12"}.type());
+  EXPECT_EQ(rgba::type::ALPHA_ONLY, rgba{"#12"}.get_type());
 
   EXPECT_EQ(0xff000000, rgba{"#ff"}.value());
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

In #2387, it was reported that configuration doesn't work in cmake 3.10. While fixing that, I stumbled upon some other build issues. This should fix all of them.

Our cmake code relied on functionality from cmake up to version 3.12 and compilation failed with gcc5.

Older cmake versions also did not provide module files for alsa and curl that created targets and because of that we didn't link them.

## Related Issues & Documents

Fixes #2387
Fixes #2393 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
