### PR TITLE
feat(ipc): allow receiving arbitrary text on IPC socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `occupied-scroll = true` option to bspwm module.
   Allows scrolling only through occupied desktops only.
   ([`#2427`](https://github.com/polybar/polybar/issues/2427))
+- `custom/ipc`: `send` action to send arbitrary strings to be displayed in the module.
+  ([`#2455`](https://github.com/polybar/polybar/issues/2455))
 
 ### Changed
 - Slight changes to the value ranges the different ramp levels are responsible

--- a/doc/user/actions.rst
+++ b/doc/user/actions.rst
@@ -258,6 +258,13 @@ custom/menu
            The data has the form ``N-M`` and the action will execute the command
            in ``menu-N-M-exec``.
 
+custom/ipc
+^^^^^^^^^^
+
+:``send``: *(Has Data)* Replace the contents of the module with the data passed in this action.
+
+  .. versionadded:: 3.6.0
+
 Deprecated Action Names
 -----------------------
 

--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -34,6 +34,11 @@ namespace modules {
 
     static constexpr auto TYPE = "custom/ipc";
 
+    static constexpr auto EVENT_SEND = "send";
+
+   protected:
+    void action_send(const string& data);
+
    private:
     static constexpr const char* TAG_OUTPUT{"<output>"};
     vector<unique_ptr<hook>> m_hooks;

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -13,6 +13,8 @@ namespace modules {
    * create formatting tags
    */
   ipc_module::ipc_module(const bar_settings& bar, string name_) : static_module<ipc_module>(bar, move(name_)) {
+    m_router->register_action_with_data(EVENT_SEND, &ipc_module::action_send);
+
     size_t index = 0;
 
     try {
@@ -125,13 +127,11 @@ namespace modules {
       broadcast();
       return;
     }
-    if (message.rfind(name() + ":", 0) == 0) {
-      m_log.info("%s: Received generic payload (%s)", name(), message);
-      string payload{message.substr(name().length() + 1)};
-      m_output.clear();
-      m_output = payload;
-      broadcast();
-    }
+  }
+
+  void ipc_module::action_send(const string& data) {
+    m_output = data;
+    broadcast();
   }
 }  // namespace modules
 

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -123,7 +123,6 @@ namespace modules {
       }
 
       broadcast();
-      return;
     }
   }
 

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -17,13 +17,11 @@ namespace modules {
 
     size_t index = 0;
 
-    try {
-      for (auto&& command : m_conf.get_list<string>(name(), "hook")) {
-        m_hooks.emplace_back(std::make_unique<hook>(hook{name() + to_string(++index), command}));
-      }
-    } catch (const key_error& err) {
-      m_log.notice("%s: no hooks defined", name());
+    for (auto&& command : m_conf.get_list<string>(name(), "hook", {})) {
+      m_hooks.emplace_back(std::make_unique<hook>(hook{name() + to_string(++index), command}));
     }
+
+    m_log.info("%s: Loaded %d hooks", name(), m_hooks.size());
 
     if ((m_initial = m_conf.get(name(), "initial", 0_z)) && m_initial > m_hooks.size()) {
       throw module_error("Initial hook out of bounds (defined: " + to_string(m_hooks.size()) + ")");


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Instead of just allowing hook numbers to be executed, the user can
send arbitrary text and the IPC module will put it in the bar. The IPC
payload format is extended to accept an arbitrary string if the first
character after the module name is ':'.

    polybar-msg hook test :'%{F#4444ff}hello%{F-}'

I did not make a new module as requested by @patrick96 as the modifications to the IPC module are minimal and the actions are reused as is. Tell me what you think.

## Related Issues & Documents
Fix #2455

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
