### PR TITLE
Remove threads from static modules

### DIFF
--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -12,7 +12,7 @@ namespace modules {
    * shell script and the resulting output will be used
    * as the module content.
    */
-  class ipc_module : public static_module<ipc_module> {
+  class ipc_module : public module<ipc_module> {
    public:
     /**
      * Hook structure that will be fired

--- a/include/modules/menu.hpp
+++ b/include/modules/menu.hpp
@@ -45,7 +45,7 @@ namespace modules {
 
     vector<unique_ptr<menu_tree>> m_levels;
 
-    std::atomic<int> m_level{-1};
+    int m_level{-1};
   };
 }  // namespace modules
 

--- a/include/modules/meta/static_module.hpp
+++ b/include/modules/meta/static_module.hpp
@@ -11,11 +11,8 @@ namespace modules {
     using module<Impl>::module;
 
     void start() override {
-      this->m_mainthread = thread([&] {
-        this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
-        CAST_MOD(Impl)->update();
-        CAST_MOD(Impl)->broadcast();
-      });
+      CAST_MOD(Impl)->update();
+      CAST_MOD(Impl)->broadcast();
     }
 
     bool build(builder*, string) const {

--- a/include/modules/xbacklight.hpp
+++ b/include/modules/xbacklight.hpp
@@ -57,7 +57,7 @@ namespace modules {
     progressbar_t m_progressbar;
 
     bool m_scroll{true};
-    std::atomic<int> m_percentage{0};
+    int m_percentage{0};
   };
 }  // namespace modules
 

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -1,16 +1,8 @@
 #pragma once
 
-#include <bitset>
-#include <mutex>
-#include <set>
-
-#include "components/config.hpp"
-#include "components/types.hpp"
 #include "modules/meta/event_handler.hpp"
 #include "modules/meta/static_module.hpp"
 #include "x11/ewmh.hpp"
-#include "x11/icccm.hpp"
-#include "x11/window.hpp"
 
 POLYBAR_NS
 
@@ -115,10 +107,6 @@ namespace modules {
     bool m_scroll{true};
     bool m_revscroll{false};
     size_t m_index{0};
-
-    // The following mutex is here to protect the data of this modules.
-    // This can't be achieved using m_buildlock since we "CRTP override" get_output().
-    mutable mutex m_workspace_mutex;
   };
 }  // namespace modules
 

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -57,6 +57,7 @@ namespace modules {
    */
   void ipc_module::start() {
     if (m_initial) {
+      // TODO do this in a thread.
       auto command = command_util::make_command<output_policy::REDIRECTED>(m_hooks.at(m_initial - 1)->command);
       command->exec(false);
       command->tail([this](string line) { m_output = line; });

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -104,10 +104,6 @@ namespace modules {
    * Update the currently active window and query its title
    */
   void xwindow_module::update(bool force) {
-    std::lock(m_buildlock, m_updatelock);
-    std::lock_guard<std::mutex> guard_a(m_buildlock, std::adopt_lock);
-    std::lock_guard<std::mutex> guard_b(m_updatelock, std::adopt_lock);
-
     xcb_window_t win;
 
     if (force) {

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -10,6 +10,7 @@
 #include "utils/math.hpp"
 #include "x11/atoms.hpp"
 #include "x11/connection.hpp"
+#include "x11/icccm.hpp"
 
 POLYBAR_NS
 
@@ -116,8 +117,6 @@ namespace modules {
    * Handler for XCB_PROPERTY_NOTIFY events
    */
   void xworkspaces_module::handle(const evt::property_notify& evt) {
-    std::lock_guard<std::mutex> lock(m_workspace_mutex);
-
     if (evt->atom == m_ewmh->_NET_CLIENT_LIST || evt->atom == m_ewmh->_NET_WM_DESKTOP) {
       rebuild_clientlist();
       rebuild_desktop_states();
@@ -322,8 +321,6 @@ namespace modules {
    * Generate module output
    */
   string xworkspaces_module::get_output() {
-    std::unique_lock<std::mutex> lock(m_workspace_mutex);
-
     // Get the module output early so that
     // the format prefix/suffix also gets wrapped
     // with the cmd handlers
@@ -378,7 +375,6 @@ namespace modules {
   }
 
   void xworkspaces_module::action_focus(const string& data) {
-    std::lock_guard<std::mutex> lock(m_workspace_mutex);
     focus_desktop(std::strtoul(data.c_str(), nullptr, 10));
   }
 
@@ -396,8 +392,6 @@ namespace modules {
    * Will wrap around at the ends and go in the order the desktops are displayed.
    */
   void xworkspaces_module::focus_direction(bool next) {
-    std::lock_guard<std::mutex> lock(m_workspace_mutex);
-
     unsigned int current_desktop{ewmh_util::get_current_desktop()};
     int current_index = -1;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

The static modules don't need any threads because nothing actually runs in them.

The ipc module also isn't really a static module since the hook commands should run in a thread (though it does not do so yet)

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
