### PR TITLE
[module/bspwm] Option to scroll through occupied desktops only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `wm-restack = generic` option that lowers polybar to the bottom of the stack.
   Fixes the issue where the bar is being drawn on top of fullscreen windows in xmonad.
   ([`#2205`](https://github.com/polybar/polybar/issues/2205))
+- Added `occupied-scroll = true` option to bspwm module.
+  Allows scrolling only through occupied desktops only.
+  ([`#2427`](https://github.com/polybar/polybar/issues/2427))
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -88,7 +88,7 @@ namespace modules {
 
     bool m_click{true};
     bool m_scroll{true};
-    bool m_occscroll{true};
+    bool m_occscroll{false};
     bool m_revscroll{true};
     bool m_pinworkspaces{true};
     bool m_inlinemode{false};

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -88,6 +88,7 @@ namespace modules {
 
     bool m_click{true};
     bool m_scroll{true};
+    bool m_occscroll{true};
     bool m_revscroll{true};
     bool m_pinworkspaces{true};
     bool m_inlinemode{false};

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -58,6 +58,7 @@ namespace modules {
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
     m_click = m_conf.get(name(), "enable-click", m_click);
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
+    m_occscroll = m_conf.get(name(), "occupied-scroll", m_occscroll);
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
     m_inlinemode = m_conf.get(name(), "inline-mode", m_inlinemode);
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
@@ -473,8 +474,12 @@ namespace modules {
     string scrolldir = next ? "next" : "prev";
     string modifier;
 
+    if (m_occscroll) {
+      modifier += ".occupied";
+    }
+
     if (m_pinworkspaces) {
-      modifier = ".local";
+      modifier += ".local";
       for (const auto& mon : m_monitors) {
         if (m_bar.monitor->match(mon->name, false) && !mon->focused) {
           send_command("monitor -f " + mon->name, "Sending monitor focus command to ipc handler");


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
New config option 'occupied-scroll' for bspwm module that allows scrolling only occupied desktops.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Closes #2427

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Update bspwm module wiki page