### PR TITLE
fix(fs): Only add spacing between shown mountpoints

### DIFF
--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -136,10 +136,16 @@ namespace modules {
     string output;
 
     for (m_index = 0_z; m_index < m_mounts.size(); ++m_index) {
-      if (!output.empty()) {
+      string mount_output = timer_module::get_output();
+      /*
+       * Add spacing before the mountpoint, but only if the mountpoint contents
+       * are not empty and there is already other content in the module.
+       */
+      if (!output.empty() && !mount_output.empty()) {
         m_builder->space(m_spacing);
+        output += m_builder->flush();
       }
-      output += timer_module::get_output();
+      output += mount_output;
     }
 
     return output;


### PR DESCRIPTION

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Empty formats in the fs module would still add spacing, resulting in large extra spacing before, after, or inside the module if some mountpoints weren't shown for some reason.

## Related Issues & Documents

Fixes #2458


## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
