### PR TITLE
add units support (POINT, PIXEL, SPACE) for polybar

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,4 +10,5 @@ AllowShortIfStatementsOnASingleLine: false
 BreakConstructorInitializersBeforeComma: true
 DerivePointerAlignment: false
 PointerAlignment: Left
+SpacesBeforeTrailingComments: 1
 ---

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -35,7 +35,7 @@ namespace tags {
 /**
  * Converts a percentage with offset into pixels
  */
-inline unsigned int geom_format_to_pixels(percentage_with_offset g_format, double max, double dpi) {
+inline unsigned int percentage_with_offset_to_pixel(percentage_with_offset g_format, double max, double dpi) {
   auto offset_pixel = unit_utils::extent_to_pixel(g_format.offset, dpi);
 
   return static_cast<unsigned int>(math_util::max<double>(

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -33,10 +33,10 @@ namespace tags {
 // }}}
 
 /**
- * Converts geometry format into pixel.
+ * Converts a percentage with offset into pixels
  */
-inline unsigned int geom_format_to_pixels(geometry_format_values g_format, double max, double dpi) {
-  auto offset_pixel = unit_utils::geometry_to_pixel(g_format.offset, dpi);
+inline unsigned int geom_format_to_pixels(percentage_with_offset g_format, double max, double dpi) {
+  auto offset_pixel = unit_utils::extent_to_pixel(g_format.offset, dpi);
 
   return static_cast<unsigned int>(math_util::max<double>(
       0, math_util::percentage_to_value<double, double>(g_format.percentage, max) + offset_pixel));

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -31,7 +31,6 @@ class builder {
   void spacing(spacing_val size);
   void spacing();
   void remove_trailing_space(size_t len);
-  void remove_trailing_space();
   void font(int index);
   void font_close();
   void background(rgba color);
@@ -55,7 +54,7 @@ class builder {
   void action(mousebtn btn, const modules::module_interface& module, string action, string data, const label_t& label);
   void action_close();
 
-  static string add_surrounding_tag(const spacing_val& space);
+  static string get_spacing_format_string(const spacing_val& space);
 
  protected:
   void tag_open(tags::syntaxtag tag, const string& value);

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -27,8 +27,8 @@ class builder {
   void node(const label_t& label);
   void node_repeat(const string& str, size_t n);
   void node_repeat(const label_t& label, size_t n);
-  void offset(int pixels);
-  void space(size_t width);
+  void offset(geometry pixels = GEOMETRY_ZERO_PIXEL);
+  void space(space_size size);
   void space();
   void remove_trailing_space(size_t len);
   void remove_trailing_space();
@@ -55,6 +55,7 @@ class builder {
   void action(mousebtn btn, const modules::module_interface& module, string action, string data, const label_t& label);
   void action_close();
 
+  static string add_surrounding_tag(const space_size& space);
  protected:
   void tag_open(tags::syntaxtag tag, const string& value);
   void tag_open(tags::attribute attr);

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -56,6 +56,7 @@ class builder {
   void action_close();
 
   static string add_surrounding_tag(const space_size& space);
+
  protected:
   void tag_open(tags::syntaxtag tag, const string& value);
   void tag_open(tags::attribute attr);

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -27,9 +27,9 @@ class builder {
   void node(const label_t& label);
   void node_repeat(const string& str, size_t n);
   void node_repeat(const label_t& label, size_t n);
-  void offset(geometry pixels = GEOMETRY_ZERO_PIXEL);
-  void space(space_size size);
-  void space();
+  void offset(extent_val pixels = ZERO_PX_EXTENT);
+  void spacing(spacing_val size);
+  void spacing();
   void remove_trailing_space(size_t len);
   void remove_trailing_space();
   void font(int index);
@@ -55,7 +55,7 @@ class builder {
   void action(mousebtn btn, const modules::module_interface& module, string action, string data, const label_t& label);
   void action_close();
 
-  static string add_surrounding_tag(const space_size& space);
+  static string add_surrounding_tag(const spacing_val& space);
 
  protected:
   void tag_open(tags::syntaxtag tag, const string& value);

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -49,7 +49,7 @@ class renderer : public renderer_interface,
   void end();
   void flush();
 
-  void render_offset(const tags::context& ctxt, geometry offset) override;
+  void render_offset(const tags::context& ctxt, const geometry offset) override;
   void render_text(const tags::context& ctxt, const string&&) override;
 
   void change_alignment(const tags::context& ctxt) override;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -30,6 +30,7 @@ struct alignment_block {
   cairo_pattern_t* pattern;
   double x;
   double y;
+  double width;
 };
 
 class renderer : public renderer_interface,
@@ -48,7 +49,7 @@ class renderer : public renderer_interface,
   void end();
   void flush();
 
-  void render_offset(const tags::context& ctxt, int pixels) override;
+  void render_offset(const tags::context& ctxt, geometry offset) override;
   void render_text(const tags::context& ctxt, const string&&) override;
 
   void change_alignment(const tags::context& ctxt) override;
@@ -62,6 +63,7 @@ class renderer : public renderer_interface,
   void fill_overline(rgba color, double x, double w);
   void fill_underline(rgba color, double x, double w);
   void fill_borders();
+  void draw_offset(rgba color, double x, double w);
 
   double block_x(alignment a) const;
   double block_y(alignment a) const;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -49,7 +49,7 @@ class renderer : public renderer_interface,
   void end();
   void flush();
 
-  void render_offset(const tags::context& ctxt, const geometry offset) override;
+  void render_offset(const tags::context& ctxt, const extent_val offset) override;
   void render_text(const tags::context& ctxt, const string&&) override;
 
   void change_alignment(const tags::context& ctxt) override;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -28,8 +28,17 @@ using std::map;
 
 struct alignment_block {
   cairo_pattern_t* pattern;
+  /**
+   * The x-position where the next thing will be rendered.
+   */
   double x;
   double y;
+  /**
+   * The total width of this block.
+   *
+   * This is always >= x, but may be larger because a negative offset may
+   * decrease x, but the width doesn't change.
+   */
   double width;
 };
 
@@ -69,6 +78,8 @@ class renderer : public renderer_interface,
   double block_y(alignment a) const;
   double block_w(alignment a) const;
   double block_h(alignment a) const;
+
+  void increase_x(double dx);
 
   void flush(alignment a);
   void highlight_clickable_areas();

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -10,7 +10,7 @@ class renderer_interface {
  public:
   renderer_interface(const tags::action_context& action_ctxt) : m_action_ctxt(action_ctxt){};
 
-  virtual void render_offset(const tags::context& ctxt, int pixels) = 0;
+  virtual void render_offset(const tags::context& ctxt, geometry offset) = 0;
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
   virtual void change_alignment(const tags::context& ctxt) = 0;
 

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -10,7 +10,7 @@ class renderer_interface {
  public:
   renderer_interface(const tags::action_context& action_ctxt) : m_action_ctxt(action_ctxt){};
 
-  virtual void render_offset(const tags::context& ctxt, geometry offset) = 0;
+  virtual void render_offset(const tags::context& ctxt, const geometry offset) = 0;
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
   virtual void change_alignment(const tags::context& ctxt) = 0;
 

--- a/include/components/renderer_interface.hpp
+++ b/include/components/renderer_interface.hpp
@@ -10,7 +10,7 @@ class renderer_interface {
  public:
   renderer_interface(const tags::action_context& action_ctxt) : m_action_ctxt(action_ctxt){};
 
-  virtual void render_offset(const tags::context& ctxt, const geometry offset) = 0;
+  virtual void render_offset(const tags::context& ctxt, const extent_val offset) = 0;
   virtual void render_text(const tags::context& ctxt, const string&& str) = 0;
   virtual void change_alignment(const tags::context& ctxt) = 0;
 

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -2,6 +2,7 @@
 
 #include <xcb/xcb.h>
 
+#include <cassert>
 #include <string>
 #include <unordered_map>
 
@@ -71,9 +72,32 @@ struct size {
   unsigned int h{1U};
 };
 
+enum class space_type { SPACE, POINT, PIXEL };
+
+enum class size_type { POINT, PIXEL };
+
+struct space_size {
+  space_type type{space_type::SPACE};
+  float value{0.f};
+};
+
+static constexpr space_size ZERO_SPACE = {space_type::SPACE, 0.};
+
+struct geometry {
+  size_type type{size_type::PIXEL};
+  float value{0.f};
+};
+
+static constexpr geometry GEOMETRY_ZERO_PIXEL = {size_type::PIXEL, 0.f};
+
 struct side_values {
-  unsigned int left{0U};
-  unsigned int right{0U};
+  space_size left{ZERO_SPACE};
+  space_size right{ZERO_SPACE};
+};
+
+struct geometry_format_values {
+  double percentage{0.};
+  geometry offset{GEOMETRY_ZERO_PIXEL};
 };
 
 struct edge_values {
@@ -121,11 +145,15 @@ struct bar_settings {
   struct size size {
     1U, 1U
   };
+
+  double dpi_x{0.};
+  double dpi_y{0.};
+
   position pos{0, 0};
   position offset{0, 0};
-  side_values padding{0U, 0U};
-  side_values margin{0U, 0U};
-  side_values module_margin{0U, 0U};
+  side_values padding{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
+  side_values margin{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
+  side_values module_margin{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
   edge_values strut{0U, 0U, 0U, 0U};
 
   rgba background{0xFF000000};
@@ -138,7 +166,7 @@ struct bar_settings {
   std::unordered_map<edge, border_settings, enum_hash> borders{};
 
   struct radius radius {};
-  int spacing{0};
+  space_size spacing{space_type::SPACE, 0_z};
   label_t separator{};
 
   string wmname{};

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -72,32 +72,37 @@ struct size {
   unsigned int h{1U};
 };
 
-enum class space_type { SPACE, POINT, PIXEL };
+enum class spacing_type { SPACE, POINT, PIXEL };
 
-enum class size_type { POINT, PIXEL };
+enum class extent_type { POINT, PIXEL };
 
-struct space_size {
-  space_type type{space_type::SPACE};
-  float value{0.f};
+struct spacing_val {
+  spacing_type type{spacing_type::SPACE};
+  float value{0};
 };
 
-static constexpr space_size ZERO_SPACE = {space_type::SPACE, 0.};
+static constexpr spacing_val ZERO_SPACING = {spacing_type::SPACE, 0};
 
-struct geometry {
-  size_type type{size_type::PIXEL};
-  float value{0.f};
+/*
+ * Defines the signed length of something as either an amount of pixels or points.
+ *
+ * Used for widths, heights, and offsets
+ */
+struct extent_val {
+  extent_type type{extent_type::PIXEL};
+  float value{0};
 };
 
-static constexpr geometry GEOMETRY_ZERO_PIXEL = {size_type::PIXEL, 0.f};
+static constexpr extent_val ZERO_PX_EXTENT = {extent_type::PIXEL, 0};
 
 struct side_values {
-  space_size left{ZERO_SPACE};
-  space_size right{ZERO_SPACE};
+  spacing_val left{ZERO_SPACING};
+  spacing_val right{ZERO_SPACING};
 };
 
-struct geometry_format_values {
-  double percentage{0.};
-  geometry offset{GEOMETRY_ZERO_PIXEL};
+struct percentage_with_offset {
+  double percentage{0};
+  extent_val offset{ZERO_PX_EXTENT};
 };
 
 struct edge_values {
@@ -151,9 +156,9 @@ struct bar_settings {
 
   position pos{0, 0};
   position offset{0, 0};
-  side_values padding{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
-  side_values margin{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
-  side_values module_margin{{space_type::SPACE, 0_z}, {space_type::SPACE, 0_z}};
+  side_values padding{ZERO_SPACING, ZERO_SPACING};
+  side_values margin{ZERO_SPACING, ZERO_SPACING};
+  side_values module_margin{ZERO_SPACING, ZERO_SPACING};
   edge_values strut{0U, 0U, 0U, 0U};
 
   rgba background{0xFF000000};
@@ -166,7 +171,7 @@ struct bar_settings {
   std::unordered_map<edge, border_settings, enum_hash> borders{};
 
   struct radius radius {};
-  space_size spacing{space_type::SPACE, 0_z};
+  spacing_val spacing{ZERO_SPACING};
   label_t separator{};
 
   string wmname{};

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -2,7 +2,6 @@
 
 #include <xcb/xcb.h>
 
-#include <cassert>
 #include <string>
 #include <unordered_map>
 
@@ -81,10 +80,10 @@ struct spacing_val {
   float value{0};
 };
 
-static constexpr spacing_val ZERO_SPACING = {spacing_type::SPACE, 0};
+static constexpr spacing_val ZERO_SPACE = {spacing_type::SPACE, 0};
 
 /*
- * Defines the signed length of something as either an amount of pixels or points.
+ * Defines the signed length of something as either a number of pixels or points.
  *
  * Used for widths, heights, and offsets
  */
@@ -96,8 +95,8 @@ struct extent_val {
 static constexpr extent_val ZERO_PX_EXTENT = {extent_type::PIXEL, 0};
 
 struct side_values {
-  spacing_val left{ZERO_SPACING};
-  spacing_val right{ZERO_SPACING};
+  spacing_val left{ZERO_SPACE};
+  spacing_val right{ZERO_SPACE};
 };
 
 struct percentage_with_offset {
@@ -156,9 +155,9 @@ struct bar_settings {
 
   position pos{0, 0};
   position offset{0, 0};
-  side_values padding{ZERO_SPACING, ZERO_SPACING};
-  side_values margin{ZERO_SPACING, ZERO_SPACING};
-  side_values module_margin{ZERO_SPACING, ZERO_SPACING};
+  side_values padding{ZERO_SPACE, ZERO_SPACE};
+  side_values margin{ZERO_SPACE, ZERO_SPACE};
+  side_values module_margin{ZERO_SPACE, ZERO_SPACE};
   edge_values strut{0U, 0U, 0U, 0U};
 
   rgba background{0xFF000000};
@@ -171,7 +170,10 @@ struct bar_settings {
   std::unordered_map<edge, border_settings, enum_hash> borders{};
 
   struct radius radius {};
-  spacing_val spacing{ZERO_SPACING};
+  /**
+   * TODO deprecated
+   */
+  spacing_val spacing{ZERO_SPACE};
   label_t separator{};
 
   string wmname{};

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -25,8 +25,8 @@ namespace drawtypes {
     rgba m_underline{};
     rgba m_overline{};
     int m_font{0};
-    side_values m_padding{0U, 0U};
-    side_values m_margin{0U, 0U};
+    side_values m_padding{{space_type::SPACE, 0U}, {space_type::SPACE, 0U}};
+    side_values m_margin{{space_type::SPACE, 0U}, {space_type::SPACE, 0U}};
 
     size_t m_minlen{0};
     /*
@@ -40,15 +40,18 @@ namespace drawtypes {
     alignment m_alignment{alignment::LEFT};
     bool m_ellipsis{true};
 
-    explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
+    explicit label(string text, int font) : m_font(font), m_text(move(text)), m_tokenized(m_text) {}
     explicit label(string text, rgba foreground = rgba{}, rgba background = rgba{}, rgba underline = rgba{},
-        rgba overline = rgba{}, int font = 0, struct side_values padding = {0U, 0U},
-        struct side_values margin = {0U, 0U}, int minlen = 0, size_t maxlen = 0_z,
-        alignment label_alignment = alignment::LEFT, bool ellipsis = true, vector<token>&& tokens = {})
-        : m_foreground(foreground)
-        , m_background(background)
-        , m_underline(underline)
-        , m_overline(overline)
+        rgba overline = rgba{}, int font = 0,
+        side_values padding = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}},
+        side_values margin = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}},
+        int minlen = 0, size_t maxlen = 0_z,
+        alignment label_alignment = alignment::LEFT,
+        bool ellipsis = true, vector<token>&& tokens = {})
+        : m_foreground(move(foreground))
+        , m_background(move(background))
+        , m_underline(move(underline))
+        , m_overline(move(overline))
         , m_font(font)
         , m_padding(padding)
         , m_margin(margin)
@@ -56,14 +59,14 @@ namespace drawtypes {
         , m_maxlen(maxlen)
         , m_alignment(label_alignment)
         , m_ellipsis(ellipsis)
-        , m_text(text)
+        , m_text(move(text))
         , m_tokenized(m_text)
         , m_tokens(forward<vector<token>>(tokens)) {
       assert(!m_ellipsis || (m_maxlen == 0 || m_maxlen >= 3));
     }
 
     string get() const;
-    operator bool();
+    explicit operator bool();
     label_t clone();
     void clear();
     void reset_tokens();

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -25,8 +25,8 @@ namespace drawtypes {
     rgba m_underline{};
     rgba m_overline{};
     int m_font{0};
-    side_values m_padding{{space_type::SPACE, 0U}, {space_type::SPACE, 0U}};
-    side_values m_margin{{space_type::SPACE, 0U}, {space_type::SPACE, 0U}};
+    side_values m_padding{ZERO_SPACING, ZERO_SPACING};
+    side_values m_margin{ZERO_SPACING, ZERO_SPACING};
 
     size_t m_minlen{0};
     /*
@@ -42,8 +42,8 @@ namespace drawtypes {
 
     explicit label(string text, int font) : m_font(font), m_text(move(text)), m_tokenized(m_text) {}
     explicit label(string text, rgba foreground = rgba{}, rgba background = rgba{}, rgba underline = rgba{},
-        rgba overline = rgba{}, int font = 0, side_values padding = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}},
-        side_values margin = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}}, int minlen = 0, size_t maxlen = 0_z,
+        rgba overline = rgba{}, int font = 0, side_values padding = {ZERO_SPACING, ZERO_SPACING},
+        side_values margin = {ZERO_SPACING, ZERO_SPACING}, int minlen = 0, size_t maxlen = 0_z,
         alignment label_alignment = alignment::LEFT, bool ellipsis = true, vector<token>&& tokens = {})
         : m_foreground(move(foreground))
         , m_background(move(background))

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -25,8 +25,8 @@ namespace drawtypes {
     rgba m_underline{};
     rgba m_overline{};
     int m_font{0};
-    side_values m_padding{ZERO_SPACING, ZERO_SPACING};
-    side_values m_margin{ZERO_SPACING, ZERO_SPACING};
+    side_values m_padding{ZERO_SPACE, ZERO_SPACE};
+    side_values m_margin{ZERO_SPACE, ZERO_SPACE};
 
     size_t m_minlen{0};
     /*
@@ -42,8 +42,8 @@ namespace drawtypes {
 
     explicit label(string text, int font) : m_font(font), m_text(move(text)), m_tokenized(m_text) {}
     explicit label(string text, rgba foreground = rgba{}, rgba background = rgba{}, rgba underline = rgba{},
-        rgba overline = rgba{}, int font = 0, side_values padding = {ZERO_SPACING, ZERO_SPACING},
-        side_values margin = {ZERO_SPACING, ZERO_SPACING}, int minlen = 0, size_t maxlen = 0_z,
+        rgba overline = rgba{}, int font = 0, side_values padding = {ZERO_SPACE, ZERO_SPACE},
+        side_values margin = {ZERO_SPACE, ZERO_SPACE}, int minlen = 0, size_t maxlen = 0_z,
         alignment label_alignment = alignment::LEFT, bool ellipsis = true, vector<token>&& tokens = {})
         : m_foreground(move(foreground))
         , m_background(move(background))
@@ -81,6 +81,6 @@ namespace drawtypes {
 
   label_t load_label(const config& conf, const string& section, string name, bool required = true, string def = ""s);
   label_t load_optional_label(const config& conf, string section, string name, string def = ""s);
-}  // namespace drawtypes
+} // namespace drawtypes
 
 POLYBAR_NS_END

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -42,12 +42,9 @@ namespace drawtypes {
 
     explicit label(string text, int font) : m_font(font), m_text(move(text)), m_tokenized(m_text) {}
     explicit label(string text, rgba foreground = rgba{}, rgba background = rgba{}, rgba underline = rgba{},
-        rgba overline = rgba{}, int font = 0,
-        side_values padding = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}},
-        side_values margin = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}},
-        int minlen = 0, size_t maxlen = 0_z,
-        alignment label_alignment = alignment::LEFT,
-        bool ellipsis = true, vector<token>&& tokens = {})
+        rgba overline = rgba{}, int font = 0, side_values padding = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}},
+        side_values margin = {{space_type::SPACE, 0U}, {space_type::SPACE, 0U}}, int minlen = 0, size_t maxlen = 0_z,
+        alignment label_alignment = alignment::LEFT, bool ellipsis = true, vector<token>&& tokens = {})
         : m_foreground(move(foreground))
         , m_background(move(background))
         , m_underline(move(underline))

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -45,7 +45,7 @@ namespace modules {
     progressbar_t m_barload;
     ramp_t m_rampload;
     ramp_t m_rampload_core;
-    space_size m_ramp_padding{space_type::SPACE, 1U};
+    spacing_val m_ramp_padding{spacing_type::SPACE, 1U};
 
     vector<cpu_time_t> m_cputimes;
     vector<cpu_time_t> m_cputimes_prev;

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -40,7 +40,6 @@ namespace modules {
     static constexpr auto TAG_RAMP_LOAD_PER_CORE = "<ramp-coreload>";
     static constexpr auto FORMAT_WARN = "format-warn";
 
-
     label_t m_label;
     label_t m_labelwarn;
     progressbar_t m_barload;

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -46,7 +46,7 @@ namespace modules {
     progressbar_t m_barload;
     ramp_t m_rampload;
     ramp_t m_rampload_core;
-    int m_ramp_padding;
+    space_size m_ramp_padding{space_type::SPACE, 1U};
 
     vector<cpu_time_t> m_cputimes;
     vector<cpu_time_t> m_cputimes_prev;

--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -68,7 +68,7 @@ namespace modules {
     vector<fs_mount_t> m_mounts;
     bool m_fixed{false};
     bool m_remove_unmounted{false};
-    space_size m_spacing{space_type::SPACE, 2U};
+    spacing_val m_spacing{spacing_type::SPACE, 2U};
     int m_perc_used_warn{90};
 
     // used while formatting output

--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -68,7 +68,7 @@ namespace modules {
     vector<fs_mount_t> m_mounts;
     bool m_fixed{false};
     bool m_remove_unmounted{false};
-    int m_spacing{2};
+    space_size m_spacing{space_type::SPACE, 2U};
     int m_perc_used_warn{90};
 
     // used while formatting output

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -67,10 +67,10 @@ namespace modules {
     rgba ol{};
     size_t ulsize{0};
     size_t olsize{0};
-    size_t spacing{0};
-    size_t padding{0};
-    size_t margin{0};
-    int offset{0};
+    space_size spacing{ZERO_SPACE};
+    space_size padding{ZERO_SPACE};
+    space_size margin{ZERO_SPACE};
+    geometry offset{GEOMETRY_ZERO_PIXEL};
     int font{0};
 
     string decorate(builder* builder, string output);

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -67,10 +67,10 @@ namespace modules {
     rgba ol{};
     size_t ulsize{0};
     size_t olsize{0};
-    space_size spacing{ZERO_SPACE};
-    space_size padding{ZERO_SPACE};
-    space_size margin{ZERO_SPACE};
-    geometry offset{GEOMETRY_ZERO_PIXEL};
+    spacing_val spacing{ZERO_SPACING};
+    spacing_val padding{ZERO_SPACING};
+    spacing_val margin{ZERO_SPACING};
+    extent_val offset{ZERO_PX_EXTENT};
     int font{0};
 
     string decorate(builder* builder, string output);

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -35,7 +35,7 @@ namespace drawtypes {
   using animation_t = shared_ptr<animation>;
   class iconset;
   using iconset_t = shared_ptr<iconset>;
-}  // namespace drawtypes
+} // namespace drawtypes
 
 class builder;
 class config;
@@ -67,9 +67,9 @@ namespace modules {
     rgba ol{};
     size_t ulsize{0};
     size_t olsize{0};
-    spacing_val spacing{ZERO_SPACING};
-    spacing_val padding{ZERO_SPACING};
-    spacing_val margin{ZERO_SPACING};
+    spacing_val spacing{ZERO_SPACE};
+    spacing_val padding{ZERO_SPACE};
+    spacing_val margin{ZERO_SPACE};
     extent_val offset{ZERO_PX_EXTENT};
     int font{0};
 
@@ -209,6 +209,6 @@ namespace modules {
   };
 
   // }}}
-}  // namespace modules
+} // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -184,7 +184,7 @@ namespace modules {
     bool no_tag_built{true};
     bool fake_no_tag_built{false};
     bool tag_built{false};
-    auto mingap = std::max(1_z, format->spacing);
+    auto mingap = std::max(1.f, format->spacing.value);
     size_t start, end;
     string value{format->value};
     while ((start = value.find('<')) != string::npos && (end = value.find('>', start)) != string::npos) {

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -210,7 +210,7 @@ namespace modules {
         continue;
       } else if (tag[0] == '<' && tag[tag.size() - 1] == '>') {
         if (!no_tag_built)
-          m_builder->space(format->spacing);
+          m_builder->spacing(format->spacing);
         else if (fake_no_tag_built)
           no_tag_built = false;
         if (!(tag_built = CONST_MOD(Impl).build(m_builder.get(), tag)) && !no_tag_built)

--- a/include/tags/parser.hpp
+++ b/include/tags/parser.hpp
@@ -126,7 +126,7 @@ namespace tags {
 
     color_value parse_color();
     int parse_fontindex();
-    geometry parse_offset();
+    extent_val parse_offset();
     controltag parse_control();
     std::pair<action_value, string> parse_action();
     mousebtn parse_action_btn();

--- a/include/tags/parser.hpp
+++ b/include/tags/parser.hpp
@@ -126,7 +126,7 @@ namespace tags {
 
     color_value parse_color();
     int parse_fontindex();
-    int parse_offset();
+    geometry parse_offset();
     controltag parse_control();
     std::pair<action_value, string> parse_action();
     mousebtn parse_action_btn();

--- a/include/tags/types.hpp
+++ b/include/tags/types.hpp
@@ -90,7 +90,7 @@ namespace tags {
       /**
        * For for 'O' tags
        */
-      geometry offset;
+      extent_val offset;
       /**
        * For for 'P' tags
        */

--- a/include/tags/types.hpp
+++ b/include/tags/types.hpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 #include "components/types.hpp"
 #include "utils/color.hpp"
+#include "utils/unit.hpp"
 
 POLYBAR_NS
 
@@ -89,7 +90,7 @@ namespace tags {
       /**
        * For for 'O' tags
        */
-      int offset;
+      geometry offset;
       /**
        * For for 'P' tags
        */

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cmath>
 #include <string>
+#include <stdexcept>
 
 #include "components/types.hpp"
 #include "utils/string.hpp"
@@ -39,18 +40,27 @@ namespace unit_utils {
     size_t pos;
     auto size_value = std::stof(str, &pos);
 
-    extent_val size{extent_type::PIXEL, size_value};
+    extent_type type;
 
     string unit = string_util::trim(str.substr(pos));
     if (!unit.empty()) {
       if (unit == "px") {
-        size.value = std::trunc(size.value);
+        type = extent_type::PIXEL;
       } else if (unit == "pt") {
-        size.type = extent_type::POINT;
+        type = extent_type::POINT;
+      } else {
+        throw std::runtime_error("Unrecognized unit '" + unit + "'");
       }
+    } else {
+      type = extent_type::PIXEL;
     }
 
-    return size;
+    // Pixel values should be integers
+    if (type == extent_type::PIXEL) {
+      size_value = std::trunc(size_value);
+    }
+
+    return {type, size_value};
   }
 
   inline string extent_to_string(extent_val extent) {

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <string>
 

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -26,7 +26,7 @@ namespace unit_utils {
   }
 
   template <typename ReturnType = int>
-  ReturnType geometry_to_pixel(geometry size, double dpi) {
+  ReturnType geometry_to_pixel(const geometry size, double dpi) {
     if (size.type == size_type::PIXEL) {
       return size.value;
     }

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -15,10 +15,10 @@ namespace unit_utils {
   }
 
   template <typename ReturnType = int>
-  ReturnType space_type_to_pixel(space_size size, double dpi) {
-    assert(size.type != space_type::SPACE);
+  ReturnType spacing_to_pixel(spacing_val size, double dpi) {
+    assert(size.type != spacing_type::SPACE);
 
-    if (size.type == space_type::PIXEL) {
+    if (size.type == spacing_type::PIXEL) {
       return size.value;
     }
 
@@ -26,26 +26,24 @@ namespace unit_utils {
   }
 
   template <typename ReturnType = int>
-  ReturnType geometry_to_pixel(const geometry size, double dpi) {
-    if (size.type == size_type::PIXEL) {
+  ReturnType extent_to_pixel(const extent_val size, double dpi) {
+    if (size.type == extent_type::PIXEL) {
       return size.value;
     }
 
     return point_to_pixel<double, ReturnType>(size.value, dpi);
   }
 
-  inline string space_size_to_string(space_size size) {
+  inline string spacing_to_string(spacing_val size) {
     if (size.value > 0) {
       switch (size.type) {
-        case space_type::SPACE:
+        case spacing_type::SPACE:
           return string(static_cast<string::size_type>(size.value), ' ');
-        case space_type::POINT: {
-          auto str = to_string(size.value);
-          str += "pt";
-          return str;
+        case spacing_type::POINT: {
+          return to_string(size.value) + "pt";
         }
-        case space_type::PIXEL: {
-          return to_string(static_cast<int>(size.value));
+        case spacing_type::PIXEL: {
+          return to_string(static_cast<int>(size.value)) + "px";
         }
       }
     }
@@ -53,35 +51,31 @@ namespace unit_utils {
     return {};
   }
 
-  inline geometry geometry_from_string(string&& str) {
+  inline extent_val parse_extent(string&& str) {
     char* new_end;
     auto size_value = std::strtof(str.c_str(), &new_end);
 
-    geometry size{size_type::PIXEL, size_value};
+    extent_val size{extent_type::PIXEL, size_value};
 
     string unit = string_util::trim(new_end);
     if (!unit.empty()) {
       if (unit == "px") {
         size.value = std::trunc(size.value);
       } else if (unit == "pt") {
-        size.type = size_type::POINT;
+        size.type = extent_type::POINT;
       }
     }
 
     return size;
   }
 
-  inline string geometry_to_string(geometry geometry) {
-    if (geometry.value > 0) {
-      switch (geometry.type) {
-        case size_type::POINT: {
-          auto str = to_string(geometry.value);
-          str += "pt";
-          return str;
-        }
-        case size_type::PIXEL: {
-          return to_string(static_cast<int>(geometry.value));
-        }
+  inline string extent_to_string(extent_val extent) {
+    if (extent.value > 0) {
+      switch (extent.type) {
+        case extent_type::POINT:
+          return to_string(extent.value) + "pt";
+        case extent_type::PIXEL:
+          return to_string(static_cast<int>(extent.value)) + "px";
       }
     }
 

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <cmath>
+#include <string>
+
+#include "components/types.hpp"
+#include "utils/string.hpp"
+
+POLYBAR_NS
+
+namespace unit_utils {
+  template <typename ValueType, typename ReturnType = long unsigned int>
+  ReturnType point_to_pixel(ValueType point, ValueType dpi) {
+    return static_cast<ReturnType>(dpi * point / ValueType(72));
+  }
+
+  template <typename ReturnType = int>
+  ReturnType space_type_to_pixel(space_size size, double dpi) {
+    assert(size.type != space_type::SPACE);
+
+    if (size.type == space_type::PIXEL) {
+      return size.value;
+    }
+
+    return point_to_pixel<double, ReturnType>(size.value, dpi);
+  }
+
+  template <typename ReturnType = int>
+  ReturnType geometry_to_pixel(geometry size, double dpi) {
+    if (size.type == size_type::PIXEL) {
+      return size.value;
+    }
+
+    return point_to_pixel<double, ReturnType>(size.value, dpi);
+  }
+
+  inline string space_size_to_string(space_size size) {
+    if (size.value > 0) {
+      switch (size.type) {
+        case space_type::SPACE:
+          return string(static_cast<string::size_type>(size.value), ' ');
+        case space_type::POINT: {
+          auto str = to_string(size.value);
+          str += "pt";
+          return str;
+        }
+        case space_type::PIXEL: {
+          return to_string(static_cast<int>(size.value));
+        }
+      }
+    }
+
+    return {};
+  }
+
+  inline geometry geometry_from_string(string&& str) {
+    char* new_end;
+    auto size_value = std::strtof(str.c_str(), &new_end);
+
+    geometry size{size_type::PIXEL, size_value};
+
+    string unit = string_util::trim(new_end);
+    if (!unit.empty()) {
+      if (unit == "px") {
+        size.value = std::trunc(size.value);
+      } else if (unit == "pt") {
+        size.type = size_type::POINT;
+      }
+    }
+
+    return size;
+  }
+
+  inline string geometry_to_string(geometry geometry) {
+    if (geometry.value > 0) {
+      switch (geometry.type) {
+        case size_type::POINT: {
+          auto str = to_string(geometry.value);
+          str += "pt";
+          return str;
+        }
+        case size_type::PIXEL: {
+          return to_string(static_cast<int>(geometry.value));
+        }
+      }
+    }
+
+    return {};
+  }
+
+}  // namespace unit_utils
+
+POLYBAR_NS_END

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -34,23 +34,6 @@ namespace unit_utils {
     return point_to_pixel<double, ReturnType>(size.value, dpi);
   }
 
-  inline string spacing_to_string(spacing_val size) {
-    if (size.value > 0) {
-      switch (size.type) {
-        case spacing_type::SPACE:
-          return string(static_cast<string::size_type>(size.value), ' ');
-        case spacing_type::POINT: {
-          return to_string(size.value) + "pt";
-        }
-        case spacing_type::PIXEL: {
-          return to_string(static_cast<int>(size.value)) + "px";
-        }
-      }
-    }
-
-    return {};
-  }
-
   inline extent_val parse_extent(string&& str) {
     char* new_end;
     auto size_value = std::strtof(str.c_str(), &new_end);
@@ -82,6 +65,6 @@ namespace unit_utils {
     return {};
   }
 
-}  // namespace unit_utils
+} // namespace unit_utils
 
 POLYBAR_NS_END

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -36,12 +36,12 @@ namespace unit_utils {
   }
 
   inline extent_val parse_extent(string&& str) {
-    char* new_end;
-    auto size_value = std::strtof(str.c_str(), &new_end);
+    size_t pos;
+    auto size_value = std::stof(str, &pos);
 
     extent_val size{extent_type::PIXEL, size_value};
 
-    string unit = string_util::trim(new_end);
+    string unit = string_util::trim(str.substr(pos));
     if (!unit.empty()) {
       if (unit == "px") {
         size.value = std::trunc(size.value);

--- a/include/utils/unit.hpp
+++ b/include/utils/unit.hpp
@@ -2,8 +2,8 @@
 
 #include <cassert>
 #include <cmath>
-#include <string>
 #include <stdexcept>
+#include <string>
 
 #include "components/types.hpp"
 #include "utils/string.hpp"
@@ -64,13 +64,11 @@ namespace unit_utils {
   }
 
   inline string extent_to_string(extent_val extent) {
-    if (extent.value > 0) {
-      switch (extent.type) {
-        case extent_type::POINT:
-          return to_string(extent.value) + "pt";
-        case extent_type::PIXEL:
-          return to_string(static_cast<int>(extent.value)) + "px";
-      }
+    switch (extent.type) {
+      case extent_type::POINT:
+        return to_string(extent.value) + "pt";
+      case extent_type::PIXEL:
+        return to_string(static_cast<int>(extent.value)) + "px";
     }
 
     return {};

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -276,7 +276,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   auto overline_size = m_conf.get(bs, "overline-size", line_size);
   auto underline_size = m_conf.get(bs, "underline-size", line_size);
 
-  m_opts.overline.size = static_cast<unsigned int>(unit_utils::extent_to_pixel(overline_size, m_opts.dpi_y));
+  m_opts.overline.size = unit_utils::extent_to_pixel<unsigned>(overline_size, m_opts.dpi_y);
   m_opts.overline.color = parse_or_throw_color("overline-color", line_color);
   m_opts.underline.size = static_cast<unsigned int>(unit_utils::extent_to_pixel(underline_size, m_opts.dpi_y));
   m_opts.underline.color = parse_or_throw_color("underline-color", line_color);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -204,11 +204,11 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.radius.bottom_left = m_conf.get(bs, "radius-bottom-left", bottom);
   m_opts.radius.bottom_right = m_conf.get(bs, "radius-bottom-right", bottom);
 
-  auto padding = m_conf.get(bs, "padding", ZERO_SPACING);
+  auto padding = m_conf.get(bs, "padding", ZERO_SPACE);
   m_opts.padding.left = m_conf.get(bs, "padding-left", padding);
   m_opts.padding.right = m_conf.get(bs, "padding-right", padding);
 
-  auto margin = m_conf.get(bs, "module-margin", ZERO_SPACING);
+  auto margin = m_conf.get(bs, "module-margin", ZERO_SPACE);
   m_opts.module_margin.left = m_conf.get(bs, "module-margin-left", margin);
   m_opts.module_margin.right = m_conf.get(bs, "module-margin-right", margin);
 

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -278,7 +278,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   m_opts.overline.size = unit_utils::extent_to_pixel<unsigned>(overline_size, m_opts.dpi_y);
   m_opts.overline.color = parse_or_throw_color("overline-color", line_color);
-  m_opts.underline.size = static_cast<unsigned int>(unit_utils::extent_to_pixel(underline_size, m_opts.dpi_y));
+  m_opts.underline.size = unit_utils::extent_to_pixel<unsigned>(underline_size, m_opts.dpi_y);
   m_opts.underline.color = parse_or_throw_color("underline-color", line_color);
 
   // Load border settings

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -190,10 +190,10 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   }
 
   // Load configuration values
-  auto parse_size_with_unit = [bs, this](string key, space_size default_value) {
+  auto parse_size_with_unit = [bs, this](string key, spacing_val default_value) {
     try {
       auto size = m_conf.get(bs, key, default_value);
-      size.type = space_type::PIXEL;
+      size.type = spacing_type::PIXEL;
       return size;
     } catch (const std::exception& err) {
       throw application_error(sstream() << "Failed to set " << bs << "." << key << " (reason: " << err.what() << ")");
@@ -213,11 +213,11 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.radius.bottom_left = m_conf.get(bs, "radius-bottom-left", bottom);
   m_opts.radius.bottom_right = m_conf.get(bs, "radius-bottom-right", bottom);
 
-  auto padding = parse_size_with_unit("padding", space_size{});
+  auto padding = parse_size_with_unit("padding", spacing_val{});
   m_opts.padding.left = parse_size_with_unit("padding-left", padding);
   m_opts.padding.right = parse_size_with_unit("padding-right", padding);
 
-  auto margin = parse_size_with_unit("module-margin", space_size{});
+  auto margin = parse_size_with_unit("module-margin", spacing_val{});
   m_opts.module_margin.left = parse_size_with_unit("module-margin-left", margin);
   m_opts.module_margin.right = parse_size_with_unit("module-margin-right", margin);
 
@@ -280,19 +280,19 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   // Load over-/underline
   auto line_color = m_conf.get(bs, "line-color", rgba{0xFFFF0000});
-  auto line_size = parse_size_with_unit("line-size", space_size{space_type::PIXEL, 0U});
+  auto line_size = parse_size_with_unit("line-size", spacing_val{spacing_type::PIXEL, 0U});
 
   auto overline_size = parse_size_with_unit("overline-size", line_size);
   auto underline_size = parse_size_with_unit("underline-size", line_size);
 
-  m_opts.overline.size = static_cast<unsigned int>(unit_utils::space_type_to_pixel(overline_size, m_opts.dpi_y));
+  m_opts.overline.size = static_cast<unsigned int>(unit_utils::spacing_to_pixel(overline_size, m_opts.dpi_y));
   m_opts.overline.color = parse_or_throw_color("overline-color", line_color);
-  m_opts.underline.size = static_cast<unsigned int>(unit_utils::space_type_to_pixel(underline_size, m_opts.dpi_y));
+  m_opts.underline.size = static_cast<unsigned int>(unit_utils::spacing_to_pixel(underline_size, m_opts.dpi_y));
   m_opts.underline.color = parse_or_throw_color("underline-color", line_color);
 
   // Load border settings
   auto border_color = m_conf.get(bs, "border-color", rgba{0x00000000});
-  auto border_size = m_conf.get(bs, "border-size", geometry_format_values{});
+  auto border_size = m_conf.get(bs, "border-size", percentage_with_offset{});
   auto border_top = m_conf.deprecated(bs, "border-top", "border-top-size", border_size);
   auto border_bottom = m_conf.deprecated(bs, "border-bottom", "border-bottom-size", border_size);
   auto border_left = m_conf.deprecated(bs, "border-left", "border-left-size", border_size);
@@ -312,10 +312,10 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.borders[edge::RIGHT].color = parse_or_throw_color("border-right-color", border_color);
 
   // Load geometry values
-  auto w = m_conf.get(m_conf.section(), "width", geometry_format_values{100.});
-  auto h = m_conf.get(m_conf.section(), "height", geometry_format_values{0., {size_type::PIXEL, 24}});
-  auto offsetx = m_conf.get(m_conf.section(), "offset-x", geometry_format_values{});
-  auto offsety = m_conf.get(m_conf.section(), "offset-y", geometry_format_values{});
+  auto w = m_conf.get(m_conf.section(), "width", percentage_with_offset{100.});
+  auto h = m_conf.get(m_conf.section(), "height", percentage_with_offset{0., {extent_type::PIXEL, 24}});
+  auto offsetx = m_conf.get(m_conf.section(), "offset-x", percentage_with_offset{});
+  auto offsety = m_conf.get(m_conf.section(), "offset-y", percentage_with_offset{});
 
   m_opts.size.w = geom_format_to_pixels(w, m_opts.monitor->w, m_opts.dpi_x);
   m_opts.size.h = geom_format_to_pixels(h, m_opts.monitor->h, m_opts.dpi_y);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -172,7 +172,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
       }
     }
 
-    // dpi to be comptued
+    // dpi to be computed
     if (dpi_x <= 0 || dpi_y <= 0) {
       auto screen = m_connection.screen();
       if (dpi_x <= 0) {
@@ -190,18 +190,9 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   }
 
   // Load configuration values
-  auto parse_size_with_unit = [bs, this](string key, spacing_val default_value) {
-    try {
-      auto size = m_conf.get(bs, key, default_value);
-      size.type = spacing_type::PIXEL;
-      return size;
-    } catch (const std::exception& err) {
-      throw application_error(sstream() << "Failed to set " << bs << "." << key << " (reason: " << err.what() << ")");
-    }
-  };
 
   m_opts.origin = m_conf.get(bs, "bottom", false) ? edge::BOTTOM : edge::TOP;
-  m_opts.spacing = parse_size_with_unit("spacing", m_opts.spacing);
+  m_opts.spacing = m_conf.get(bs, "spacing", m_opts.spacing);
   m_opts.separator = drawtypes::load_optional_label(m_conf, bs, "separator", "");
   m_opts.locale = m_conf.get(bs, "locale", ""s);
 
@@ -213,13 +204,13 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.radius.bottom_left = m_conf.get(bs, "radius-bottom-left", bottom);
   m_opts.radius.bottom_right = m_conf.get(bs, "radius-bottom-right", bottom);
 
-  auto padding = parse_size_with_unit("padding", spacing_val{});
-  m_opts.padding.left = parse_size_with_unit("padding-left", padding);
-  m_opts.padding.right = parse_size_with_unit("padding-right", padding);
+  auto padding = m_conf.get(bs, "padding", ZERO_SPACING);
+  m_opts.padding.left = m_conf.get(bs, "padding-left", padding);
+  m_opts.padding.right = m_conf.get(bs, "padding-right", padding);
 
-  auto margin = parse_size_with_unit("module-margin", spacing_val{});
-  m_opts.module_margin.left = parse_size_with_unit("module-margin-left", margin);
-  m_opts.module_margin.right = parse_size_with_unit("module-margin-right", margin);
+  auto margin = m_conf.get(bs, "module-margin", ZERO_SPACING);
+  m_opts.module_margin.left = m_conf.get(bs, "module-margin-left", margin);
+  m_opts.module_margin.right = m_conf.get(bs, "module-margin-right", margin);
 
   if (only_initialize_values) {
     return;
@@ -280,14 +271,14 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   // Load over-/underline
   auto line_color = m_conf.get(bs, "line-color", rgba{0xFFFF0000});
-  auto line_size = parse_size_with_unit("line-size", spacing_val{spacing_type::PIXEL, 0U});
+  auto line_size = m_conf.get(bs, "line-size", ZERO_PX_EXTENT);
 
-  auto overline_size = parse_size_with_unit("overline-size", line_size);
-  auto underline_size = parse_size_with_unit("underline-size", line_size);
+  auto overline_size = m_conf.get(bs, "overline-size", line_size);
+  auto underline_size = m_conf.get(bs, "underline-size", line_size);
 
-  m_opts.overline.size = static_cast<unsigned int>(unit_utils::spacing_to_pixel(overline_size, m_opts.dpi_y));
+  m_opts.overline.size = static_cast<unsigned int>(unit_utils::extent_to_pixel(overline_size, m_opts.dpi_y));
   m_opts.overline.color = parse_or_throw_color("overline-color", line_color);
-  m_opts.underline.size = static_cast<unsigned int>(unit_utils::spacing_to_pixel(underline_size, m_opts.dpi_y));
+  m_opts.underline.size = static_cast<unsigned int>(unit_utils::extent_to_pixel(underline_size, m_opts.dpi_y));
   m_opts.underline.color = parse_or_throw_color("underline-color", line_color);
 
   // Load border settings

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -290,16 +290,16 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   auto border_right = m_conf.deprecated(bs, "border-right", "border-right-size", border_size);
 
   m_opts.borders.emplace(edge::TOP, border_settings{});
-  m_opts.borders[edge::TOP].size = geom_format_to_pixels(border_top, m_opts.monitor->h, m_opts.dpi_y);
+  m_opts.borders[edge::TOP].size = percentage_with_offset_to_pixel(border_top, m_opts.monitor->h, m_opts.dpi_y);
   m_opts.borders[edge::TOP].color = parse_or_throw_color("border-top-color", border_color);
   m_opts.borders.emplace(edge::BOTTOM, border_settings{});
-  m_opts.borders[edge::BOTTOM].size = geom_format_to_pixels(border_bottom, m_opts.monitor->h, m_opts.dpi_y);
+  m_opts.borders[edge::BOTTOM].size = percentage_with_offset_to_pixel(border_bottom, m_opts.monitor->h, m_opts.dpi_y);
   m_opts.borders[edge::BOTTOM].color = parse_or_throw_color("border-bottom-color", border_color);
   m_opts.borders.emplace(edge::LEFT, border_settings{});
-  m_opts.borders[edge::LEFT].size = geom_format_to_pixels(border_left, m_opts.monitor->w, m_opts.dpi_x);
+  m_opts.borders[edge::LEFT].size = percentage_with_offset_to_pixel(border_left, m_opts.monitor->w, m_opts.dpi_x);
   m_opts.borders[edge::LEFT].color = parse_or_throw_color("border-left-color", border_color);
   m_opts.borders.emplace(edge::RIGHT, border_settings{});
-  m_opts.borders[edge::RIGHT].size = geom_format_to_pixels(border_right, m_opts.monitor->w, m_opts.dpi_x);
+  m_opts.borders[edge::RIGHT].size = percentage_with_offset_to_pixel(border_right, m_opts.monitor->w, m_opts.dpi_x);
   m_opts.borders[edge::RIGHT].color = parse_or_throw_color("border-right-color", border_color);
 
   // Load geometry values
@@ -308,10 +308,10 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   auto offsetx = m_conf.get(m_conf.section(), "offset-x", percentage_with_offset{});
   auto offsety = m_conf.get(m_conf.section(), "offset-y", percentage_with_offset{});
 
-  m_opts.size.w = geom_format_to_pixels(w, m_opts.monitor->w, m_opts.dpi_x);
-  m_opts.size.h = geom_format_to_pixels(h, m_opts.monitor->h, m_opts.dpi_y);
-  m_opts.offset.x = geom_format_to_pixels(offsetx, m_opts.monitor->w, m_opts.dpi_x);
-  m_opts.offset.y = geom_format_to_pixels(offsety, m_opts.monitor->h, m_opts.dpi_y);
+  m_opts.size.w = percentage_with_offset_to_pixel(w, m_opts.monitor->w, m_opts.dpi_x);
+  m_opts.size.h = percentage_with_offset_to_pixel(h, m_opts.monitor->h, m_opts.dpi_y);
+  m_opts.offset.x = percentage_with_offset_to_pixel(offsetx, m_opts.monitor->w, m_opts.dpi_x);
+  m_opts.offset.y = percentage_with_offset_to_pixel(offsety, m_opts.monitor->h, m_opts.dpi_y);
 
   // Apply offsets
   m_opts.pos.x = m_opts.offset.x + m_opts.monitor->x;

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -158,9 +158,50 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.wmname = m_conf.get(bs, "wm-name", "polybar-" + bs.substr(4) + "_" + m_opts.monitor->name);
   m_opts.wmname = string_util::replace(m_opts.wmname, " ", "-");
 
+  // Configure DPI
+  {
+    double dpi_x = 96, dpi_y = 96;
+    if (m_conf.has(m_conf.section(), "dpi")) {
+      dpi_x = dpi_y = m_conf.get<double>("dpi");
+    } else {
+      if (m_conf.has(m_conf.section(), "dpi-x")) {
+        dpi_x = m_conf.get<double>("dpi-x");
+      }
+      if (m_conf.has(m_conf.section(), "dpi-y")) {
+        dpi_y = m_conf.get<double>("dpi-y");
+      }
+    }
+
+    // dpi to be comptued
+    if (dpi_x <= 0 || dpi_y <= 0) {
+      auto screen = m_connection.screen();
+      if (dpi_x <= 0) {
+        dpi_x = screen->width_in_pixels * 25.4 / screen->width_in_millimeters;
+      }
+      if (dpi_y <= 0) {
+        dpi_y = screen->height_in_pixels * 25.4 / screen->height_in_millimeters;
+      }
+    }
+
+    m_opts.dpi_x = dpi_x;
+    m_opts.dpi_y = dpi_y;
+
+    m_log.info("Configured DPI = %gx%g", dpi_x, dpi_y);
+  }
+
   // Load configuration values
+  auto parse_size_with_unit = [bs, this](string key, space_size default_value) {
+    try {
+      auto size = m_conf.get(bs, key, default_value);
+      size.type = space_type::PIXEL;
+      return size;
+    } catch (const std::exception& err) {
+      throw application_error(sstream() << "Failed to set " << bs << "." << key << " (reason: " << err.what() << ")");
+    }
+  };
+
   m_opts.origin = m_conf.get(bs, "bottom", false) ? edge::BOTTOM : edge::TOP;
-  m_opts.spacing = m_conf.get(bs, "spacing", m_opts.spacing);
+  m_opts.spacing = parse_size_with_unit("spacing", m_opts.spacing);
   m_opts.separator = drawtypes::load_optional_label(m_conf, bs, "separator", "");
   m_opts.locale = m_conf.get(bs, "locale", ""s);
 
@@ -172,21 +213,21 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_opts.radius.bottom_left = m_conf.get(bs, "radius-bottom-left", bottom);
   m_opts.radius.bottom_right = m_conf.get(bs, "radius-bottom-right", bottom);
 
-  auto padding = m_conf.get<unsigned int>(bs, "padding", 0U);
-  m_opts.padding.left = m_conf.get(bs, "padding-left", padding);
-  m_opts.padding.right = m_conf.get(bs, "padding-right", padding);
+  auto padding = parse_size_with_unit("padding", space_size{});
+  m_opts.padding.left = parse_size_with_unit("padding-left", padding);
+  m_opts.padding.right = parse_size_with_unit("padding-right", padding);
 
-  auto margin = m_conf.get<unsigned int>(bs, "module-margin", 0U);
-  m_opts.module_margin.left = m_conf.get(bs, "module-margin-left", margin);
-  m_opts.module_margin.right = m_conf.get(bs, "module-margin-right", margin);
+  auto margin = parse_size_with_unit("module-margin", space_size{});
+  m_opts.module_margin.left = parse_size_with_unit("module-margin-left", margin);
+  m_opts.module_margin.right = parse_size_with_unit("module-margin-right", margin);
 
   if (only_initialize_values) {
     return;
   }
 
   // Load values used to adjust the struts atom
-  m_opts.strut.top = m_conf.get("global/wm", "margin-top", 0);
-  m_opts.strut.bottom = m_conf.get("global/wm", "margin-bottom", 0);
+  m_opts.strut.top = m_conf.get("global/wm", "margin-top", 0U);
+  m_opts.strut.bottom = m_conf.get("global/wm", "margin-bottom", 0U);
 
   // Load commands used for fallback click handlers
   vector<action> actions;
@@ -239,44 +280,47 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   // Load over-/underline
   auto line_color = m_conf.get(bs, "line-color", rgba{0xFFFF0000});
-  auto line_size = m_conf.get(bs, "line-size", 0);
+  auto line_size = parse_size_with_unit("line-size", space_size{space_type::PIXEL, 0U});
 
-  m_opts.overline.size = m_conf.get(bs, "overline-size", line_size);
+  auto overline_size = parse_size_with_unit("overline-size", line_size);
+  auto underline_size = parse_size_with_unit("underline-size", line_size);
+
+  m_opts.overline.size = static_cast<unsigned int>(unit_utils::space_type_to_pixel(overline_size, m_opts.dpi_y));
   m_opts.overline.color = parse_or_throw_color("overline-color", line_color);
-  m_opts.underline.size = m_conf.get(bs, "underline-size", line_size);
+  m_opts.underline.size = static_cast<unsigned int>(unit_utils::space_type_to_pixel(underline_size, m_opts.dpi_y));
   m_opts.underline.color = parse_or_throw_color("underline-color", line_color);
 
   // Load border settings
   auto border_color = m_conf.get(bs, "border-color", rgba{0x00000000});
-  auto border_size = m_conf.get(bs, "border-size", ""s);
+  auto border_size = m_conf.get(bs, "border-size", geometry_format_values{});
   auto border_top = m_conf.deprecated(bs, "border-top", "border-top-size", border_size);
   auto border_bottom = m_conf.deprecated(bs, "border-bottom", "border-bottom-size", border_size);
   auto border_left = m_conf.deprecated(bs, "border-left", "border-left-size", border_size);
   auto border_right = m_conf.deprecated(bs, "border-right", "border-right-size", border_size);
 
   m_opts.borders.emplace(edge::TOP, border_settings{});
-  m_opts.borders[edge::TOP].size = geom_format_to_pixels(border_top, m_opts.monitor->h);
+  m_opts.borders[edge::TOP].size = geom_format_to_pixels(border_top, m_opts.monitor->h, m_opts.dpi_y);
   m_opts.borders[edge::TOP].color = parse_or_throw_color("border-top-color", border_color);
   m_opts.borders.emplace(edge::BOTTOM, border_settings{});
-  m_opts.borders[edge::BOTTOM].size = geom_format_to_pixels(border_bottom, m_opts.monitor->h);
+  m_opts.borders[edge::BOTTOM].size = geom_format_to_pixels(border_bottom, m_opts.monitor->h, m_opts.dpi_y);
   m_opts.borders[edge::BOTTOM].color = parse_or_throw_color("border-bottom-color", border_color);
   m_opts.borders.emplace(edge::LEFT, border_settings{});
-  m_opts.borders[edge::LEFT].size = geom_format_to_pixels(border_left, m_opts.monitor->w);
+  m_opts.borders[edge::LEFT].size = geom_format_to_pixels(border_left, m_opts.monitor->w, m_opts.dpi_x);
   m_opts.borders[edge::LEFT].color = parse_or_throw_color("border-left-color", border_color);
   m_opts.borders.emplace(edge::RIGHT, border_settings{});
-  m_opts.borders[edge::RIGHT].size = geom_format_to_pixels(border_right, m_opts.monitor->w);
+  m_opts.borders[edge::RIGHT].size = geom_format_to_pixels(border_right, m_opts.monitor->w, m_opts.dpi_x);
   m_opts.borders[edge::RIGHT].color = parse_or_throw_color("border-right-color", border_color);
 
   // Load geometry values
-  auto w = m_conf.get(m_conf.section(), "width", "100%"s);
-  auto h = m_conf.get(m_conf.section(), "height", "24"s);
-  auto offsetx = m_conf.get(m_conf.section(), "offset-x", ""s);
-  auto offsety = m_conf.get(m_conf.section(), "offset-y", ""s);
+  auto w = m_conf.get(m_conf.section(), "width", geometry_format_values{100.});
+  auto h = m_conf.get(m_conf.section(), "height", geometry_format_values{0., {size_type::PIXEL, 24}});
+  auto offsetx = m_conf.get(m_conf.section(), "offset-x", geometry_format_values{});
+  auto offsety = m_conf.get(m_conf.section(), "offset-y", geometry_format_values{});
 
-  m_opts.size.w = geom_format_to_pixels(w, m_opts.monitor->w);
-  m_opts.size.h = geom_format_to_pixels(h, m_opts.monitor->h);
-  m_opts.offset.x = geom_format_to_pixels(offsetx, m_opts.monitor->w);
-  m_opts.offset.y = geom_format_to_pixels(offsety, m_opts.monitor->h);
+  m_opts.size.w = geom_format_to_pixels(w, m_opts.monitor->w, m_opts.dpi_x);
+  m_opts.size.h = geom_format_to_pixels(h, m_opts.monitor->h, m_opts.dpi_y);
+  m_opts.offset.x = geom_format_to_pixels(offsetx, m_opts.monitor->w, m_opts.dpi_x);
+  m_opts.offset.y = geom_format_to_pixels(offsety, m_opts.monitor->h, m_opts.dpi_y);
 
   // Apply offsets
   m_opts.pos.x = m_opts.offset.x + m_opts.monitor->x;
@@ -294,9 +338,11 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
     throw application_error("Resulting bar height is out of bounds (" + to_string(m_opts.size.h) + ")");
   }
 
+  // clang-format off
   m_log.info("Bar geometry: %ix%i+%i+%i; Borders: %d,%d,%d,%d", m_opts.size.w, m_opts.size.h, m_opts.pos.x,
       m_opts.pos.y, m_opts.borders[edge::TOP].size, m_opts.borders[edge::RIGHT].size, m_opts.borders[edge::BOTTOM].size,
       m_opts.borders[edge::LEFT].size);
+  // clang-format on
 
   m_log.trace("bar: Attach X event sink");
   m_connection.attach_sink(this, SINK_PRIORITY_BAR);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -329,11 +329,9 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
     throw application_error("Resulting bar height is out of bounds (" + to_string(m_opts.size.h) + ")");
   }
 
-  // clang-format off
   m_log.info("Bar geometry: %ix%i+%i+%i; Borders: %d,%d,%d,%d", m_opts.size.w, m_opts.size.h, m_opts.pos.x,
       m_opts.pos.y, m_opts.borders[edge::TOP].size, m_opts.borders[edge::RIGHT].size, m_opts.borders[edge::BOTTOM].size,
       m_opts.borders[edge::LEFT].size);
-  // clang-format on
 
   m_log.trace("bar: Attach X event sink");
   m_connection.attach_sink(this, SINK_PRIORITY_BAR);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -217,8 +217,10 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   }
 
   // Load values used to adjust the struts atom
-  m_opts.strut.top = m_conf.get("global/wm", "margin-top", 0U);
-  m_opts.strut.bottom = m_conf.get("global/wm", "margin-bottom", 0U);
+  auto margin_top = m_conf.get("global/wm", "margin-top", percentage_with_offset{});
+  auto margin_bottom = m_conf.get("global/wm", "margin-bottom", percentage_with_offset{});
+  m_opts.strut.top = percentage_with_offset_to_pixel(margin_top, m_opts.monitor->h, m_opts.dpi_y);
+  m_opts.strut.bottom = percentage_with_offset_to_pixel(margin_bottom, m_opts.monitor->h, m_opts.dpi_y);
 
   // Load commands used for fallback click handlers
   vector<action> actions;

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -161,7 +161,7 @@ void builder::node(const label_t& label) {
     color_close();
   }
 
-  if (!label->m_underline.has_color() || (label->m_margin.right.value > 0 && m_tags[syntaxtag::u] > 0)) {
+  if (label->m_underline.has_color()) {
     underline_close();
   }
   if (!label->m_overline.has_color() || (label->m_margin.right.value > 0 && m_tags[syntaxtag::o] > 0)) {

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -164,7 +164,7 @@ void builder::node(const label_t& label) {
   if (label->m_underline.has_color()) {
     underline_close();
   }
-  if (!label->m_overline.has_color() || (label->m_margin.right.value > 0 && m_tags[syntaxtag::o] > 0)) {
+  if (label->m_overline.has_color()) {
     overline_close();
   }
 

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -127,7 +127,7 @@ void builder::node(const label_t& label) {
   auto text = label->get();
 
   if (label->m_margin.left.value > 0) {
-    space(label->m_margin.left);
+    spacing(label->m_margin.left);
   }
 
   if (label->m_overline.has_color()) {
@@ -145,13 +145,13 @@ void builder::node(const label_t& label) {
   }
 
   if (label->m_padding.left.value > 0) {
-    space(label->m_padding.left);
+    spacing(label->m_padding.left);
   }
 
   node(text, label->m_font);
 
   if (label->m_padding.right.value > 0) {
-    space(label->m_padding.right);
+    spacing(label->m_padding.right);
   }
 
   if (label->m_background.has_color()) {
@@ -169,7 +169,7 @@ void builder::node(const label_t& label) {
   }
 
   if (label->m_margin.right.value > 0) {
-    space(label->m_margin.right);
+    spacing(label->m_margin.right);
   }
 }
 
@@ -203,26 +203,26 @@ void builder::node_repeat(const label_t& label, size_t n) {
 /**
  * Insert tag that will offset the contents by given pixels
  */
-void builder::offset(geometry pixels) {
+void builder::offset(extent_val pixels) {
   if (pixels.value == 0) {
     return;
   }
-  tag_open(syntaxtag::O, unit_utils::geometry_to_string(pixels));
+  tag_open(syntaxtag::O, unit_utils::extent_to_string(pixels));
 }
 
 /**
  * Insert spaces
  */
-void builder::space(space_size size) {
+void builder::spacing(spacing_val size) {
   if (size.value > 0.) {
     m_output += add_surrounding_tag(size);
   } else {
-    space();
+    spacing();
   }
 }
-void builder::space() {
+void builder::spacing() {
   if (m_bar.spacing.value > 0) {
-    space(m_bar.spacing);
+    spacing(m_bar.spacing);
   }
 }
 
@@ -576,19 +576,19 @@ void builder::tag_close(attribute attr) {
       break;
   }
 }
-string builder::add_surrounding_tag(const space_size& space) {
+string builder::add_surrounding_tag(const spacing_val& space) {
   if (space.value == 0) {
     return "";
   }
 
   string out;
-  if (space.type == space_type::POINT || space.type == space_type::PIXEL) {
+  if (space.type == spacing_type::POINT || space.type == spacing_type::PIXEL) {
     out += "%{O";
   }
 
-  out += unit_utils::space_size_to_string(space);
+  out += unit_utils::spacing_to_string(space);
 
-  if (space.type == space_type::POINT || space.type == space_type::PIXEL) {
+  if (space.type == spacing_type::POINT || space.type == spacing_type::PIXEL) {
     out += '}';
   }
 

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -254,7 +254,7 @@ percentage_with_offset config::convert(string&& value) const {
 
   if (i == std::string::npos) {
     if (value.find('%') != std::string::npos) {
-      return {strtod(value.c_str(), nullptr), {}};
+      return {std::stoi(value), {}};
     } else {
       return {0., convert<extent_val>(move(value))};
     }

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -213,8 +213,8 @@ unsigned long long config::convert(string&& value) const {
 
 template <>
 spacing_val config::convert(string&& value) const {
-  char* new_end;
-  auto size_value = std::strtof(value.c_str(), &new_end);
+  size_t pos;
+  auto size_value = std::stof(value, &pos);
 
   if (size_value < 0) {
     throw application_error(sstream() << "Value: " << value << " must be positive ");
@@ -222,7 +222,7 @@ spacing_val config::convert(string&& value) const {
 
   spacing_val size{spacing_type::SPACE, size_value};
 
-  string unit = string_util::trim(new_end);
+  string unit = string_util::trim(value.substr(pos));
   if (!unit.empty()) {
     if (unit == "px") {
       size.type = spacing_type::PIXEL;

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -260,7 +260,7 @@ percentage_with_offset config::convert(string&& value) const {
     }
   } else {
     std::string percentage = value.substr(0, i - 1);
-    return {strtod(percentage.c_str(), nullptr), convert<extent_val>(value.substr(i + 1))};
+    return {std::stoi(percentage), convert<extent_val>(value.substr(i + 1))};
   }
 }
 

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -1,11 +1,11 @@
 #include "components/config.hpp"
-#include "components/types.hpp"
 
 #include <climits>
 #include <cmath>
 #include <fstream>
 
 #include "cairo/utils.hpp"
+#include "components/types.hpp"
 #include "utils/color.hpp"
 #include "utils/env.hpp"
 #include "utils/factory.hpp"

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -220,21 +220,24 @@ spacing_val config::convert(string&& value) const {
     throw application_error(sstream() << "Value: " << value << " must be positive ");
   }
 
-  spacing_val size{spacing_type::SPACE, size_value};
+  spacing_type type;
 
   string unit = string_util::trim(value.substr(pos));
   if (!unit.empty()) {
     if (unit == "px") {
-      size.type = spacing_type::PIXEL;
-      size.value = std::trunc(size.value);
+      type = spacing_type::PIXEL;
+      size_value = std::trunc(size_value);
     } else if (unit == "pt") {
-      size.type = spacing_type::POINT;
+      type = spacing_type::POINT;
     } else {
-      size.value = std::trunc(size.value);
+      throw value_error("Unrecognized unit '" + unit + "'");
     }
+  } else {
+    type = spacing_type::SPACE;
+    size_value = std::trunc(size_value);
   }
 
-  return size;
+  return {type, size_value};
 }
 
 template <>

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -254,13 +254,13 @@ percentage_with_offset config::convert(string&& value) const {
 
   if (i == std::string::npos) {
     if (value.find('%') != std::string::npos) {
-      return {std::stoi(value), {}};
+      return {std::stod(value), {}};
     } else {
       return {0., convert<extent_val>(move(value))};
     }
   } else {
     std::string percentage = value.substr(0, i - 1);
-    return {std::stoi(percentage), convert<extent_val>(value.substr(i + 1))};
+    return {std::stod(percentage), convert<extent_val>(value.substr(i + 1))};
   }
 }
 

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -212,7 +212,7 @@ unsigned long long config::convert(string&& value) const {
 }
 
 template <>
-space_size config::convert(string&& value) const {
+spacing_val config::convert(string&& value) const {
   char* new_end;
   auto size_value = std::strtof(value.c_str(), &new_end);
 
@@ -220,15 +220,15 @@ space_size config::convert(string&& value) const {
     throw application_error(sstream() << "Value: " << value << " must be positive ");
   }
 
-  space_size size{space_type::SPACE, size_value};
+  spacing_val size{spacing_type::SPACE, size_value};
 
   string unit = string_util::trim(new_end);
   if (!unit.empty()) {
     if (unit == "px") {
-      size.type = space_type::PIXEL;
+      size.type = spacing_type::PIXEL;
       size.value = std::trunc(size.value);
     } else if (unit == "pt") {
-      size.type = space_type::POINT;
+      size.type = spacing_type::POINT;
     } else {
       size.value = std::trunc(size.value);
     }
@@ -238,8 +238,8 @@ space_size config::convert(string&& value) const {
 }
 
 template <>
-geometry config::convert(std::string&& value) const {
-  return unit_utils::geometry_from_string(move(value));
+extent_val config::convert(std::string&& value) const {
+  return unit_utils::parse_extent(move(value));
 }
 
 /**
@@ -249,18 +249,18 @@ geometry config::convert(std::string&& value) const {
  * describing a pixel offset. The actual value is calculated by X% * max + Z
  */
 template <>
-geometry_format_values config::convert(string&& value) const {
+percentage_with_offset config::convert(string&& value) const {
   size_t i = value.find(':');
 
   if (i == std::string::npos) {
     if (value.find('%') != std::string::npos) {
       return {strtod(value.c_str(), nullptr), {}};
     } else {
-      return {0., convert<geometry>(move(value))};
+      return {0., convert<extent_val>(move(value))};
     }
   } else {
     std::string percentage = value.substr(0, i - 1);
-    return {strtod(percentage.c_str(), nullptr), convert<geometry>(value.substr(i + 1))};
+    return {strtod(percentage.c_str(), nullptr), convert<extent_val>(value.substr(i + 1))};
   }
 }
 

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -573,10 +573,10 @@ void controller::process_inputdata() {
 bool controller::process_update(bool force) {
   const bar_settings& bar{m_bar->settings()};
   string contents;
-  string padding_left = builder::add_surrounding_tag(bar.padding.left);
-  string padding_right = builder::add_surrounding_tag(bar.padding.right);
-  string margin_left = builder::add_surrounding_tag(bar.module_margin.left);
-  string margin_right = builder::add_surrounding_tag(bar.module_margin.right);
+  string padding_left = builder::get_spacing_format_string(bar.padding.left);
+  string padding_right = builder::get_spacing_format_string(bar.padding.right);
+  string margin_left = builder::get_spacing_format_string(bar.module_margin.left);
+  string margin_right = builder::get_spacing_format_string(bar.module_margin.right);
 
   builder build{bar};
   build.node(bar.separator);

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -573,10 +573,10 @@ void controller::process_inputdata() {
 bool controller::process_update(bool force) {
   const bar_settings& bar{m_bar->settings()};
   string contents;
-  string padding_left(bar.padding.left, ' ');
-  string padding_right(bar.padding.right, ' ');
-  string margin_left(bar.module_margin.left, ' ');
-  string margin_right(bar.module_margin.right, ' ');
+  string padding_left = builder::add_surrounding_tag(bar.padding.left);
+  string padding_right = builder::add_surrounding_tag(bar.padding.right);
+  string margin_left = builder::add_surrounding_tag(bar.module_margin.left);
+  string margin_right = builder::add_surrounding_tag(bar.module_margin.right);
 
   builder build{bar};
   build.node(bar.separator);

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -746,7 +746,7 @@ void renderer::draw_offset(rgba color, double x, double w) {
   }
 }
 
-void renderer::render_offset(const tags::context& ctxt, geometry offset) {
+void renderer::render_offset(const tags::context& ctxt, const geometry offset) {
   m_log.trace_x("renderer: offset_pixel(%f)", offset);
 
   int offset_width = unit_utils::geometry_to_pixel(offset, m_bar.dpi_x);

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -746,10 +746,10 @@ void renderer::draw_offset(rgba color, double x, double w) {
   }
 }
 
-void renderer::render_offset(const tags::context& ctxt, const geometry offset) {
+void renderer::render_offset(const tags::context& ctxt, const extent_val offset) {
   m_log.trace_x("renderer: offset_pixel(%f)", offset);
 
-  int offset_width = unit_utils::geometry_to_pixel(offset, m_bar.dpi_x);
+  int offset_width = unit_utils::extent_to_pixel(offset, m_bar.dpi_x);
   rgba bg = ctxt.get_bg();
   draw_offset(bg, m_blocks[m_align].x, offset_width);
   m_blocks[m_align].x += offset_width;

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -264,7 +264,7 @@ void renderer::end() {
   // the bar will be filled by the wallpaper creating illusion of transparency.
   if (m_pseudo_transparency) {
     cairo_pattern_t* barcontents{};
-    m_context->pop(&barcontents);  // corresponding push is in renderer::begin
+    m_context->pop(&barcontents); // corresponding push is in renderer::begin
 
     auto root_bg = m_background->get_surface();
     if (root_bg != nullptr) {

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -196,7 +196,7 @@ namespace drawtypes {
         }
       };
 
-      auto value = parse_or_throw(key, spacing_val{});
+      auto value = parse_or_throw(key, ZERO_SPACE);
       auto left = parse_or_throw(key + "-left", value);
       auto right = parse_or_throw(key + "-right", value);
       return side_values{left, right};

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -187,7 +187,7 @@ namespace drawtypes {
     }
 
     const auto get_left_right = [&](string&& key) {
-      const auto parse_or_throw = [&](const string& key, space_size default_value) {
+      const auto parse_or_throw = [&](const string& key, spacing_val default_value) {
         try {
           return conf.get(section, key, default_value);
         } catch (const std::exception& err) {
@@ -196,7 +196,7 @@ namespace drawtypes {
         }
       };
 
-      auto value = parse_or_throw(key, space_size{});
+      auto value = parse_or_throw(key, spacing_val{});
       auto left = parse_or_throw(key + "-left", value);
       auto right = parse_or_throw(key + "-right", value);
       return side_values{left, right};

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -388,7 +388,7 @@ namespace modules {
     string output;
     for (m_index = 0U; m_index < m_monitors.size(); m_index++) {
       if (m_index > 0) {
-        m_builder->space(m_formatter->get(DEFAULT_FORMAT)->spacing);
+        m_builder->spacing(m_formatter->get(DEFAULT_FORMAT)->spacing);
       }
       output += this->event_module::get_output();
     }

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -112,7 +112,7 @@ namespace modules {
       auto i = 0;
       for (auto&& load : m_load) {
         if (i++ > 0) {
-          builder->space(m_ramp_padding);
+          builder->spacing(m_ramp_padding);
         }
         builder->node(m_rampload_core->get_by_percentage_with_borders(load, 0.0f, m_totalwarn));
       }

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -18,7 +18,7 @@ namespace modules {
   cpu_module::cpu_module(const bar_settings& bar, string name_) : timer_module<cpu_module>(bar, move(name_)) {
     set_interval(1s);
     m_totalwarn = m_conf.get(name(), "warn-percentage", m_totalwarn);
-    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-coreload-spacing", 1);
+    m_ramp_padding = m_conf.get(name(), "ramp-coreload-spacing", m_ramp_padding);
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
     m_formatter->add_optional(FORMAT_WARN, {TAG_LABEL_WARN, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -1,14 +1,13 @@
+#include "modules/cpu.hpp"
+
 #include <fstream>
 #include <istream>
-
-#include "modules/cpu.hpp"
 
 #include "drawtypes/label.hpp"
 #include "drawtypes/progressbar.hpp"
 #include "drawtypes/ramp.hpp"
-#include "utils/math.hpp"
-
 #include "modules/meta/base.inl"
+#include "utils/math.hpp"
 
 POLYBAR_NS
 
@@ -73,7 +72,8 @@ namespace modules {
     const auto replace_tokens = [&](label_t& label) {
       label->reset_tokens();
       label->replace_token("%percentage%", to_string(static_cast<int>(m_total + 0.5)));
-      label->replace_token("%percentage-sum%", to_string(static_cast<int>(m_total * static_cast<float>(cores_n) + 0.5)));
+      label->replace_token(
+          "%percentage-sum%", to_string(static_cast<int>(m_total * static_cast<float>(cores_n) + 0.5)));
       label->replace_token("%percentage-cores%", string_util::join(percentage_cores, "% ") + "%");
 
       for (size_t i = 0; i < percentage_cores.size(); i++) {
@@ -98,7 +98,6 @@ namespace modules {
       return DEFAULT_FORMAT;
     }
   }
-
 
   bool cpu_module::build(builder* builder, const string& tag) const {
     if (tag == TAG_LABEL) {
@@ -179,6 +178,6 @@ namespace modules {
 
     return math_util::cap<float>(percentage, 0, 100);
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -1,15 +1,16 @@
+#include "modules/fs.hpp"
+
 #include <sys/statvfs.h>
+
 #include <fstream>
 
 #include "drawtypes/label.hpp"
 #include "drawtypes/progressbar.hpp"
 #include "drawtypes/ramp.hpp"
-#include "modules/fs.hpp"
+#include "modules/meta/base.inl"
 #include "utils/factory.hpp"
 #include "utils/math.hpp"
 #include "utils/string.hpp"
-
-#include "modules/meta/base.inl"
 
 POLYBAR_NS
 
@@ -142,7 +143,7 @@ namespace modules {
        * are not empty and there is already other content in the module.
        */
       if (!output.empty() && !mount_output.empty()) {
-        m_builder->space(m_spacing);
+        m_builder->spacing(m_spacing);
         output += m_builder->flush();
       }
       output += mount_output;

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -77,7 +77,7 @@ namespace modules {
       // Insert separator after menu-toggle and before menu-items for expand-right=true
       if (m_expand_right && *m_labelseparator) {
         builder->node(m_labelseparator);
-        builder->space(spacing);
+        builder->spacing(spacing);
       }
       auto&& items = m_levels[m_level]->items;
       for (size_t i = 0; i < items.size(); i++) {
@@ -85,14 +85,14 @@ namespace modules {
         builder->action(
             mousebtn::LEFT, *this, string(EVENT_EXEC), to_string(m_level) + "-" + to_string(i), item->label);
         if (item != m_levels[m_level]->items.back()) {
-          builder->space(spacing);
+          builder->spacing(spacing);
           if (*m_labelseparator) {
             builder->node(m_labelseparator);
-            builder->space(spacing);
+            builder->spacing(spacing);
           }
           // Insert separator after last menu-item and before menu-toggle for expand-right=false
         } else if (!m_expand_right && *m_labelseparator) {
-          builder->space(spacing);
+          builder->spacing(spacing);
           builder->node(m_labelseparator);
         }
       }

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -87,8 +87,9 @@ namespace modules {
   // module_formatter {{{
 
   void module_formatter::add_value(string&& name, string&& value, vector<string>&& tags, vector<string>&& whitelist) {
-    const auto formatdef = [&](
-        const string& param, const auto& fallback) { return m_conf.get("settings", "format-" + param, fallback); };
+    const auto formatdef = [&](const string& param, const auto& fallback) {
+      return m_conf.get("settings", "format-" + param, fallback);
+    };
 
     auto format = make_unique<module_format>();
     format->value = move(value);

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -19,7 +19,7 @@ namespace modules {
       builder->offset(offset);
     }
     if (margin.value > 0) {
-      builder->space(margin);
+      builder->spacing(margin);
     }
     if (bg.has_color()) {
       builder->background(bg);
@@ -37,7 +37,7 @@ namespace modules {
       builder->font(font);
     }
     if (padding.value > 0) {
-      builder->space(padding);
+      builder->spacing(padding);
     }
 
     builder->node(prefix);
@@ -59,7 +59,7 @@ namespace modules {
     builder->node(suffix);
 
     if (padding.value > 0) {
-      builder->space(padding);
+      builder->spacing(padding);
     }
     if (font > 0) {
       builder->font_close();
@@ -77,7 +77,7 @@ namespace modules {
       builder->background_close();
     }
     if (margin.value > 0) {
-      builder->space(margin);
+      builder->spacing(margin);
     }
 
     return builder->flush();

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -15,10 +15,10 @@ namespace modules {
       builder->flush();
       return "";
     }
-    if (offset != 0) {
+    if (offset.value != 0) {
       builder->offset(offset);
     }
-    if (margin > 0) {
+    if (margin.value > 0) {
       builder->space(margin);
     }
     if (bg.has_color()) {
@@ -36,7 +36,7 @@ namespace modules {
     if (font > 0) {
       builder->font(font);
     }
-    if (padding > 0) {
+    if (padding.value > 0) {
       builder->space(padding);
     }
 
@@ -58,7 +58,7 @@ namespace modules {
     builder->append(move(output));
     builder->node(suffix);
 
-    if (padding > 0) {
+    if (padding.value > 0) {
       builder->space(padding);
     }
     if (font > 0) {
@@ -76,7 +76,7 @@ namespace modules {
     if (bg.has_color()) {
       builder->background_close();
     }
-    if (margin > 0) {
+    if (margin.value > 0) {
       builder->space(margin);
     }
 

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -194,7 +194,7 @@ namespace modules {
       for (auto&& indicator : m_indicators) {
         if (*indicator.second) {
           if (n++) {
-            builder->space(m_formatter->get(DEFAULT_FORMAT)->spacing);
+            builder->spacing(m_formatter->get(DEFAULT_FORMAT)->spacing);
           }
           builder->node(indicator.second);
         }

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -331,7 +331,7 @@ namespace modules {
     string output;
     for (m_index = 0; m_index < m_viewports.size(); m_index++) {
       if (m_index > 0) {
-        m_builder->space(m_formatter->get(DEFAULT_FORMAT)->spacing);
+        m_builder->spacing(m_formatter->get(DEFAULT_FORMAT)->spacing);
       }
       output += module::get_output();
     }

--- a/src/tags/parser.cpp
+++ b/src/tags/parser.cpp
@@ -340,26 +340,18 @@ namespace tags {
     }
   }
 
-  int parser::parse_offset() {
+  geometry parser::parse_offset() {
     string s = get_tag_value();
 
     if (s.empty()) {
-      return 0;
+      return GEOMETRY_ZERO_PIXEL;
     }
 
     try {
-      size_t ptr;
-      int ret = std::stoi(s, &ptr, 10);
-
-      if (ptr != s.size()) {
-        throw offset_error(s, "Offset contains non-number characters");
-      }
-
-      return ret;
+      return unit_utils::geometry_from_string(string{s});
     } catch (const std::exception& err) {
       throw offset_error(s, err.what());
     }
-    return 0;
   }
 
   controltag parser::parse_control() {

--- a/src/tags/parser.cpp
+++ b/src/tags/parser.cpp
@@ -340,15 +340,15 @@ namespace tags {
     }
   }
 
-  geometry parser::parse_offset() {
+  extent_val parser::parse_offset() {
     string s = get_tag_value();
 
     if (s.empty()) {
-      return GEOMETRY_ZERO_PIXEL;
+      return ZERO_PX_EXTENT;
     }
 
     try {
-      return unit_utils::geometry_from_string(string{s});
+      return unit_utils::parse_extent(string{s});
     } catch (const std::exception& err) {
       throw offset_error(s, err.what());
     }

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -1,9 +1,7 @@
-#include "common/test.hpp"
 #include "components/bar.hpp"
+#include "common/test.hpp"
 
 using namespace polybar;
-
-
 
 /**
  * \brief Class for parameterized tests on geom_format_to_pixels
@@ -11,38 +9,44 @@ using namespace polybar;
  * The first element in the tuple is the expected return value, the second
  * value is the format string. The max value is always 1000
  */
-class GeomFormatToPixelsTest :
-  public ::testing::Test,
-  public ::testing::WithParamInterface<pair<double, string>> {};
+class GeomFormatToPixelsTest : public ::testing::Test,
+                               public ::testing::WithParamInterface<pair<unsigned int, geometry_format_values>> {};
 
-vector<pair<double, string>> to_pixels_no_offset_list = {
-  {1000, "100%"},
-  {0, "0%"},
-  {1000, "150%"},
-  {100, "10%"},
-  {0, "0"},
-  {1234, "1234"},
-  {1.234, "1.234"},
+vector<pair<unsigned int, geometry_format_values>> to_pixels_no_offset_list = {
+    {1000, geometry_format_values{100.}},
+    {0, geometry_format_values{0.}},
+    {1000, geometry_format_values{150.}},
+    {100, geometry_format_values{10.}},
+    {0, geometry_format_values{0., geometry{size_type::PIXEL, 0}}},
+    {1234, geometry_format_values{0., geometry{size_type::PIXEL, 1234}}},
+    {1, geometry_format_values{0., geometry{size_type::PIXEL, 1}}},
 };
 
-vector<pair<double, string>> to_pixels_with_offset_list = {
-  {1000, "100%:-0"},
-  {1000, "100%:+0"},
-  {1010, "100%:+10"},
-  {990, "100%:-10"},
-  {10, "0%:+10"},
-  {1000, "99%:+10"},
-  {0, "1%:-100"},
+vector<pair<unsigned int, geometry_format_values>> to_pixels_with_offset_list = {
+    {1000, geometry_format_values{100., geometry{size_type::PIXEL, 0}}},
+    {1010, geometry_format_values{100., geometry{size_type::PIXEL, 10}}},
+    {990, geometry_format_values{100., geometry{size_type::PIXEL, -10}}},
+    {10, geometry_format_values{0., geometry{size_type::PIXEL, 10}}},
+    {1000, geometry_format_values{99., geometry{size_type::PIXEL, 10}}},
+    {0, geometry_format_values{1., geometry{size_type::PIXEL, -100}}},
 };
 
-INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest,
-    ::testing::ValuesIn(to_pixels_no_offset_list));
+vector<pair<unsigned int, geometry_format_values>> to_pixels_with_units_list = {
+    {1013, geometry_format_values{100., geometry{size_type::POINT, 10}}},
+    {987, geometry_format_values{100., geometry{size_type::POINT, -10}}},
+    {1003, geometry_format_values{99., geometry{size_type::POINT, 10}}},
+    {13, geometry_format_values{0., geometry{size_type::POINT, 10}}},
+    {0, geometry_format_values{0, geometry{size_type::POINT, -10}}},
+};
 
-INSTANTIATE_TEST_SUITE_P(WithOffset, GeomFormatToPixelsTest,
-    ::testing::ValuesIn(to_pixels_with_offset_list));
+INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_no_offset_list));
+
+INSTANTIATE_TEST_SUITE_P(WithOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_with_offset_list));
+
+INSTANTIATE_TEST_SUITE_P(WithUnits, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_with_units_list));
 
 TEST_P(GeomFormatToPixelsTest, correctness) {
-  double exp = GetParam().first;
-  std::string str = GetParam().second;
-  EXPECT_DOUBLE_EQ(exp, geom_format_to_pixels(str, 1000));
+  unsigned int exp = GetParam().first;
+  polybar::geometry_format_values geometry = GetParam().second;
+  EXPECT_DOUBLE_EQ(exp, geom_format_to_pixels(geometry, 1000, 96));
 }

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -49,5 +49,5 @@ INSTANTIATE_TEST_SUITE_P(WithUnits, GeomFormatToPixelsTest, ::testing::ValuesIn(
 TEST_P(GeomFormatToPixelsTest, correctness) {
   unsigned int exp = GetParam().first;
   polybar::percentage_with_offset geometry = GetParam().second;
-  EXPECT_DOUBLE_EQ(exp, geom_format_to_pixels(geometry, 1000, 96));
+  EXPECT_DOUBLE_EQ(exp, percentage_with_offset_to_pixel(geometry, 1000, 96));
 }

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -1,4 +1,5 @@
 #include "components/bar.hpp"
+
 #include "common/test.hpp"
 
 using namespace polybar;

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -11,33 +11,33 @@ using namespace polybar;
  * value is the format string. The max value is always 1000
  */
 class GeomFormatToPixelsTest : public ::testing::Test,
-                               public ::testing::WithParamInterface<pair<unsigned int, geometry_format_values>> {};
+                               public ::testing::WithParamInterface<pair<unsigned int, percentage_with_offset>> {};
 
-vector<pair<unsigned int, geometry_format_values>> to_pixels_no_offset_list = {
-    {1000, geometry_format_values{100.}},
-    {0, geometry_format_values{0.}},
-    {1000, geometry_format_values{150.}},
-    {100, geometry_format_values{10.}},
-    {0, geometry_format_values{0., geometry{size_type::PIXEL, 0}}},
-    {1234, geometry_format_values{0., geometry{size_type::PIXEL, 1234}}},
-    {1, geometry_format_values{0., geometry{size_type::PIXEL, 1}}},
+vector<pair<unsigned int, percentage_with_offset>> to_pixels_no_offset_list = {
+    {1000, percentage_with_offset{100.}},
+    {0, percentage_with_offset{0.}},
+    {1000, percentage_with_offset{150.}},
+    {100, percentage_with_offset{10.}},
+    {0, percentage_with_offset{0., ZERO_PX_EXTENT}},
+    {1234, percentage_with_offset{0., extent_val{extent_type::PIXEL, 1234}}},
+    {1, percentage_with_offset{0., extent_val{extent_type::PIXEL, 1}}},
 };
 
-vector<pair<unsigned int, geometry_format_values>> to_pixels_with_offset_list = {
-    {1000, geometry_format_values{100., geometry{size_type::PIXEL, 0}}},
-    {1010, geometry_format_values{100., geometry{size_type::PIXEL, 10}}},
-    {990, geometry_format_values{100., geometry{size_type::PIXEL, -10}}},
-    {10, geometry_format_values{0., geometry{size_type::PIXEL, 10}}},
-    {1000, geometry_format_values{99., geometry{size_type::PIXEL, 10}}},
-    {0, geometry_format_values{1., geometry{size_type::PIXEL, -100}}},
+vector<pair<unsigned int, percentage_with_offset>> to_pixels_with_offset_list = {
+    {1000, percentage_with_offset{100., ZERO_PX_EXTENT}},
+    {1010, percentage_with_offset{100., extent_val{extent_type::PIXEL, 10}}},
+    {990, percentage_with_offset{100., extent_val{extent_type::PIXEL, -10}}},
+    {10, percentage_with_offset{0., extent_val{extent_type::PIXEL, 10}}},
+    {1000, percentage_with_offset{99., extent_val{extent_type::PIXEL, 10}}},
+    {0, percentage_with_offset{1., extent_val{extent_type::PIXEL, -100}}},
 };
 
-vector<pair<unsigned int, geometry_format_values>> to_pixels_with_units_list = {
-    {1013, geometry_format_values{100., geometry{size_type::POINT, 10}}},
-    {987, geometry_format_values{100., geometry{size_type::POINT, -10}}},
-    {1003, geometry_format_values{99., geometry{size_type::POINT, 10}}},
-    {13, geometry_format_values{0., geometry{size_type::POINT, 10}}},
-    {0, geometry_format_values{0, geometry{size_type::POINT, -10}}},
+vector<pair<unsigned int, percentage_with_offset>> to_pixels_with_units_list = {
+    {1013, percentage_with_offset{100., extent_val{extent_type::POINT, 10}}},
+    {987, percentage_with_offset{100., extent_val{extent_type::POINT, -10}}},
+    {1003, percentage_with_offset{99., extent_val{extent_type::POINT, 10}}},
+    {13, percentage_with_offset{0., extent_val{extent_type::POINT, 10}}},
+    {0, percentage_with_offset{0, extent_val{extent_type::POINT, -10}}},
 };
 
 INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest, ::testing::ValuesIn(to_pixels_no_offset_list));
@@ -48,6 +48,6 @@ INSTANTIATE_TEST_SUITE_P(WithUnits, GeomFormatToPixelsTest, ::testing::ValuesIn(
 
 TEST_P(GeomFormatToPixelsTest, correctness) {
   unsigned int exp = GetParam().first;
-  polybar::geometry_format_values geometry = GetParam().second;
+  polybar::percentage_with_offset geometry = GetParam().second;
   EXPECT_DOUBLE_EQ(exp, geom_format_to_pixels(geometry, 1000, 96));
 }

--- a/tests/unit_tests/tags/dispatch.cpp
+++ b/tests/unit_tests/tags/dispatch.cpp
@@ -15,11 +15,17 @@ using ::testing::Property;
 using ::testing::Return;
 using ::testing::Truly;
 
+namespace polybar {
+  inline bool operator==(const geometry& a, const geometry& b) {
+    return a.type == b.type && a.value == b.value;
+  }
+}  // namespace polybar
+
 class MockRenderer : public renderer_interface {
  public:
   MockRenderer(action_context& action_ctxt) : renderer_interface(action_ctxt){};
 
-  MOCK_METHOD(void, render_offset, (const context& ctxt, int pixels), (override));
+  MOCK_METHOD(void, render_offset, (const context& ctxt, const geometry offset), (override));
   MOCK_METHOD(void, render_text, (const context& ctxt, const string&& str), (override));
   MOCK_METHOD(void, change_alignment, (const context& ctxt), (override));
   MOCK_METHOD(double, get_x, (const context& ctxt), (const, override));
@@ -53,7 +59,7 @@ class DispatchTest : public ::testing::Test {
 TEST_F(DispatchTest, ignoreFormatting) {
   {
     InSequence seq;
-    EXPECT_CALL(r, render_offset(_, 10)).Times(1);
+    EXPECT_CALL(r, render_offset(_, geometry{size_type::PIXEL, 10})).Times(1);
     EXPECT_CALL(r, render_text(_, string{"abc"})).Times(1);
     EXPECT_CALL(r, render_text(_, string{"foo"})).Times(1);
   }
@@ -74,7 +80,7 @@ TEST_F(DispatchTest, formatting) {
 
   {
     InSequence seq;
-    EXPECT_CALL(r, render_offset(_, 10)).Times(1);
+    EXPECT_CALL(r, render_offset(_, geometry{size_type::PIXEL, 10})).Times(1);
     EXPECT_CALL(r, render_text(match_fg(c1), string{"abc"})).Times(1);
     EXPECT_CALL(r, render_text(match_fg(bar_fg), string{"foo"})).Times(1);
     EXPECT_CALL(r, change_alignment(match_left_align)).Times(1);

--- a/tests/unit_tests/tags/dispatch.cpp
+++ b/tests/unit_tests/tags/dispatch.cpp
@@ -16,7 +16,7 @@ using ::testing::Return;
 using ::testing::Truly;
 
 namespace polybar {
-  inline bool operator==(const geometry& a, const geometry& b) {
+  inline bool operator==(const extent_val& a, const extent_val& b) {
     return a.type == b.type && a.value == b.value;
   }
 }  // namespace polybar
@@ -25,7 +25,7 @@ class MockRenderer : public renderer_interface {
  public:
   MockRenderer(action_context& action_ctxt) : renderer_interface(action_ctxt){};
 
-  MOCK_METHOD(void, render_offset, (const context& ctxt, const geometry offset), (override));
+  MOCK_METHOD(void, render_offset, (const context& ctxt, const extent_val offset), (override));
   MOCK_METHOD(void, render_text, (const context& ctxt, const string&& str), (override));
   MOCK_METHOD(void, change_alignment, (const context& ctxt), (override));
   MOCK_METHOD(double, get_x, (const context& ctxt), (const, override));
@@ -59,7 +59,7 @@ class DispatchTest : public ::testing::Test {
 TEST_F(DispatchTest, ignoreFormatting) {
   {
     InSequence seq;
-    EXPECT_CALL(r, render_offset(_, geometry{size_type::PIXEL, 10})).Times(1);
+    EXPECT_CALL(r, render_offset(_, extent_val{extent_type::PIXEL, 10})).Times(1);
     EXPECT_CALL(r, render_text(_, string{"abc"})).Times(1);
     EXPECT_CALL(r, render_text(_, string{"foo"})).Times(1);
   }
@@ -80,7 +80,7 @@ TEST_F(DispatchTest, formatting) {
 
   {
     InSequence seq;
-    EXPECT_CALL(r, render_offset(_, geometry{size_type::PIXEL, 10})).Times(1);
+    EXPECT_CALL(r, render_offset(_, extent_val{extent_type::PIXEL, 10})).Times(1);
     EXPECT_CALL(r, render_text(match_fg(c1), string{"abc"})).Times(1);
     EXPECT_CALL(r, render_text(match_fg(bar_fg), string{"foo"})).Times(1);
     EXPECT_CALL(r, change_alignment(match_left_align)).Times(1);

--- a/tests/unit_tests/tags/parser.cpp
+++ b/tests/unit_tests/tags/parser.cpp
@@ -75,10 +75,18 @@ class TestableTagParser : public parser {
     EXPECT_EQ(exp, current.tag_data.font);
   }
 
-  void expect_offset(int exp) {
+  void expect_offset_pixel(int exp) {
     set_current();
     assert_format(syntaxtag::O);
-    EXPECT_EQ(exp, current.tag_data.offset);
+    EXPECT_EQ(size_type::PIXEL, current.tag_data.offset.type);
+    EXPECT_EQ(exp, current.tag_data.offset.value);
+  }
+
+  void expect_offset_points(int exp) {
+    set_current();
+    assert_format(syntaxtag::O);
+    EXPECT_EQ(size_type::POINT, current.tag_data.offset.type);
+    EXPECT_EQ(exp, current.tag_data.offset.value);
   }
 
   void expect_ctrl(controltag exp) {
@@ -308,19 +316,31 @@ TEST_F(TagParserTest, font) {
 
 TEST_F(TagParserTest, offset) {
   p.setup_parser_test("%{O}");
-  p.expect_offset(0);
+  p.expect_offset_pixel(0);
   p.expect_done();
 
   p.setup_parser_test("%{O0}");
-  p.expect_offset(0);
+  p.expect_offset_pixel(0);
   p.expect_done();
 
   p.setup_parser_test("%{O-112}");
-  p.expect_offset(-112);
+  p.expect_offset_pixel(-112);
   p.expect_done();
 
   p.setup_parser_test("%{O123}");
-  p.expect_offset(123);
+  p.expect_offset_pixel(123);
+  p.expect_done();
+
+  p.setup_parser_test("%{O0pt}");
+  p.expect_offset_points(0);
+  p.expect_done();
+
+  p.setup_parser_test("%{O-112pt}");
+  p.expect_offset_points(-112);
+  p.expect_done();
+
+  p.setup_parser_test("%{O123pt}");
+  p.expect_offset_points(123);
   p.expect_done();
 }
 
@@ -408,6 +428,8 @@ vector<exception_test> parse_error_test = {
     {"%{P}", exc::CTRL},
     {"%{PA}", exc::CTRL},
     {"%{Oabc}", exc::OFFSET},
+    {"%{O0ptx}", exc::OFFSET},
+    {"%{O0a}", exc::OFFSET},
     {"%{A2:cmd:cmd:}", exc::TAG_END},
     {"%{A9}", exc::BTN},
     {"%{rQ}", exc::TAG_END},

--- a/tests/unit_tests/tags/parser.cpp
+++ b/tests/unit_tests/tags/parser.cpp
@@ -78,14 +78,14 @@ class TestableTagParser : public parser {
   void expect_offset_pixel(int exp) {
     set_current();
     assert_format(syntaxtag::O);
-    EXPECT_EQ(size_type::PIXEL, current.tag_data.offset.type);
+    EXPECT_EQ(extent_type::PIXEL, current.tag_data.offset.type);
     EXPECT_EQ(exp, current.tag_data.offset.value);
   }
 
   void expect_offset_points(int exp) {
     set_current();
     assert_format(syntaxtag::O);
-    EXPECT_EQ(size_type::POINT, current.tag_data.offset.type);
+    EXPECT_EQ(extent_type::POINT, current.tag_data.offset.type);
     EXPECT_EQ(exp, current.tag_data.offset.value);
   }
 

--- a/tests/unit_tests/tags/parser.cpp
+++ b/tests/unit_tests/tags/parser.cpp
@@ -82,7 +82,7 @@ class TestableTagParser : public parser {
     EXPECT_EQ(exp, current.tag_data.offset.value);
   }
 
-  void expect_offset_points(int exp) {
+  void expect_offset_points(float exp) {
     set_current();
     assert_format(syntaxtag::O);
     EXPECT_EQ(extent_type::POINT, current.tag_data.offset.type);
@@ -342,6 +342,18 @@ TEST_F(TagParserTest, offset) {
   p.setup_parser_test("%{O123pt}");
   p.expect_offset_points(123);
   p.expect_done();
+
+  p.setup_parser_test("%{O1.5pt}");
+  p.expect_offset_points(1.5);
+  p.expect_done();
+
+  p.setup_parser_test("%{O1.1px}");
+  p.expect_offset_pixel(1);
+  p.expect_done();
+
+  p.setup_parser_test("%{O1.1}");
+  p.expect_offset_pixel(1);
+  p.expect_done();
 }
 
 TEST_F(TagParserTest, alignment) {
@@ -428,6 +440,7 @@ vector<exception_test> parse_error_test = {
     {"%{P}", exc::CTRL},
     {"%{PA}", exc::CTRL},
     {"%{Oabc}", exc::OFFSET},
+    {"%{O123foo}", exc::OFFSET},
     {"%{O0ptx}", exc::OFFSET},
     {"%{O0a}", exc::OFFSET},
     {"%{A2:cmd:cmd:}", exc::TAG_END},


### PR DESCRIPTION
This is an almost direct rebase of #1671

Fixes #1651, #951, #1700 and #1265

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

Disclaimer: I merely rebased this from the original PR. I changed as little as possible to make it work. I expect there will be plenty of style and similar comments in the review, which I intend to fix before this is merged. Created as a draft to collect feedback before final round of reviewing

## Checklist:
* [x] Compile & Run
* [x] clang-format
* [ ] Unit tests for `unit.hpp`
* [ ] Decide if negative spacing is allowed
* [ ] Go through all config options that use extents or percentage_with_offset and see how they deal with negative values (and if they're even allowed).
* [ ] Address the weirdness in `base.inl`: https://github.com/polybar/polybar/pull/1671#discussion_r369192910
* [ ] Community testing
* [ ] Probably some other things