### PR TITLE
fix: unbounded_percentage always rounded down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `internal/fs`: `format-warn`, `label-warn`, `warn-percentage = 90`
   - `internal/memory`: `format-warn`, `label-warn`, `warn-percentage = 90`
 - `radius` now affects the bar border as well
-  ([`#1566`](https://github.com/polybar/polybar/issues/1566))  
+  ([`#1566`](https://github.com/polybar/polybar/issues/1566))
 - Per-corner corner radius with `radius-{bottom,top}-{left,right}`
   ([`#2294`](https://github.com/polybar/polybar/issues/2294))
 - `internal/network`: `speed-unit = B/s` can be used to customize how network
@@ -109,6 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#2292`](https://github.com/polybar/polybar/issues/2292))
 - Parser error if click command contained `}`
   ([`#2040`](https://github.com/polybar/polybar/issues/2040))
+- Slight imprecision when calculating percentages. This caused the volume
+  reported by alsa to be off by one.
+  ([`#2399`](https://github.com/polybar/polybar/issues/2399))
 - `internal/backlight`: With amdgpu backlights, the brightness indicator was slightly behind.
   ([`#2367](https://github.com/polybar/polybar/issues/2367))
 

--- a/include/utils/math.hpp
+++ b/include/utils/math.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 
 #include "common.hpp"
 
@@ -37,14 +38,16 @@ namespace math_util {
    * Calculate the percentage for a value
    * between min_value and max_value
    */
-  template<typename ValueType, typename ReturnType = int>
-  ReturnType unbounded_percentage(ValueType value, ValueType min_value, ValueType max_value){
+  template <typename ValueType, typename ReturnType = int>
+  ReturnType unbounded_percentage(ValueType value, ValueType min_value, ValueType max_value) {
     auto upper = (max_value - min_value);
     auto lower = static_cast<float>(value - min_value);
-    ValueType percentage = (lower / upper) * 100.0f;
-    if (std::is_integral<ReturnType>())
-      percentage += 0.5f;
-    return percentage;
+    float percentage = (lower / upper) * 100.0f;
+    if (std::is_integral<ReturnType>()) {
+      return static_cast<ReturnType>(std::round(percentage));
+    } else {
+      return percentage;
+    }
   }
 
   /**
@@ -113,6 +116,6 @@ namespace math_util {
   inline int ceil(double value, int step = 1) {
     return static_cast<int>((value * 10 + step * 10 - 1) / (step * 10)) * step;
   }
-}
+}  // namespace math_util
 
 POLYBAR_NS_END

--- a/tests/unit_tests/utils/math.cpp
+++ b/tests/unit_tests/utils/math.cpp
@@ -1,5 +1,6 @@
-#include "common/test.hpp"
 #include "utils/math.hpp"
+
+#include "common/test.hpp"
 
 using namespace polybar;
 
@@ -38,7 +39,7 @@ TEST(Math, percentage) {
   EXPECT_EQ(55.0f, (math_util::percentage<float, float>(5.5f, 0.0f, 10.0f)));
   EXPECT_EQ(56, (math_util::percentage<float, int>(5.55f, 0.0f, 10.0f)));
   EXPECT_EQ(43.75f, (math_util::percentage<float, float>(5.25f, 0.0f, 12.0f)));
-  EXPECT_EQ(41, (math_util::percentage<int, int>(5, 0, 12)));
+  EXPECT_EQ(42, (math_util::percentage<int, int>(5, 0, 12)));
   EXPECT_EQ(20.5f, (math_util::percentage<float, float>(20.5f, 0.0f, 100.0f)));
   EXPECT_EQ(70.0f, (math_util::percentage<float, float>(4.5f, 1.0f, 6.0f)));
   EXPECT_EQ(21, (math_util::percentage<float, int>(20.5f, 0.0f, 100.0f)));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

For example if lower / upper = 0.019 (1.9%), it would return 1% instead of 2%

## Related Issues & Documents
Fixes #2399

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes