### PR TITLE
feat: Support reading config from non-regular files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DEBUG_SHADED` cmake variable and its associated functionality.
 
 ### Added
+- Polybar can now read config files from stdin: `polybar -c /dev/stdin`.
 - `custom/script`: Implement `env-*` config option.
    ([2090](https://github.com/polybar/polybar/issues/2090))
 - `drawtypes/ramp`: Add support for ramp weights.

--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -83,6 +83,7 @@ class fd_stream : public StreamType {
 namespace file_util {
   bool exists(const string& filename);
   bool is_file(const string& filename);
+  bool is_dir(const string& filename);
   string pick(const vector<string>& filenames);
   string contents(const string& filename);
   void write_contents(const string& filename, const string& contents);

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -126,8 +126,8 @@ void config_parser::parse_file(const string& file, file_list path) {
     throw application_error("Failed to open config file " + file + ": " + strerror(errno));
   }
 
-  if (!file_util::is_file(file)) {
-    throw application_error("Config file " + file + " is not a file");
+  if (file_util::is_dir(file)) {
+    throw application_error("Config file " + file + " is a directory");
   }
 
   m_log.trace("config_parser: Parsing %s", file);

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -166,6 +166,19 @@ namespace file_util {
   }
 
   /**
+   * Checks if the given path exists and is a file
+   */
+  bool is_dir(const string& filename) {
+    struct stat buffer {};
+
+    if (stat(filename.c_str(), &buffer) != 0) {
+      return false;
+    }
+
+    return S_ISDIR(buffer.st_mode);
+  }
+
+  /**
    * Picks the first existing file out of given entries
    */
   string pick(const vector<string>& filenames) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

We had a check that restricted config files to "regular files".
This check was to restrictive as it didn't allow for things like:

```
polybar -c <(gen_config)
gen_config | polybar -c /dev/stdin
```

Now, polybar can easily read config data from stdin.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
