### PR TITLE
Stop using deprecated CMake command in uninstall template

### DIFF
--- a/cmake/templates/uninstall.cmake.in
+++ b/cmake/templates/uninstall.cmake.in
@@ -11,7 +11,7 @@ foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
   if(EXISTS "$ENV{DESTDIR}${file}")
     execute_process(COMMAND "@CMAKE_COMMAND@"
-      -E remove "$ENV{DESTDIR}${file}"
+      -E rm "$ENV{DESTDIR}${file}"
       OUTPUT_VARIABLE rm_out
       RESULT_VARIABLE rm_retval)
     if(NOT ${rm_retval} EQUAL 0)


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [x] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
The uninstall template is using a deprecated CMake command to remove the files, this patch fixes that.
To confirm, I ran the following command `$ cmake -E help` which outputs:
```
  remove [-f] <file>...     - remove the file(s), use -f to force it (deprecated: use rm instead)
```

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
