### PR TITLE
do not show to long string for keyboard layout name

### DIFF
--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -123,7 +123,11 @@ namespace modules {
       m_layout->replace_token("%name%", m_keyboard->group_name(m_keyboard->current()));
       m_layout->replace_token("%variant%", m_keyboard->variant_name(m_keyboard->current()));
 
-      auto const current_layout = m_keyboard->layout_name(m_keyboard->current());
+      auto current_layout = m_keyboard->layout_name(m_keyboard->current());
+      const auto slash_pos = current_layout.rfind('/');
+      if (slash_pos != string::npos) {
+        current_layout.erase(0, slash_pos + 1);
+      }
       auto icon = m_layout_icons->get(current_layout, DEFAULT_LAYOUT_ICON);
 
       m_layout->replace_token("%icon%", icon->get());


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
In my case layout name "macintosh_vndr/gb". It is too long,
"gb" is enough.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
