### PR TITLE
fix(tray): Support clients with different depths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Build
 - Support building documentation on sphinx 4.0 ([`#2424`](https://github.com/polybar/polybar/issues/2424))
+### Fixed
+- Tray icons sometimes appears outside of bar ([`#2430`](https://github.com/polybar/polybar/issues/2430), [`#1679`](https://github.com/polybar/polybar/issues/1679))
 
 ## [3.5.5] - 2021-03-01
 ### Build

--- a/src/x11/tray_client.cpp
+++ b/src/x11/tray_client.cpp
@@ -1,9 +1,10 @@
+#include "x11/tray_client.hpp"
+
 #include <xcb/xcb.h>
 #include <xcb/xcb_aux.h>
 
 #include "utils/memory.hpp"
 #include "x11/connection.hpp"
-#include "x11/tray_client.hpp"
 #include "x11/xembed.hpp"
 
 POLYBAR_NS
@@ -28,11 +29,7 @@ unsigned int tray_client::height() const {
 }
 
 void tray_client::clear_window() const {
-  try {
-    m_connection.clear_area_checked(1, window(), 0, 0, width(), height());
-  } catch (const xpp::x::error::window& err) {
-    // ignore
-  }
+  m_connection.clear_area_checked(1, window(), 0, 0, width(), height());
 }
 
 /**

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -726,7 +726,7 @@ void tray_manager::track_selection_owner(xcb_window_t owner) {
  * Process client docking request
  */
 void tray_manager::process_docking_request(xcb_window_t win) {
-  m_log.info("Processing docking request from %s", m_connection.id(win));
+  m_log.info("Processing docking request from '%s' (%s)", ewmh_util::get_wm_name(win), m_connection.id(win));
 
   m_clients.emplace_back(factory_util::shared<tray_client>(m_connection, win, m_opts.width, m_opts.height));
   auto& client = m_clients.back();
@@ -734,18 +734,15 @@ void tray_manager::process_docking_request(xcb_window_t win) {
   try {
     m_log.trace("tray: Get client _XEMBED_INFO");
     xembed::query(m_connection, win, client->xembed());
-  } catch (const application_error& err) {
-    m_log.err(err.what());
-  } catch (const xpp::x::error::window& err) {
+  } catch (const std::exception& err) {
     m_log.err("Failed to query _XEMBED_INFO, removing client... (%s)", err.what());
     remove_client(win, true);
     return;
   }
 
   try {
-    const unsigned int mask{XCB_CW_BACK_PIXMAP | XCB_CW_EVENT_MASK};
-    const unsigned int values[]{
-        XCB_BACK_PIXMAP_PARENT_RELATIVE, XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_STRUCTURE_NOTIFY};
+    const unsigned int mask = XCB_CW_EVENT_MASK;
+    const unsigned int values[]{XCB_EVENT_MASK_PROPERTY_CHANGE | XCB_EVENT_MASK_STRUCTURE_NOTIFY};
 
     m_log.trace("tray: Update client window");
     m_connection.change_window_attributes_checked(client->window(), mask, values);
@@ -767,8 +764,9 @@ void tray_manager::process_docking_request(xcb_window_t win) {
       m_log.trace("tray: Map client");
       m_connection.map_window_checked(client->window());
     }
-  } catch (const xpp::x::error::window& err) {
-    m_log.err("Failed to setup tray client, removing... (%s)", err.what());
+
+  } catch (const std::exception& err) {
+    m_log.err("Failed to setup tray client removing... (%s)", err.what());
     remove_client(win, false);
   }
 }


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
XCB_BACK_PIXMAP_PARENT_RELATIVE requires that the client has the same
depth as the tray window.

There was an issue with dropbox having a depth of 32 and the tray window
having a depth of 24 that caused the configuration of the icon to fail.
It would then be displayed outside of the bar because the catch block
was not hit (different exception).

We now just don't configure XCB_CW_BACK_PIXMAP. This seems to work and
is also what stalonetray does.

This does not fix the issue with dropbox having an arbitrary background.

I also noticed that these are the same symptoms as #1679, so I think that should be fixed now as well (though I can't confirm because the issue no longer occurs because of a new synology drive version)

## Related Issues & Documents

Fixes #2430
Fixes #1679

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
