### PR TITLE
[module/memory] Display MiB instead of GiB when GiB value is less than 1GiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `POLYBAR_FLAGS` cmake variable can be used to pass extra C++ compiler flags.
 
 ### Added
-- `module/memory`: Display MiB instead of GiB when GiB value is less than 1GiB
+- `internal/memory`: New tokens `%used%`, `%free%`, `%total%`, `%swap_total%`, 
+  `%swap_free%`, and `%swap_used%` that automatically switch between MiB and GiB
+  when below or above 1GiB.
   ([`2472`](https://github.com/polybar/polybar/issues/2472))
 - Option to always show urgent windows in i3 module when `pin-workspace` is active
   ([`2374`](https://github.com/polybar/polybar/issues/2374))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `POLYBAR_FLAGS` cmake variable can be used to pass extra C++ compiler flags.
 
 ### Added
+- `module/memory`: Display MiB instead of GiB when GiB value is less than 1GiB
+  ([`2472`](https://github.com/polybar/polybar/issues/2472))
 - Option to always show urgent windows in i3 module when `pin-workspace` is active
   ([`2374`](https://github.com/polybar/polybar/issues/2374))
 - `internal/xworkspaces`: `reverse-scroll` can be used to reverse the scroll

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -96,7 +96,7 @@ namespace string_util {
   string floating_point(double value, size_t precision, bool fixed = false, const string& locale = "");
   string filesize_mib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
   string filesize_gib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
-  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string locale = "");
+  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string& locale = "");
   string filesize(unsigned long long kbytes, size_t precision = 0, bool fixed = false, const string& locale = "");
 
   hash_type hash(const string& src);

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -96,7 +96,7 @@ namespace string_util {
   string floating_point(double value, size_t precision, bool fixed = false, const string& locale = "");
   string filesize_mib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
   string filesize_gib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
-  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string& locale = "");
+  string filesize_gib_mib(unsigned long long kibibytes, size_t precision_mib, size_t precision_gib, const string& locale = "");
   string filesize(unsigned long long kbytes, size_t precision = 0, bool fixed = false, const string& locale = "");
 
   hash_type hash(const string& src);

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -96,6 +96,7 @@ namespace string_util {
   string floating_point(double value, size_t precision, bool fixed = false, const string& locale = "");
   string filesize_mib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
   string filesize_gib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
+  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string locale = "");
   string filesize(unsigned long long kbytes, size_t precision = 0, bool fixed = false, const string& locale = "");
 
   hash_type hash(const string& src);

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -96,7 +96,7 @@ namespace string_util {
   string floating_point(double value, size_t precision, bool fixed = false, const string& locale = "");
   string filesize_mib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
   string filesize_gib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
-  string filesize_gib_mib(unsigned long long kibibytes, size_t precision_mib, size_t precision_gib, const string& locale = "");
+  string filesize_gib_mib(unsigned long long kibibytes, size_t precision_mib = 0, size_t precision_gib = 0, const string& locale = "");
   string filesize(unsigned long long kbytes, size_t precision = 0, bool fixed = false, const string& locale = "");
 
   hash_type hash(const string& src);

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -124,7 +124,7 @@ namespace modules {
       label->replace_token("%total%", string_util::filesize_gib_mib(kb_total, 2, m_bar.locale));
       label->replace_token("%swap_total%", string_util::filesize_gib_mib(kb_swap_total, 2, m_bar.locale));
       label->replace_token("%swap_free%", string_util::filesize_gib_mib(kb_swap_free, 2, m_bar.locale));
-      label->replace_token("%swap_used%", string_util::filesize_gib_mib(kb_swap_total, 2, m_bar.locale));
+      label->replace_token("%swap_used%", string_util::filesize_gib_mib(kb_swap_total - kb_swap_free, 2, m_bar.locale));
     };
 
     if (m_label) {

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -1,5 +1,5 @@
 #include <fstream>
- #include <iomanip>
+#include <iomanip>
 #include <istream>
 
 #include "drawtypes/label.hpp"

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -119,6 +119,12 @@ namespace modules {
       label->replace_token("%gb_swap_total%", string_util::filesize_gib(kb_swap_total, 2, m_bar.locale));
       label->replace_token("%gb_swap_free%", string_util::filesize_gib(kb_swap_free, 2, m_bar.locale));
       label->replace_token("%gb_swap_used%", string_util::filesize_gib(kb_swap_total - kb_swap_free, 2, m_bar.locale));
+      label->replace_token("%used%", string_util::filesize_gib_mib(kb_total - kb_avail, 2, m_bar.locale));
+      label->replace_token("%free%", string_util::filesize_gib_mib(kb_avail, 2, m_bar.locale));
+      label->replace_token("%total%", string_util::filesize_gib_mib(kb_total, 2, m_bar.locale));
+      label->replace_token("%swap_total%", string_util::filesize_gib_mib(kb_swap_total, 2, m_bar.locale));
+      label->replace_token("%swap_free%", string_util::filesize_gib_mib(kb_swap_free, 2, m_bar.locale));
+      label->replace_token("%swap_used%", string_util::filesize_gib_mib(kb_swap_total, 2, m_bar.locale));
     };
 
     if (m_label) {

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -1,5 +1,5 @@
 #include <fstream>
-#include <iomanip>
+ #include <iomanip>
 #include <istream>
 
 #include "drawtypes/label.hpp"
@@ -119,12 +119,12 @@ namespace modules {
       label->replace_token("%gb_swap_total%", string_util::filesize_gib(kb_swap_total, 2, m_bar.locale));
       label->replace_token("%gb_swap_free%", string_util::filesize_gib(kb_swap_free, 2, m_bar.locale));
       label->replace_token("%gb_swap_used%", string_util::filesize_gib(kb_swap_total - kb_swap_free, 2, m_bar.locale));
-      label->replace_token("%used%", string_util::filesize_gib_mib(kb_total - kb_avail, 2, m_bar.locale));
-      label->replace_token("%free%", string_util::filesize_gib_mib(kb_avail, 2, m_bar.locale));
-      label->replace_token("%total%", string_util::filesize_gib_mib(kb_total, 2, m_bar.locale));
-      label->replace_token("%swap_total%", string_util::filesize_gib_mib(kb_swap_total, 2, m_bar.locale));
-      label->replace_token("%swap_free%", string_util::filesize_gib_mib(kb_swap_free, 2, m_bar.locale));
-      label->replace_token("%swap_used%", string_util::filesize_gib_mib(kb_swap_total - kb_swap_free, 2, m_bar.locale));
+      label->replace_token("%used%", string_util::filesize_gib_mib(kb_total - kb_avail, 0, 2, m_bar.locale));
+      label->replace_token("%free%", string_util::filesize_gib_mib(kb_avail, 0, 2, m_bar.locale));
+      label->replace_token("%total%", string_util::filesize_gib_mib(kb_total, 0, 2, m_bar.locale));
+      label->replace_token("%swap_total%", string_util::filesize_gib_mib(kb_swap_total, 0, 2, m_bar.locale));
+      label->replace_token("%swap_free%", string_util::filesize_gib_mib(kb_swap_free, 0, 2, m_bar.locale));
+      label->replace_token("%swap_used%", string_util::filesize_gib_mib(kb_swap_total - kb_swap_free, 0, 2, m_bar.locale));
     };
 
     if (m_label) {
@@ -137,7 +137,7 @@ namespace modules {
 
     return true;
   }
-  
+
   string memory_module::get_format() const {
     if (m_perc_memused>= m_perc_memused_warn && m_formatter->has_format(FORMAT_WARN)) {
       return FORMAT_WARN;

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -294,7 +294,7 @@ namespace string_util {
   /**
    * Create a GiB string, if the value in GiB is >= 1.0. Otherwise, create a MiB string.
    */
-  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string locale) {
+  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string& locale) {
     if(kibibytes / 1024.0 / 1024.0 < 1.0) {
       return filesize_mib(kibibytes, precision, locale);
     } else {

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -294,11 +294,11 @@ namespace string_util {
   /**
    * Create a GiB string, if the value in GiB is >= 1.0. Otherwise, create a MiB string.
    */
-  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string& locale) {
-    if(kibibytes / 1024.0 / 1024.0 < 1.0) {
-      return filesize_mib(kibibytes, precision, locale);
+  string filesize_gib_mib(unsigned long long kibibytes, size_t precision_mib, size_t precision_gib, const string& locale) {
+    if(kibibytes < 1024 * 1024) {
+      return filesize_mib(kibibytes, precision_mib, locale);
     } else {
-      return filesize_gib(kibibytes, precision, locale);
+      return filesize_gib(kibibytes, precision_gib, locale);
     }
   }
 

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -292,6 +292,17 @@ namespace string_util {
   }
 
   /**
+   * Create a GiB string, if the value in GiB is >= 1.0. Otherwise, create a MiB string.
+   */
+  string filesize_gib_mib(unsigned long long kibibytes, size_t precision, const string locale) {
+    if(kibibytes / 1024.0 / 1024.0 < 1.0) {
+      return filesize_mib(kibibytes, precision, locale);
+    } else {
+      return filesize_gib(kibibytes, precision, locale);
+    }
+  }
+
+  /**
    * Create a filesize string by converting given bytes to highest unit possible
    */
   string filesize(unsigned long long bytes, size_t precision, bool fixed, const string& locale) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

Memory/swap values can now be displayed in MiB instead of GiB when the value is less than 1 GiB, for better precision.
For example, display 512 MiB instead of 0.50 GiB.

The following tokens have been added to the memory module in order to activate this behavior from config:
```
;   %used%
;   %free%
;   %total%
;   %swap_total%
;   %swap_free%
;   %swap_used%
```

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Closes #2472 

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The documentation of the memory module should be updated with the tokens described earlier, and a description on their behavior.
