### PR TITLE
fix(monitor): do not include outputs when monitors are supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#2367`](https://github.com/polybar/polybar/issues/2367))
 - Warning message regarding T@ in bspwm module
   ([`#2371`](https://github.com/polybar/polybar/issues/2371))
+- `polybar -m` hides physical outputs covered by monitors
+  ([`#2481`](https://github.com/polybar/polybar/issues/2481))
 
 ## [3.5.6] - 2021-05-24
 ### Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#2367`](https://github.com/polybar/polybar/issues/2367))
 - Warning message regarding T@ in bspwm module
   ([`#2371`](https://github.com/polybar/polybar/issues/2371))
-- `polybar -m` hides physical outputs covered by monitors
+- `polybar -m` used to show both physical outputs and randr monitors, even if the outputs were covered by monitors.
   ([`#2481`](https://github.com/polybar/polybar/issues/2481))
 
 ## [3.5.6] - 2021-05-24

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,8 +81,8 @@ int main(int argc, char** argv) {
       bool purge_clones = !cli->has("list-all-monitors");
       auto monitors = randr_util::get_monitors(conn, conn.root(), true, purge_clones);
       for (auto&& mon : monitors) {
-        if (WITH_XRANDR_MONITORS && mon->output == XCB_NONE) {
-          printf("%s: %ix%i+%i+%i (XRandR monitor%s)\n", mon->name.c_str(), mon->w, mon->h, mon->x, mon->y,
+        if (mon->output == XCB_NONE) {
+          printf("%s: %ix%i+%i+%i (no output%s)\n", mon->name.c_str(), mon->w, mon->h, mon->x, mon->y,
               mon->primary ? ", primary" : "");
         } else {
           printf("%s: %ix%i+%i+%i%s\n", mon->name.c_str(), mon->w, mon->h, mon->x, mon->y,


### PR DESCRIPTION
Previously, when splitting an output into two monitors, `polybar -m`
would report both the splitted monitors and the output. This was not
caught by the the clone detection as the detection works by removing
monitors contained into another monitors (and monitors were excluded
from that logic) and we want the other way around: outputs covered by
monitors should be ignored.

Instead of trying to detect covered outputs, the solution is quite
simple: when monitors are supported, do not consider outputs. A
monitor can be set primary (and RandR reports primary outputs as
primary monitors). The only information we would miss from monitors
are things like refresh rate and EDID. We don't need that, so we are
fine.

As monitors are only created for connected output (and they are in
this case "active") or disconnected output if they are mapped (and
they are in this case "inactive"), I am a bit unsure if we have
exactly the same behaviour as previously when `connected_only` is set
to `false`.

As some modules require an output, we keep the output in the
`monitor_t` structure and we ensure it is correctly set when using
monitors. A monitor can have 0 or several outputs. We only handle the
0 and 1 cases. When a monitor has more outputs, only the first one is
used. AFAIK, only the xbacklight module needs that and I think we are
fine waiting for a user needing this module and merging monitors.

This last part is buggy. The C++ binding fail to expose the
`outputs()` method to iterate over the outputs of a monitor. This
seems to be a bug in XPP. The field is correctly defined in the RandR
XML file and it works with the Python binding. I attempt to fallback
to C, but the C header does not have room to include this information
and the C++ binding may make a copy, losing the information.

```xml
	<struct name="MonitorInfo">
		<field type="ATOM" name="name" />
		<field type="BOOL" name="primary" />
		<field type="BOOL" name="automatic" />
		<field type="CARD16" name="nOutput" />
		<field type="INT16" name="x" />
		<field type="INT16" name="y" />
		<field type="CARD16" name="width" /> <!-- pixels -->
		<field type="CARD16" name="height" /> <!-- pixels -->
		<field type="CARD32" name="width_in_millimeters" />
		<field type="CARD32" name="height_in_millimeters" />
		<list type="OUTPUT" name="outputs">
		    <fieldref>nOutput</fieldref>
		</list>
	</struct>
```

When not buggy, we shouldn't get "XRandR monitor" in the output of
`polybar -m` unless there is no output attached to the monitor.

Fixes #2481

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
