### PR TITLE
fix(build): Disable sphinx manpage section dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Build
+- Support building documentation on sphinx 4.0 ([`#2424`](https://github.com/polybar/polybar/issues/2424))
+
 ## [3.5.5] - 2021-03-01
 ### Build
 - Support older python sphinx versions again ([`#2356`](https://github.com/polybar/polybar/issues/2356))

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -185,6 +185,9 @@ man_pages = [
     ('man/polybar.5', 'polybar', 'configuration file for polybar(1)', [], 5)
 ]
 
+man_make_section_directory = False
+
+
 # -- Options for Texinfo output ----------------------------------------------
 
 # Grouping the document tree into Texinfo files. List of tuples


### PR DESCRIPTION



<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: *Build*

## Description
Before sphinx 4.0, this was the default but was changed in 4.0.
Now by default the folder structure looks like this:

```
man
├── 1
│   └── polybar.1
└── 5
    └── polybar.5
```

This restores the old behavior where there weren't individual folders
for the different sections:

```
man
├── polybar.1
└── polybar.5
```

## Related Issues & Documents

Fixes #2424
Ref: https://www.sphinx-doc.org/en/master/changes.html#id14

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
