### PR TITLE
Add support for a `tray-foreground` setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([`#2414`](https://github.com/polybar/polybar/issues/2414))
 - `custom/ipc`: Add `hook`, `next`, `prev`, `reset` actions to the ipc module
   ([`#2464`](https://github.com/polybar/polybar/issues/2464))
+- Added a new `tray-foreground` setting to give hints to tray icons about what
+  color they should be.
+  ([#2235](https://github.com/polybar/polybar/issues/2235))
 
 ### Changed
 - Polybar now also reads `config.ini` when searching for config files.

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -61,6 +61,7 @@ struct tray_settings {
   unsigned int spacing{0U};
   unsigned int sibling{0U};
   rgba background{};
+  rgba foreground{};
   bool transparent{false};
   bool detached{false};
 };

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -133,8 +133,9 @@ void tray_manager::setup(const bar_settings& bar_opts) {
     m_log.warn("tray-transparent is deprecated, the tray always uses pseudo-transparency. Please remove it.");
   }
 
-  // Set user-defined background color
+  // Set user-defined foreground and background colors.
   m_opts.background = conf.get(bs, "tray-background", bar_opts.background);
+  m_opts.foreground = conf.get(bs, "tray-foreground", bar_opts.foreground);
 
   if (m_opts.background.alpha_i() != 255) {
     m_log.trace("tray: enable transparency");
@@ -650,17 +651,21 @@ void tray_manager::set_wm_hints() {
  * Set color atom used by clients when determing icon theme
  */
 void tray_manager::set_tray_colors() {
-  m_log.trace("tray: Set _NET_SYSTEM_TRAY_COLORS to %x", m_opts.background);
+  m_log.trace("tray: Set _NET_SYSTEM_TRAY_COLORS to %x", m_opts.foreground);
 
-  auto r = m_opts.background.red_i();
-  auto g = m_opts.background.green_i();
-  auto b = m_opts.background.blue_i();
+  auto r = m_opts.foreground.red_i();
+  auto g = m_opts.foreground.green_i();
+  auto b = m_opts.foreground.blue_i();
 
-  const unsigned int colors[12] = {
-      r, g, b,  // normal
-      r, g, b,  // error
-      r, g, b,  // warning
-      r, g, b,  // success
+  const uint16_t r16 = (r << 8) | r;
+  const uint16_t g16 = (g << 8) | g;
+  const uint16_t b16 = (b << 8) | b;
+
+  const uint32_t colors[12] = {
+      r16, g16, b16,  // normal
+      r16, g16, b16,  // error
+      r16, g16, b16,  // warning
+      r16, g16, b16,  // success
   };
 
   m_connection.change_property(


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

This adds a new `tray-foreground` config option, and uses it instead of
the `tray-background` setting to build up the `_NET_SYSTEM_TRAY_COLORS`
property. I'm pretty sure that the previous behavior was a mistake (this
was introduced in 94298741b6de08e79131006504850820bdff9024 which is a
pretty large diff).  For me and some other people, this results in a
black icon being drawn on top of a black background, which is pretty
useless! I would say that this diff fixes
https://github.com/polybar/polybar/issues/2235. Note: the old code dealt
with `unsigned int` and maxed values out at 0xff. The new code deals
with `uint16_t` and maxes values out at 0xffff. I haven't found the
relevant documentation to justify this change, but from manually
testing, I'm pretty confident this is the right change.

This all matches pretty closely with this code from i3:
[`i3bar/src/xcb.c::init_tray_colors`
code](https://github.com/i3/i3/blob/43e805a00d1835db4fc0730ce5003956824b350d/i3bar/src/xcb.c#L1490-L1522),
which you can see also uses the bar's foreground color and maxes values
out at 0xffff, not 0xff.

Before:

<img width="261" alt="2021-11-16_20-32-03_dalinar" src="https://user-images.githubusercontent.com/277474/142144626-bc2b750a-a497-4a39-a3b3-5ccec1e128e7.png">

After:

<img width="313" alt="2021-11-16_20-32-21_dalinar" src="https://user-images.githubusercontent.com/277474/142144652-eb605148-57c7-4956-8c01-e1f32b48897f.png">


## Related Issues & Documents
Fixes #2235

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation: https://github.com/polybar/polybar/wiki/Configuration#bar-settings needs to mention the new `tray-foreground` setting. I'd say something like:

      ; Foreground color for the tray container
      ; ARGB color (e.g. #f00, #ff992a, #ddff1023)
      ; Will use the bar foreground color by default
      tray-foreground = ${root.foreground}

* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
