### PR TITLE
fix(net): Use canonical interface name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ([`#2491`](https://github.com/polybar/polybar/issues/2491))
   - Module would error if WM was not full started up.
     ([`#1915`](https://github.com/polybar/polybar/issues/1915))
+- `internal/network`: The module now properly supports 'altnames' for
+  interfaces.
 
 ## [3.5.7] - 2021-09-21
 ### Fixed

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -38,6 +38,7 @@ namespace net {
   DEFINE_ERROR(network_error);
 
   bool is_interface_valid(const string& ifname);
+  std::pair<string, bool> get_canonical_interface(const string& ifname);
   bool is_wireless_interface(const string& ifname);
   std::string find_wireless_interface();
   std::string find_wired_interface();

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -63,6 +63,31 @@ namespace net {
   }
 
   /**
+   * Returns the canonical name of the given interface and whether that differs
+   * from the given name.
+   *
+   * The canonical name is the name that has an entry in `/sys/class/net`.
+   *
+   * This resolves any altnames that were defined (see man ip-link).
+   */
+  std::pair<string, bool> get_canonical_interface(const string& ifname) {
+    int idx = if_nametoindex(ifname.c_str());
+
+    if (idx == 0) {
+      throw system_error("if_nameindex(" + ifname + ")");
+    }
+
+    char canonical[IF_NAMESIZE];
+    if (!if_indextoname(idx, canonical)) {
+      throw system_error("if_indextoname(" + to_string(idx) + ")");
+    }
+
+    string str{canonical};
+
+    return {str, str != ifname};
+  }
+
+  /**
    * Test if interface with given name is a wireless device
    */
   bool is_wireless_interface(const string& ifname) {

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -44,6 +44,14 @@ namespace modules {
       throw module_error("Invalid network interface \"" + m_interface + "\"");
     }
 
+    auto canonical = net::get_canonical_interface(m_interface);
+
+    if (canonical.second) {
+      m_log.info(
+          "%s: Replacing given interface '%s' with its canonical name '%s'", name(), m_interface, canonical.first);
+      m_interface = canonical.first;
+    }
+
     m_ping_nth_update = m_conf.get(name(), "ping-interval", m_ping_nth_update);
     m_udspeed_minwidth = m_conf.get(name(), "udspeed-minwidth", m_udspeed_minwidth);
     m_accumulate = m_conf.get(name(), "accumulate-stats", m_accumulate);


### PR DESCRIPTION



<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
One can define an 'altname' for an interface. That name is valid of
if_nametoindex but it doesn't appear in `/sys/class/net`:

```
sudo ip link property add dev enp0s31f6 altname eno
```

This creates an altname eno for the existing interface enp0s31f6

Before, using eno, would lead to an error in `realpath`.


## Related Issues & Documents
Ref: https://www.reddit.com/r/Polybar/comments/q8f0ye/error_disabling_module_network_reason_realpath/hgqpq1m/?context=3

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
