### PR TITLE
fix(bspwm): Handle monitor names with illegal characters

### DIFF
--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -36,6 +36,7 @@ namespace modules {
       label_t label;
       string name;
       bool focused{false};
+      size_t index{0};
     };
 
    public:


### PR DESCRIPTION
Adding monitor index field into `bspwm_monitor`
command to focus: `bspc desktop -f <mon_name>:^<workspace_n>` -> `bspc desktop -f ^<mon_index>:^<workspace_n>`

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

## Related Issues & Documents

Fixes #2420 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
