### PR TITLE
Fix race condition when creating socket folder

### DIFF
--- a/src/ipc/util.cpp
+++ b/src/ipc/util.cpp
@@ -20,7 +20,10 @@ namespace ipc {
   string ensure_runtime_path() {
     string runtime_path = get_runtime_path();
     if (!file_util::exists(runtime_path) && mkdir(runtime_path.c_str(), 0700) == -1) {
-      throw system_error("Failed to create ipc socket folders");
+      // It's possible the folder was created in the meantime, we have to check again.
+      if (!file_util::exists(runtime_path)) {
+        throw system_error("Failed to create ipc socket folders");
+      }
     }
 
     return runtime_path;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,7 +148,12 @@ int main(int argc, char** argv) {
     unique_ptr<ipc::ipc> ipc{};
 
     if (conf.get(conf.section(), "enable-ipc", false)) {
-      ipc = ipc::ipc::make(loop);
+      try {
+        ipc = ipc::ipc::make(loop);
+      } catch (const std::exception& e) {
+        ipc.reset();
+        logger.err("Disabling IPC channels due to error: %s", e.what());
+      }
     }
 
     auto ctrl = controller::make((bool)ipc, loop);


### PR DESCRIPTION

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
If two processes call `mkdir` at the same time, the second one will fail
and wrongly assume the folder wasn't created properly.

We now first check if the folder really doesn't exist and we also catch
any IPC initialization errors and disable IPC instead of crashing the
whole bar.


## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
