### PR TITLE
fix(xworkspaces): Segfault for wrong _NET_CURRENT_DESKTOP

### DIFF
--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -71,6 +71,7 @@ namespace modules {
     void rebuild_urgent_hints();
     void rebuild_desktops();
     void rebuild_desktop_states();
+    void update_current_desktop();
 
     void action_focus(const string& data);
     void action_next();

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -95,14 +95,22 @@ namespace modules {
 
     // Get desktop details
     m_desktop_names = get_desktop_names();
-    m_current_desktop = ewmh_util::get_current_desktop();
-    m_current_desktop_name = m_desktop_names[m_current_desktop];
+    update_current_desktop();
 
     rebuild_desktops();
 
     // Get _NET_CLIENT_LIST
     rebuild_clientlist();
     rebuild_desktop_states();
+  }
+
+  void xworkspaces_module::update_current_desktop() {
+    m_current_desktop = ewmh_util::get_current_desktop();
+    if (m_current_desktop < m_desktop_names.size()) {
+      m_current_desktop_name = m_desktop_names[m_current_desktop];
+    } else {
+      throw module_error("The current desktop is outside of the number of desktops reported by the WM");
+    }
   }
 
   /**
@@ -120,8 +128,7 @@ namespace modules {
       rebuild_clientlist();
       rebuild_desktop_states();
     } else if (evt->atom == m_ewmh->_NET_CURRENT_DESKTOP) {
-      m_current_desktop = ewmh_util::get_current_desktop();
-      m_current_desktop_name = m_desktop_names[m_current_desktop];
+      update_current_desktop();
       rebuild_desktop_states();
     } else if (evt->atom == WM_HINTS) {
       rebuild_urgent_hints();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

While it shouldn't happen with compliant WMs, it was possibe to crash
polybar with _NET_CURRENT_DESKTOP >= _NET_NUMBER_OF_DESKTOPS and this
should not be possible.

## Related Issues & Documents

Includes polybar/xpp#31
Fixes #2398

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes