### PR TITLE
fix(ipc): don't format empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,8 +169,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are relative to the folder of the file where those directives appear.
   ([`#2523`](https://github.com/polybar/polybar/issues/2523))
 - `custom/ipc`: Empty output strings are no longer formatted. This prevents
-  extraneous spaces and separators from appearing in the bar when an ipc
-  module's output is empty.
+  extraneous spaces and separators from appearing in the bar when the output of
+  an ipc module is empty.
 
 ### Fixed
 - `custom/script`: Concurrency issues with fast-updating tailed scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `include-directory` and `include-file` now support relative paths. The paths
   are relative to the folder of the file where those directives appear.
   ([`#2523`](https://github.com/polybar/polybar/issues/2523))
+- `custom/ipc`: Empty output strings are no longer formatted. This prevents
+  extraneous spaces and separators from appearing in the bar when an ipc
+  module's output is empty.
 
 ### Fixed
 - `custom/script`: Concurrency issues with fast-updating tailed scripts.

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -90,6 +90,9 @@ namespace modules {
     // the format prefix/suffix also gets wrapper
     // with the cmd handlers
     string output{module::get_output()};
+    if (output.empty()) {
+      return "";
+    }
 
     for (auto&& action : m_actions) {
       if (!action.second.empty()) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor  #f1aa33db
* [ ] Feature  #8542db39
* [X] Bug Fix  #627e82cd
* [ ] Optimization  #2d7909d2
* [ ] Documentation Update  #9715eb09
* [ ] Other: *Replace this with a description of the type of this PR*  #03ee0365

## Description
Current behavior makes it so that empty ipc module outputs get formatted. This means, when the output string is empty, there will be (depending on the module margins) extraneous spaces in the bar at the position of the ipc module.

This PR makes ipc modules have the same behavior as script modules when dealing with empty output strings. That is, when the output of the ipc module is empty, no formatting gets applied so that adjacent modules become neighbors (i.e. no margins or separators get applied to the empty string).

I found this bug while making an update module that changes output on click actions and on an interval, as mentioned [here](https://github.com/polybar/polybar/issues/786#issuecomment-679112469). Preventing the module from appearing in the bar when there are no updates available is one example of wanting this fix. There could be other use-cases for empty ipc output strings, but this is the first that comes to mind.

## Related Issues & Documents

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)  #0bd89c4b
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).  #d9eb2ad3
* [X] Does not require documentation changes  #58d6c87d
