### PR TITLE
feat(i3): allow per monitor configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `double-click-interval` setting to the bar section to control the time
   interval in which a double-click is recognized. Defaults to 400 (ms)
   ([`#1441`](https://github.com/polybar/polybar/issues/1441))
+- `internal/i3`: Enable workspace configuration based on monitor
+  ([`#2391`](https://github.com/polybar/polybar/issues/2391))
 
 ### Changed
 - We rewrote polybar's main event loop. This shouldn't change any behavior for

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -96,6 +96,7 @@ namespace modules {
     bool m_show_urgent{false};
     bool m_strip_wsnumbers{false};
     bool m_fuzzy_match{false};
+    map<string, map<state, label_t> > m_monitor_statelabels;
 
     unique_ptr<i3_util::connection_t> m_ipc;
   };

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -50,6 +50,20 @@ namespace modules {
           make_pair(state::VISIBLE, load_optional_label(m_conf, name(), "label-visible", DEFAULT_WS_LABEL)));
       m_statelabels.insert(
           make_pair(state::URGENT, load_optional_label(m_conf, name(), "label-urgent", DEFAULT_WS_LABEL)));
+
+      vector<string> monitors_focused = m_conf.get_list(name(), "label-monitors", vector<string>());
+      for (auto it = monitors_focused.begin(); it != monitors_focused.end(); it++) {
+        map<state, label_t> monitor_statelabels;
+            monitor_statelabels.insert(
+                make_pair(state::FOCUSED, load_optional_label(m_conf, name(), "label-" + *it + "-focused", DEFAULT_WS_LABEL)));
+            monitor_statelabels.insert(
+                make_pair(state::UNFOCUSED, load_optional_label(m_conf, name(), "label-" + *it + "-unfocused", DEFAULT_WS_LABEL)));
+            monitor_statelabels.insert(
+                make_pair(state::VISIBLE, load_optional_label(m_conf, name(), "label-" + *it + "-visible", DEFAULT_WS_LABEL)));
+            monitor_statelabels.insert(
+                make_pair(state::URGENT, load_optional_label(m_conf, name(), "label-" + *it + "-urgent", DEFAULT_WS_LABEL)));
+        m_monitor_statelabels.insert(make_pair(*it, monitor_statelabels));
+      }
     }
 
     if (m_formatter->has(TAG_LABEL_MODE)) {
@@ -166,6 +180,10 @@ namespace modules {
 
         auto icon = m_icons->get(ws->name, DEFAULT_WS_ICON, m_fuzzy_match);
         auto label = m_statelabels.find(ws_state)->second->clone();
+        auto monitor_statelabels = m_monitor_statelabels.find(ws->output);
+        if (monitor_statelabels != m_monitor_statelabels.end()) {
+          label->replace_defined_values(monitor_statelabels->second.find(ws_state)->second);
+        }
 
         label->reset_tokens();
         label->replace_token("%output%", ws->output);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [X] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This PR adds 2 kind of entries to the i3 module configuration:
* a list of the monitors on which specific configuration will apply `label-monitors-N`
* some new `label` entries to configure per monitor `label-<monitor>-<status>-<item>`

This design mainly comes from the fact that there's no wait to get all the configuration keys for a module.
Thus it's not possible to store any defined per monitor configuration without knowing the monitors before-hand.

See the documentation update for an example.

## Related Issues & Documents
Closes #2391

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The wiki documentation may be updated like:
```
; You may define per monitor labels based on state
;
; When per monitor configuration is used, the 'general' label configuration is used
; and the properties define for a monitor are overwritten to make the label rendered.
;
; Per monitor formatting requires 2 steps:
;   Define the list of the monitors to be handled
;   Define per monitor labels with label-<monitor_name>-NAME-<suffix>

label-monitors-0 = eDP-1
label-monitors-1 = HDMI-1

label-eDP-1-focused-underline = #22fbfb
label-eDP-1-unfocused-background = #000000
label-eDP-1-unfocused-underline = #8022fbfb
label-eDP-1-visible-underline = #c022fbfb

label-HDMI-1-focused-overline = #fba922
label-HDMI-1-visible-overline = #555555

; Separator in between workspaces
label-separator = |
label-separator-padding = 2
label-separator-foreground = #ffb52a
```
