### PR TITLE
Get battery status before adapter. (#2363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,8 +174,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/ipc`: Empty output strings are no longer formatted. This prevents
   extraneous spaces and separators from appearing in the bar when the output of
   an ipc module is empty.
-  - `internal/battery`: Get battery status before adapter
-  ([`#2363`](https://github.com/polybar/polybar/issues/2363))
 
 ### Fixed
 - `custom/script`: Concurrency issues with fast-updating tailed scripts.
@@ -201,6 +199,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ([`#1915`](https://github.com/polybar/polybar/issues/1915))
 - `internal/network`: The module now properly supports 'altnames' for
   interfaces.
+- `internal/battery`: More accurate battery state
+([`#2563`](https://github.com/polybar/polybar/issues/2563))
 
 ## [3.5.7] - 2021-09-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/ipc`: Empty output strings are no longer formatted. This prevents
   extraneous spaces and separators from appearing in the bar when the output of
   an ipc module is empty.
+  - `internal/battery`: Get battery status before adapter
+  ([`#2363`](https://github.com/polybar/polybar/issues/2363))
 
 ### Fixed
 - `custom/script`: Concurrency issues with fast-updating tailed scripts.

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -35,11 +35,11 @@ namespace modules {
     auto path_battery = string_util::replace(PATH_BATTERY, "%battery%", m_conf.get(name(), "battery", "BAT0"s)) + "/";
 
     // Make state reader
-    if (file_util::exists((m_fstate = path_adapter + "online"))) {
+    if (file_util::exists((m_fstate = path_battery + "status"))) {
+          m_state_reader =
+              make_unique<state_reader>([=] { return file_util::contents(m_fstate).compare(0, 8, "Charging") == 0; });
+    } else if (file_util::exists((m_fstate = path_adapter + "online"))) {
       m_state_reader = make_unique<state_reader>([=] { return file_util::contents(m_fstate).compare(0, 1, "1") == 0; });
-    } else if (file_util::exists((m_fstate = path_battery + "status"))) {
-      m_state_reader =
-          make_unique<state_reader>([=] { return file_util::contents(m_fstate).compare(0, 8, "Charging") == 0; });
     } else {
       throw module_error("No suitable way to get current charge state");
     }
@@ -261,7 +261,7 @@ namespace modules {
       case battery_module::state::LOW:
         if (m_formatter->has_format(FORMAT_LOW)) {
           return FORMAT_LOW;
-        }  
+        }
         return FORMAT_DISCHARGING;
       case battery_module::state::DISCHARGING: return FORMAT_DISCHARGING;
       default: return FORMAT_CHARGING;


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [x] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Get battery status before check if adapter is online. Avoid to have label-charging when the ac is plugged in but the battery do not charge.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
[`#2363`](https://github.com/polybar/polybar/issues/2363)

Fixes #2563 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
