### PR TITLE
fix: Set WM_SIZE_HINTS to fix position in openbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/battery`: More accurate battery state
 ([`#2563`](https://github.com/polybar/polybar/issues/2563))
 - Some modules stop updating when system time moves backwards. ([`#857`](https://github.com/polybar/polybar/issues/857), [`#1932`](https://github.com/polybar/polybar/issues/1932))
+- Broken positioning in Openbox when the bar is hidden and shown again
+  ([`#2021`](https://github.com/polybar/polybar/issues/2021))
 
 ## [3.5.7] - 2021-09-21
 ### Fixed

--- a/include/x11/icccm.hpp
+++ b/include/x11/icccm.hpp
@@ -13,6 +13,8 @@ namespace icccm_util {
   void set_wm_name(xcb_connection_t* c, xcb_window_t w, const char* wmname, size_t l, const char* wmclass, size_t l2);
   void set_wm_protocols(xcb_connection_t* c, xcb_window_t w, vector<xcb_atom_t> flags);
   bool get_wm_urgency(xcb_connection_t* c, xcb_window_t w);
+
+  void set_wm_size_hints(xcb_connection_t* c, xcb_window_t w, int x, int y, int width, int height);
 }
 
 POLYBAR_NS_END

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -593,6 +593,8 @@ void bar::reconfigure_wm_hints() {
 
   m_log.trace("bar: Set window _NET_WM_PID");
   ewmh_util::set_wm_pid(win);
+
+  icccm_util::set_wm_size_hints(m_connection, win, m_opts.pos.x, m_opts.pos.y, m_opts.size.w, m_opts.size.h);
 }
 
 /**
@@ -871,9 +873,6 @@ void bar::start() {
   // With the mapping, the absolute position of our window may have changed (due to re-parenting for example).
   // Notify all components that depend on the absolute bar position (such as the background manager).
   m_sig.emit(signals::ui::update_geometry{});
-
-  // Reconfigure window position after mapping (required by Openbox)
-  reconfigure_pos();
 
   m_log.trace("bar: Draw empty bar");
   m_renderer->begin(m_opts.inner_area());

--- a/src/x11/icccm.cpp
+++ b/src/x11/icccm.cpp
@@ -38,6 +38,18 @@ namespace icccm_util {
     }
     return false;
   }
+
+  void set_wm_size_hints(xcb_connection_t* c, xcb_window_t w, int x, int y, int width, int height) {
+    xcb_size_hints_t hints;
+
+    xcb_icccm_size_hints_set_size(&hints, false, width, height);
+    xcb_icccm_size_hints_set_min_size(&hints, width, height);
+    xcb_icccm_size_hints_set_max_size(&hints, width, height);
+    xcb_icccm_size_hints_set_base_size(&hints, width, height);
+    xcb_icccm_size_hints_set_position(&hints, false, x, y);
+
+    xcb_icccm_set_wm_size_hints(c, w, XCB_ATOM_WM_NORMAL_HINTS, &hints);
+  }
 }
 
 POLYBAR_NS_END


### PR DESCRIPTION


<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
When polybar is remapped (either through IPC or something like xdo
show), openbox positions it somewhere on the screen using the same
positioning algorithm as it would for regular windows.

If the position and size is set in the WM_SIZE_HINTS atom, openbox will
respect the position and size declared by the window.

## Related Issues & Documents

Fixes #2021

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
