### PR TITLE
Make it possible to run tests.

### DIFF
--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
I followed the instructions on
https://github.com/polybar/polybar/wiki/Testing, and this happened to
me:

    $ cmake .. -DBUILD_TESTS=ON
    ...
    [ 11%] Creating directories for 'googletest'
    [ 22%] Performing download step (git clone) for 'googletest'
    Cloning into 'googletest-src'...
    fatal: invalid reference: master
    CMake Error at googletest-download/googletest-prefix/tmp/googletest-gitclone.cmake:40 (message):
      Failed to checkout tag: 'master'

    make[2]: *** [CMakeFiles/googletest.dir/build.make:99: googletest-prefix/src/googletest-stamp/googletest-download] Error 1
    make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/googletest.dir/all] Error 2
    make: *** [Makefile:91: all] Error 2
    CMake Error at tests/CMakeLists.txt:19 (message):
      Build step for googletest failed: 2

It looks like the problem is that
[googletest](https://github.com/google/googletest/) changed their branch from
`master` to `main` at some point.

## Related Issues & Documents
N/A

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes: I fixed a broken link
https://github.com/polybar/polybar/wiki/Testing. Hopefully it's
intentional that random members of the public such as myself are allowed
to do that?
