### PR TITLE
feat(script): add formatting for script failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DEBUG_SHADED` cmake variable and its associated functionality.
 
 ### Added
+- `custom/script`: Add formatting for script failure (`format-fail`, `label-fail`) ([`#2588`](https://github.com/polybar/polybar/issues/2588))
 - Support `px` and `pt` units everyhwere where before only a number of spaces
   or pixels could be specified.
   ([`#2578`](https://github.com/polybar/polybar/pull/2578))

--- a/include/adapters/script_runner.hpp
+++ b/include/adapters/script_runner.hpp
@@ -12,8 +12,8 @@ POLYBAR_NS
 class script_runner {
  public:
   using interval = std::chrono::duration<double>;
-  script_runner(std::function<void(void)> on_update, string exec, string exec_if, bool tail, interval interval,
-      const vector<pair<string, string>>& env);
+  script_runner(std::function<void(void)> on_update, const string& exec, const string& exec_if, bool tail,
+      interval interval, const vector<pair<string, string>>& env);
 
   bool check_condition() const;
   interval process();

--- a/include/adapters/script_runner.hpp
+++ b/include/adapters/script_runner.hpp
@@ -12,8 +12,8 @@ POLYBAR_NS
 class script_runner {
  public:
   using interval = std::chrono::duration<double>;
-  script_runner(std::function<void(void)> on_update, const string& exec, const string& exec_if, bool tail,
-      interval interval, const vector<pair<string, string>>& env);
+  script_runner(std::function<void(void)> on_update, string exec, string exec_if, bool tail, interval interval,
+      const vector<pair<string, string>>& env);
 
   bool check_condition() const;
   interval process();
@@ -24,13 +24,14 @@ class script_runner {
 
   int get_pid() const;
   int get_counter() const;
+  int get_exit_status() const;
 
   string get_output();
 
   bool is_stopping() const;
 
  protected:
-  bool set_output(const string&&);
+  bool set_output(string&&);
 
   interval run_tail();
   interval run();
@@ -52,6 +53,7 @@ class script_runner {
   std::atomic_int m_counter{0};
   std::atomic_bool m_stopping{false};
   std::atomic_int m_pid{-1};
+  std::atomic_int m_exit_status{0};
 };
 
 POLYBAR_NS_END

--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -32,7 +32,6 @@ namespace modules {
 
     const bool m_tail;
     const script_runner::interval m_interval{0};
-    const bool m_has_format_fail;
 
     script_runner m_runner;
 

--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -16,6 +16,8 @@ namespace modules {
     void stop() override;
 
     string get_output();
+    string get_format() const;
+
     bool build(builder* builder, const string& tag) const;
 
     static constexpr auto TYPE = "custom/script";
@@ -24,16 +26,20 @@ namespace modules {
     bool check_condition();
 
    private:
-    static constexpr const char* TAG_LABEL{"<label>"};
+    static constexpr auto TAG_LABEL = "<label>";
+    static constexpr auto TAG_LABEL_FAIL = "<label-fail>";
+    static constexpr auto FORMAT_FAIL = "format-fail";
 
     const bool m_tail;
     const script_runner::interval m_interval{0};
+    const bool m_has_format_fail;
 
     script_runner m_runner;
 
     map<mousebtn, string> m_actions;
 
     label_t m_label;
+    label_t m_label_fail;
   };
 }  // namespace modules
 

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -11,7 +11,7 @@
 
 POLYBAR_NS
 
-script_runner::script_runner(std::function<void(void)> on_update, string exec, string exec_if, bool tail,
+script_runner::script_runner(std::function<void(void)> on_update, const string& exec, const string& exec_if, bool tail,
     interval interval, const vector<pair<string, string>>& env)
     : m_log(logger::make())
     , m_on_update(std::move(on_update))

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -11,12 +11,12 @@
 
 POLYBAR_NS
 
-script_runner::script_runner(std::function<void(void)> on_update, const string& exec, const string& exec_if, bool tail,
+script_runner::script_runner(std::function<void(void)> on_update, string exec, string exec_if, bool tail,
     interval interval, const vector<pair<string, string>>& env)
     : m_log(logger::make())
-    , m_on_update(on_update)
-    , m_exec(exec)
-    , m_exec_if(exec_if)
+    , m_on_update(std::move(on_update))
+    , m_exec(std::move(exec))
+    , m_exec_if(std::move(exec_if))
     , m_tail(tail)
     , m_interval(interval)
     , m_env(env) {}
@@ -60,6 +60,10 @@ int script_runner::get_counter() const {
   return m_counter;
 }
 
+int script_runner::get_exit_status() const {
+  return m_exit_status;
+}
+
 string script_runner::get_output() {
   std::lock_guard<std::mutex> guard(m_output_lock);
   return m_output;
@@ -74,7 +78,7 @@ bool script_runner::is_stopping() const {
  *
  * Returns true if the output changed.
  */
-bool script_runner::set_output(const string&& new_output) {
+bool script_runner::set_output(string&& new_output) {
   std::lock_guard<std::mutex> guard(m_output_lock);
 
   if (m_output != new_output) {
@@ -98,16 +102,16 @@ script_runner::interval script_runner::run() {
     throw modules::module_error("Failed to execute command, stopping module...");
   }
 
-  int status = cmd->get_exit_status();
+  m_exit_status = cmd->get_exit_status();
   int fd = cmd->get_stdout(PIPE_READ);
   assert(fd != -1);
   bool changed = io_util::poll_read(fd) && set_output(cmd->readline());
 
-  if (!changed && status != 0) {
+  if (!changed && m_exit_status != 0) {
     clear_output();
   }
 
-  if (status == 0) {
+  if (m_exit_status == 0) {
     return m_interval;
   } else {
     return std::max(m_interval, interval{1s});
@@ -142,7 +146,7 @@ script_runner::interval script_runner::run_tail() {
     return 0s;
   }
 
-  bool exit_status = cmd->wait();
+  auto exit_status = cmd->wait();
 
   if (exit_status == 0) {
     return m_interval;

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -14,9 +14,9 @@ POLYBAR_NS
 script_runner::script_runner(std::function<void(void)> on_update, const string& exec, const string& exec_if, bool tail,
     interval interval, const vector<pair<string, string>>& env)
     : m_log(logger::make())
-    , m_on_update(std::move(on_update))
-    , m_exec(std::move(exec))
-    , m_exec_if(std::move(exec_if))
+    , m_on_update(on_update)
+    , m_exec(exec)
+    , m_exec_if(exec_if)
     , m_tail(tail)
     , m_interval(interval)
     , m_env(env) {}

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -10,7 +10,6 @@ namespace modules {
       : module<script_module>(bar, move(name_))
       , m_tail(m_conf.get(name(), "tail", false))
       , m_interval(m_conf.get<script_runner::interval>(name(), "interval", m_tail ? 0s : 5s))
-      , m_has_format_fail(m_conf.has(name(), FORMAT_FAIL))
       , m_runner([this]() { broadcast(); }, m_conf.get(name(), "exec", ""s), m_conf.get(name(), "exec-if", ""s), m_tail,
             m_interval, m_conf.get_with_prefix(name(), "env-")) {
     // Load configured click handlers
@@ -29,7 +28,7 @@ namespace modules {
       m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%output%");
     }
 
-    m_formatter->add(FORMAT_FAIL, TAG_LABEL_FAIL, {TAG_LABEL_FAIL});
+    m_formatter->add_optional(FORMAT_FAIL, {TAG_LABEL_FAIL});
     if (m_formatter->has(TAG_LABEL_FAIL)) {
       m_label_fail = load_optional_label(m_conf, name(), TAG_LABEL_FAIL, "%output%");
     }
@@ -77,7 +76,7 @@ namespace modules {
    * Generate module output
    */
   string script_module::get_format() const {
-    if (m_runner.get_exit_status() != 0 && m_has_format_fail) {
+    if (m_runner.get_exit_status() != 0 && m_conf.has(name(), FORMAT_FAIL)) {
       return FORMAT_FAIL;
     }
     return DEFAULT_FORMAT;


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
_The behavior is not changed unless the feature is used. Old configuration files should work the same way._

This PR adds formatting for script failure (when exited with non-zero exit status):

```ini
format-fail = <label-fail>
; and all the others format-fail-*

label-fail = %output%
; and all the others label-fail-*
```

Falls back to `format`, if `format-fail` isn't specified.

The feature is disabled for `tail=true` scripts, since they either run indefinitely (so exit status doesn't have a change to be used) or stop for an `interval` that should be relatively short compared to the lifetime of a script. In both scenarios, exit status is received too late for it to be useful so there's no way to implement meaningful formatting for those scripts.
 
## Related Issues & Documents
Closes #2588 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The following should be added to [Modules/script/Additional Formatting](https://github.com/polybar/polybar/wiki/Module:-script#additional-formatting):

```ini
; Format for script failure (when exited with non-zero exit status)
; If not specified, 'format' is used instead
; Available tags:
;   <label-fail> (default)
format-fail = <label-fail>
format-fail-background = #900
format-fail-foreground = #fff
format-fail-padding = 4

; Available tokens:
;   %output%
; Default: %output%
label-fail = %output:0:15:...%
```