### PR TITLE
feat(net): improve interface discovery 

### DIFF
--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -97,12 +97,23 @@ namespace net {
   std::string find_interface(NetType type) {
     struct ifaddrs* ifaddrs;
     getifaddrs(&ifaddrs);
+
+    struct ifaddrs* candidate_if = nullptr;
+
     for (struct ifaddrs* i = ifaddrs; i != nullptr; i = i->ifa_next) {
       const std::string name{i->ifa_name};
       const NetType iftype = iface_type(name);
       if (iftype != type) {
         continue;
       }
+      if (candidate_if == nullptr) {
+        candidate_if = i;
+      } else if (((candidate_if->ifa_flags & IFF_RUNNING) == 0) && ((i->ifa_flags & IFF_RUNNING) > 0)) {
+        candidate_if = i;
+      }
+    }
+    if (candidate_if) {
+      const std::string name{candidate_if->ifa_name};
       freeifaddrs(ifaddrs);
       return name;
     }


### PR DESCRIPTION
## What type of PR is this?

* [x] Optimization

## Description
This PR is a follow up change to #2025 attempt to improve the adapter/net.cpp:find_interface()
to return a interface name that is currently running if any interface is found, else just return the 
first one found.

This will allow the interface-type to work with multiple net interface
of the same type, and prefer to one that is currently connect to
a network. This works great HW with multiple Ethernet port and user
expect to occasionally swap between the two.