### PR TITLE
Add wm-restack=generic option that lowers polybar to the bottom of the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   windows per workspace
   ([`#604`](https://github.com/polybar/polybar/issues/604))
 - `internal/backlight`: added `use-actual-brightness` option
+- Added `wm-restack = generic` option that lowers polybar to the bottom of the stack.
+  Fixes the issue where the bar is being drawn on top of fullscreen windows in xmonad.
+  ([`#2205`](https://github.com/polybar/polybar/issues/2205))
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/config/config.cmake
+++ b/config/config.cmake
@@ -63,6 +63,7 @@ tray-position = right
 tray-padding = 2
 ;tray-background = #0063ff
 
+;wm-restack = generic
 ;wm-restack = bspwm
 ;wm-restack = i3
 

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -468,7 +468,7 @@ void bar::restack_window() {
       }
       restacked = true;
     } catch (const exception& err) {
-      m_log.err("Failed to restack bar window (err=%s", err.what());
+      m_log.err("Failed to restack bar window (err=%s)", err.what());
     }
   } else if (wm_restack == "bspwm") {
     restacked = bspwm_util::restack_to_root(m_connection, m_opts.monitor, m_opts.window);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -458,7 +458,19 @@ void bar::restack_window() {
 
   auto restacked = false;
 
-  if (wm_restack == "bspwm") {
+  if (wm_restack == "generic") {
+    try {
+      auto children = m_connection.query_tree(m_connection.screen()->root).children();
+      if (children.begin() != children.end() && *children.begin() != m_opts.window) {
+        const unsigned int value_mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
+        const unsigned int value_list[2]{*children.begin(), XCB_STACK_MODE_BELOW};
+        m_connection.configure_window_checked(m_opts.window, value_mask, value_list);
+      }
+      restacked = true;
+    } catch (const exception& err) {
+      m_log.err("Failed to restack bar window (err=%s", err.what());
+    }
+  } else if (wm_restack == "bspwm") {
     restacked = bspwm_util::restack_to_root(m_connection, m_opts.monitor, m_opts.window);
 #if ENABLE_I3
   } else if (wm_restack == "i3" && m_opts.override_redirect) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Previously wm-restack only supported bspwm and i3. Both have a special
top-level window that polybar detects and places itself directly above.
This patch adds wm-restack=generic which simply lowers polybar to the
very bottom of the stack. This option was tested and confirmed to work
with xmonad which doesn't have a special top-level window and therefore
doesn't require special handling like bspwm and i3.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

Fixes #2205
Closes #1657 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)

I suggest the following changes to the configuration page on the wiki:

```
; Restack the bar window. Fixes the issue where the
; bar is being drawn on top of fullscreen windows.
;
; Currently supported options:
;   generic (works in xmonad, may work with other WMs)
;   bspwm
;   i3 (requires: `override-redirect = true`)
; wm-restack =
```

* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
