### PR TITLE
The xworkspaces module should wait for EWMH to become available

### DIFF
--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -99,7 +99,6 @@ namespace modules {
     vector<string> m_desktop_names;
     vector<bool> m_urgent_desktops;
     unsigned int m_current_desktop;
-    string m_current_desktop_name;
 
     /**
      * Maps an xcb window to its desktop number

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -50,11 +50,6 @@ namespace modules {
       throw module_error("Failed to initialize ewmh atoms");
     }
 
-    // Check if the WM supports _NET_CURRENT_DESKTOP
-    if (!ewmh_util::supports(m_ewmh->_NET_CURRENT_DESKTOP)) {
-      throw module_error("The WM does not support _NET_CURRENT_DESKTOP, aborting...");
-    }
-
     // Check if the WM supports _NET_DESKTOP_VIEWPORT
     if (!(m_monitorsupport = ewmh_util::supports(m_ewmh->_NET_DESKTOP_VIEWPORT)) && m_pinworkspaces) {
       throw module_error("The WM does not support _NET_DESKTOP_VIEWPORT (required when `pin-workspaces = true`)");
@@ -106,11 +101,6 @@ namespace modules {
 
   void xworkspaces_module::update_current_desktop() {
     m_current_desktop = ewmh_util::get_current_desktop();
-    if (m_current_desktop < m_desktop_names.size()) {
-      m_current_desktop_name = m_desktop_names[m_current_desktop];
-    } else {
-      throw module_error("The current desktop is outside of the number of desktops reported by the WM");
-    }
   }
 
   /**


### PR DESCRIPTION


<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

Before this change if EWMH wasn't available the xworkspaces module was
permanently disabled. When polybar was started alongside the window
manager e.g. from .xinitrc this caused a race condition between polybar
and the window manager and the xworkspaces module may or may not be
displayed. After this change polybar will wait for EWMH to become
available. This change closes #1915, see that issue for more details.

Curiously this only required the removal of the error condition which
used the be raised when EWMH wasn't available. The xworkspaces module
will show up on the bar as soon as the first EWMH event is processed by
the existing event handling code. I can't argue much about the
correctness of this patch but it seems to work flawlessly in my testing
with xmonad. I didn't test any other window managers. Note that removing
the error condition below which checks that _NET_DESKTOP_VIEWPORT is
available might make this work with pin-workspaces=true. I couldn't test
the effects of that change because I only tested with xmonad and xmonad
doesn't support _NET_DESKTOP_VIEWPORT, so I didn't make that change.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

Closes #1915

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
