### PR TITLE
Added support for hook cycling using prev and next

### DIFF
--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -3,6 +3,9 @@
 #include "modules/meta/static_module.hpp"
 #include "utils/command.hpp"
 
+#include <mutex>
+
+
 POLYBAR_NS
 
 namespace modules {
@@ -38,9 +41,14 @@ namespace modules {
 
    protected:
     void action_send(const string& data);
+    string replace_active_hook_token(string hook_command);
 
    private:
     static constexpr const char* TAG_OUTPUT{"<output>"};
+    size_t get_active();
+    void set_active(size_t);
+    size_t active_hook;
+    mutex active_mutex;
     vector<unique_ptr<hook>> m_hooks;
     map<mousebtn, string> m_actions;
     string m_output;

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -71,13 +71,13 @@ namespace modules {
   }
 
   string ipc_module::replace_active_hook_token(string hook_command) {
-    const char active_hook_token[] = "%active-hook%";
+    const char active_hook_token[] = "%hook%";
     const char next_hook_token[] = "%next%";
     const char prev_hook_token[] = "%prev%";
 
     string::size_type a = hook_command.find(active_hook_token);
     if(a != string::npos){
-      hook_command.replace(a, 13, to_string(get_active()));
+      hook_command.replace(a, 6, to_string(get_active()));
     }
     string::size_type n = hook_command.find(next_hook_token);
     if(n != string::npos){

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -77,7 +77,7 @@ namespace modules {
 
     string::size_type a = hook_command.find(active_hook_token);
     if(a != string::npos){
-      hook_command.replace(a, 6, to_string(get_active()));
+      hook_command.replace(a, 6, to_string((get_active())%m_hooks.size()+1));
     }
     string::size_type n = hook_command.find(next_hook_token);
     if(n != string::npos){

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -25,8 +25,7 @@ namespace modules {
 
     if ((m_initial = m_conf.get(name(), "initial", 0_z)) && m_initial > m_hooks.size()) {
       throw module_error("Initial hook out of bounds (defined: " + to_string(m_hooks.size()) + ")");
-    }
-    else{
+    } else {
       active_hook = m_initial;
     }
 
@@ -76,16 +75,16 @@ namespace modules {
     const char prev_hook_token[] = "%prev%";
 
     string::size_type a = hook_command.find(active_hook_token);
-    if(a != string::npos){
-      hook_command.replace(a, 6, to_string((get_active())%m_hooks.size()+1));
+    if (a != string::npos) {
+      hook_command.replace(a, 6, to_string((get_active()) % m_hooks.size() + 1));
     }
     string::size_type n = hook_command.find(next_hook_token);
-    if(n != string::npos){
-      hook_command.replace(n, 6, to_string((get_active()+1)%m_hooks.size()+1));
+    if (n != string::npos) {
+      hook_command.replace(n, 6, to_string((get_active() + 1) % m_hooks.size() + 1));
     }
     string::size_type p = hook_command.find(prev_hook_token);
-    if(p != string::npos){
-      hook_command.replace(p, 6, to_string((get_active()-1)%m_hooks.size()+1));
+    if (p != string::npos) {
+      hook_command.replace(p, 6, to_string((get_active() - 1) % m_hooks.size() + 1));
     }
     return hook_command;
   }
@@ -127,7 +126,7 @@ namespace modules {
    * execute its command
    */
   void ipc_module::on_message(const string& message) {
-    for (size_t i = 0; i<m_hooks.size(); i++) {
+    for (size_t i = 0; i < m_hooks.size(); i++) {
       auto&& hook = m_hooks[i];
       if (hook->payload != message) {
         continue;
@@ -156,18 +155,19 @@ namespace modules {
     broadcast();
   }
 
-  void ipc_module::set_active(size_t current){
+  void ipc_module::set_active(size_t current) {
     active_mutex.lock();
-    active_hook=current;
+    active_hook = current;
     active_mutex.unlock();
   }
 
-  size_t ipc_module::get_active(){
+  size_t ipc_module::get_active() {
     size_t active;
     active_mutex.lock();
-    active=active_hook;
+    active = active_hook;
     active_mutex.unlock();
     return active;
   }
+}
 
 POLYBAR_NS_END


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  I added support for hook rotating selection in the ipc module actions. This adds the tokens "%prev%", "%next%" and "%hook% tags for cycling through the hooks. This feature allows for dynamic hook calling so it could be used to minimize ui needed to fully realize a substantial number of hooks. 
-->

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
https://github.com/polybar/polybar/issues/2464
https://github.com/polybar/polybar/issues/999

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

It would be a good idea to include examples of using the cycling and current tokens in the ipc module example config. 
