### PR TITLE
feat(pulseaudio): add support for source device

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -25,11 +25,25 @@ namespace modules {
     m_interval = m_conf.get(name(), "interval", m_interval);
 
     auto sink_name = m_conf.get(name(), "sink", ""s);
+    auto source_name = m_conf.get(name(), "source", ""s);
+    string device_name;
     bool m_max_volume = m_conf.get(name(), "use-ui-max", true);
     m_reverse_scroll = m_conf.get(name(), "reverse-scroll", false);
 
+    if (!sink_name.empty() && !source_name.empty()) {
+      throw module_error("Use either source or sink, not both");
+    }
+    pulseaudio::devicetype device_type;
+    if (!source_name.empty()) {
+      device_type = pulseaudio::devicetype::SOURCE;
+      device_name = move(source_name);
+    } else {
+      device_type = pulseaudio::devicetype::SINK;
+      device_name = move(sink_name);
+    }
+
     try {
-      m_pulseaudio = std::make_unique<pulseaudio>(m_log, move(sink_name), m_max_volume);
+      m_pulseaudio = std::make_unique<pulseaudio>(m_log, device_type, move(device_name), m_max_volume);
     } catch (const pulseaudio_error& err) {
       throw module_error(err.what());
     }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -98,7 +98,7 @@ namespace modules {
         m_muted = m_muted || m_pulseaudio->is_muted();
       }
     } catch (const pulseaudio_error& err) {
-      m_log.err("%s: Failed to query pulseaudio sink (%s)", name(), err.what());
+      m_log.err("%s: Failed to query pulseaudio (%s)", name(), err.what());
     }
 
     // Replace label tokens
@@ -122,6 +122,17 @@ namespace modules {
   }
 
   string pulseaudio_module::get_output() {
+    // Exclude monitors and auto_null
+    if (!m_pulseaudio) {
+      return ""s;
+    }
+    auto s_name = m_pulseaudio->get_name();
+    if (s_name.empty() ||
+        s_name == "auto_null" ||
+        (s_name.size() >= 8 && s_name.compare(s_name.size() - 8, s_name.size(), ".monitor") == 0)) {
+      return ""s;
+    }
+
     // Get the module output early so that
     // the format prefix/suffix also gets wrapper
     // with the cmd handlers


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Update pulseaudio module to accept a source instead of a sink.

This is quite similar to #2238 but I had the feeling there was too
much code duplication. At first, I did try to rely heavily on
templating to avoid that and keep the number of lines changed to a
minimum, but my C++ foo was not good enough (I can push what I have
currently if someone is interested, but it does not compile).

In this attempt, only a few functions are templated (not the whole
class) and a few helper functions are introduced to implement the
differences.

Instead of using switch/case to implement the differences, helper
functions could be specified as an abstract class and implemented by
different classes. I think this is not worth the effort.

```ini
[module/speaker]
type = internal/pulseaudio
format-volume = <label-volume>
format-muted = <label-muted>
label-volume = speaker: %percentage: 2%%
label-muted = muted speaker: %percentage: 2%%

[module/micro]
type = internal/pulseaudio
source = "@DEFAULT_SOURCE"
format-volume = <label-volume>
format-muted = <label-muted>
label-volume = micro: %percentage: 2%%
label-muted = muted micro: %percentage: 2%%
```

Fix #1096.

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
