### PR TITLE
Adding case to ignore T@ in bspwm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reported by alsa to be off by one.
   ([`#2399`](https://github.com/polybar/polybar/issues/2399))
 - `internal/backlight`: With amdgpu backlights, the brightness indicator was slightly behind.
-  ([`#2367](https://github.com/polybar/polybar/issues/2367))
+  ([`#2367`](https://github.com/polybar/polybar/issues/2367))
+- Warning message regarding T@ in bspwm module
+  ([`#2371`](https://github.com/polybar/polybar/issues/2371))
 
 ## [3.5.6] - 2021-05-24
 ### Build

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -287,6 +287,8 @@ namespace modules {
           switch (value[0]) {
             case 0:
               break;
+            case '@':
+              break;
             case 'T':
               break;
             case '=':


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
T@ is producing an warning message in bspwm. Since T@ is not a special state in bspwm I've added a case so that it can be ignored. 
## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Fixes #2371
## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
