### PR TITLE
Include fd_stream in command.hpp

### DIFF
--- a/include/utils/command.hpp
+++ b/include/utils/command.hpp
@@ -4,12 +4,10 @@
 #include "components/logger.hpp"
 #include "components/types.hpp"
 #include "errors.hpp"
+#include "utils/file.hpp"
 #include "utils/functional.hpp"
 
 POLYBAR_NS
-
-template <typename T>
-class fd_stream;
 
 DEFINE_ERROR(command_error);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: Build fix

## Description

On older gcc versions, the incomplete type can lead to a compilation
error because unique_ptr requires the complete type for its destructor.

## Related Issues & Documents

Ref: https://www.reddit.com/r/Polybar/comments/q68mq0/how_to_compile_polybar_for_older_ubuntu_distros/hgc7u1j/?context=3

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
