### PR TITLE
ipc: Move running initial hook to update function

### DIFF
--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -27,7 +27,7 @@ namespace modules {
     explicit ipc_module(const bar_settings&, string);
 
     void start() override;
-    void update() {}
+    void update();
     string get_output();
     bool build(builder* builder, const string& tag) const;
     void on_message(const string& message);
@@ -47,13 +47,20 @@ namespace modules {
     void action_prev();
     void action_reset();
 
+    void hook_offset(int offset);
+
+    bool has_initial() const;
+    bool has_hook() const;
+
+    void set_hook(int h);
+
    private:
     static constexpr const char* TAG_OUTPUT{"<output>"};
     vector<unique_ptr<hook>> m_hooks;
     map<mousebtn, string> m_actions;
     string m_output;
-    size_t m_initial;
-    size_t m_current_hook;
+    int m_initial{-1};
+    int m_current_hook{-1};
     void exec_hook();
   };
 }  // namespace modules


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Seems that when the execution of the initial hook is in the start function, polybar can get stuck.

I also refactored how we store the initial hook.

## Related Issues & Documents

Fixes #2477

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
