### PR TITLE
Add netspeed parameter (#1083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - For module actions, you can now also specify the module name,
       action name, and optional data as separate arguments.
     - Added man page
+- `internal/network`: New token `%netspeed%` that provides the total speed of the internet (up + down speed) ([#2590](https://github.com/polybar/polybar/issues/2590))
 
 ### Changed
 - Polybar now also reads `config.ini` when searching for config files.

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -90,6 +90,7 @@ namespace net {
     string mac() const;
     string downspeed(int minwidth = 3, const string& unit = "B/s") const;
     string upspeed(int minwidth = 3, const string& unit = "B/s") const;
+    string netspeed(int minwidth = 3, const string& unit = "B/s") const;
     void set_unknown_up(bool unknown = true);
 
    protected:

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -274,6 +274,15 @@ namespace net {
     float bytes_diff = m_status.current.transmitted - m_status.previous.transmitted;
     return format_speedrate(bytes_diff, minwidth, unit);
   }
+  
+  /**
+   * Get total net speed rate
+   */
+  string network::netspeed(int minwidth, const string& unit) const {
+    float bytes_diff = m_status.current.received - m_status.previous.received
+                     + m_status.current.transmitted - m_status.previous.transmitted;
+    return format_speedrate(bytes_diff, minwidth, unit);
+  }
 
   /**
    * Set if unknown counts as up

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -148,6 +148,7 @@ namespace modules {
 
     auto upspeed = network->upspeed(m_udspeed_minwidth, m_udspeed_unit);
     auto downspeed = network->downspeed(m_udspeed_minwidth, m_udspeed_unit);
+    auto netspeed = network->netspeed(m_udspeed_minwidth, m_udspeed_unit);
 
     // Update label contents
     const auto replace_tokens = [&](label_t& label) {
@@ -158,7 +159,7 @@ namespace modules {
       label->replace_token("%local_ip6%", network->ip6());
       label->replace_token("%upspeed%", upspeed);
       label->replace_token("%downspeed%", downspeed);
-      label->replace_token("%netspeed%", upspeed + downspeed);
+      label->replace_token("%netspeed%", netspeed);
 
       if (m_wired) {
         label->replace_token("%linkspeed%", m_wired->linkspeed());

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -158,6 +158,7 @@ namespace modules {
       label->replace_token("%local_ip6%", network->ip6());
       label->replace_token("%upspeed%", upspeed);
       label->replace_token("%downspeed%", downspeed);
+      label->replace_token("%netspeed%", upspeed + downspeed);
 
       if (m_wired) {
         label->replace_token("%linkspeed%", m_wired->linkspeed());


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Adds netspeed parameter which is basically sum of up and down speeds

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Fixes #1083, Although this doesn't add dynamic icons of up and down

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
`netspeed` parameter uses needs to be described in the network module documentation.
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
