### PR TITLE
Enable module in start funcion

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -158,6 +158,7 @@ namespace modules {
 
     bool visible() const override;
 
+    void start() override;
     void join() final override;
     void stop() override;
     void halt(string error_message) override;
@@ -218,7 +219,7 @@ namespace modules {
     bool m_handle_events{true};
 
    private:
-    atomic<bool> m_enabled{true};
+    atomic<bool> m_enabled{false};
     atomic<bool> m_visible{true};
     atomic<bool> m_changed{true};
     string m_cache;

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -66,6 +66,11 @@ namespace modules {
   }
 
   template <class Impl>
+  void module<Impl>::start() {
+    m_enabled = true;
+  }
+
+  template <class Impl>
   void module<Impl>::join() {
     for (auto&& thread_ : m_threads) {
       if (thread_.joinable()) {

--- a/include/modules/meta/event_module.hpp
+++ b/include/modules/meta/event_module.hpp
@@ -11,6 +11,7 @@ namespace modules {
     using module<Impl>::module;
 
     void start() override {
+      this->module<Impl>::start();
       this->m_mainthread = thread(&event_module::runner, this);
     }
 

--- a/include/modules/meta/inotify_module.hpp
+++ b/include/modules/meta/inotify_module.hpp
@@ -12,6 +12,7 @@ namespace modules {
     using module<Impl>::module;
 
     void start() override {
+      this->module<Impl>::start();
       this->m_mainthread = thread(&inotify_module::runner, this);
     }
 

--- a/include/modules/meta/static_module.hpp
+++ b/include/modules/meta/static_module.hpp
@@ -11,6 +11,7 @@ namespace modules {
     using module<Impl>::module;
 
     void start() override {
+      this->module<Impl>::start();
       CAST_MOD(Impl)->update();
       CAST_MOD(Impl)->broadcast();
     }

--- a/include/modules/meta/timer_module.hpp
+++ b/include/modules/meta/timer_module.hpp
@@ -13,6 +13,7 @@ namespace modules {
     using module<Impl>::module;
 
     void start() override {
+      this->module<Impl>::start();
       this->m_mainthread = thread(&timer_module::runner, this);
     }
 

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -68,6 +68,7 @@ namespace modules {
    * Start module and run first defined hook if configured to
    */
   void ipc_module::start() {
+    this->module::start();
     m_mainthread = thread([&] {
       m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
       update();

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -33,6 +33,7 @@ namespace modules {
    * Start the module worker
    */
   void script_module::start() {
+    this->module::start();
     m_mainthread = thread([&] {
       try {
         while (running()) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Before it was enabled by default. That means if the constructor fails,
the destructor will complain that the module was not stopped before
deconstructing.

We can't just call stop if module creation fails because the module is
only partially initialized.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
