### PR TITLE
Fix issues with border corner radii

### DIFF
--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -128,7 +128,21 @@ namespace cairo {
     context& operator<<(const circle_segment& segment) {
       cairo_new_sub_path(m_c);
       cairo_arc(m_c, segment.x, segment.y, segment.radius, segment.angle_from * degree, segment.angle_to * degree);
-      cairo_line_to(m_c, segment.x, segment.y);
+      switch ((int)segment.angle_to) {
+        case 0:
+          cairo_rel_line_to(m_c, -segment.w, 0);
+          break;
+        case 90:
+          cairo_rel_line_to(m_c, 0, -segment.w);
+          break;
+        case 180:
+          cairo_rel_line_to(m_c, segment.w, 0);
+          break;
+        default:
+          cairo_rel_line_to(m_c, 0, segment.w);
+          break;
+      }
+      cairo_arc_negative(m_c, segment.x, segment.y, segment.radius - segment.w, segment.angle_to * degree, segment.angle_from * degree);
       cairo_close_path(m_c);
       return *this;
     }

--- a/include/cairo/types.hpp
+++ b/include/cairo/types.hpp
@@ -57,6 +57,7 @@ namespace cairo {
   struct circle_segment {
     double x;
     double y;
+    double w;
     double angle_from;
     double angle_to;
     double radius;

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -587,6 +587,7 @@ void renderer::fill_borders() {
     borderTL.y = m_bar.borders.at(edge::TOP).size + m_bar.radius.top_left;
     borderTL.angle_from = 180;
     borderTL.angle_to = 270;
+    borderTL.w = m_bar.borders.at(edge::LEFT).size;
     (*m_context << borderTL << m_bar.borders.at(edge::LEFT).color).fill();
   }
 
@@ -597,6 +598,7 @@ void renderer::fill_borders() {
     borderBL.y = m_bar.size.h - (m_bar.borders.at(edge::BOTTOM).size + m_bar.radius.bottom_left);
     borderBL.angle_from = 90;
     borderBL.angle_to = 180;
+    borderBL.w = m_bar.borders.at(edge::LEFT).size;
     (*m_context << borderBL << m_bar.borders.at(edge::LEFT).color).fill();
   }
 
@@ -607,6 +609,7 @@ void renderer::fill_borders() {
     borderTR.y = m_bar.borders.at(edge::TOP).size + m_bar.radius.top_right;
     borderTR.angle_from = -90;
     borderTR.angle_to = 0;
+    borderTR.w = m_bar.borders.at(edge::RIGHT).size;
     (*m_context << borderTR << m_bar.borders.at(edge::RIGHT).color).fill();
   }
 
@@ -617,6 +620,7 @@ void renderer::fill_borders() {
     borderBR.y = m_bar.size.h - (m_bar.borders.at(edge::BOTTOM).size + m_bar.radius.bottom_right);
     borderBR.angle_from = 0;
     borderBR.angle_to = 90;
+    borderBR.w = m_bar.borders.at(edge::RIGHT).size;
     (*m_context << borderBR << m_bar.borders.at(edge::RIGHT).color).fill();
   }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

With the merging of PR #2359, borders on curved corners were created by placing a rectangle with a curved corner behind the main polybar. However, when the main polybar is transparent, you can see the rectangle behind the main bar. This, instead, turns the rectangle into a curved line and only draws it on the border so that there is no rectangle behind the main bar to show when the bar is transparent.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Fixes #2406

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
