### PR TITLE
Skip manpage and html doc installation if they weren't generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Build
 - Fixed compiler warning in Clang 13 ([`#2613`](https://github.com/polybar/polybar/pull/2613))
 - Fixed compiler error in GCC 12 ([`#2616`](https://github.com/polybar/polybar/pull/2616), [`#2614`](https://github.com/polybar/polybar/issues/2614))
+- Fixed installation of docs when some are not generated (man, html...) ([`#2612`](https://github.com/polybar/polybar/pull/2612)
 
 ## [3.6.0] - 2022-03-01
 ### Breaking

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -49,10 +49,12 @@ endforeach()
 # Dummy target that depends on all documentation targets
 add_custom_target(doc ALL DEPENDS ${doc_targets})
 
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
+if (BUILD_DOC_HTML)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
   DESTINATION ${CMAKE_INSTALL_DOCDIR}
   COMPONENT doc
   PATTERN ".buildinfo" EXCLUDE)
+endif()
 
 install(FILES ${CMAKE_SOURCE_DIR}/CHANGELOG.md
   DESTINATION ${CMAKE_INSTALL_DOCDIR}
@@ -62,14 +64,17 @@ install(FILES ${CMAKE_CURRENT_LIST_DIR}/config.ini
   DESTINATION ${CMAKE_INSTALL_DOCDIR}/examples
   COMPONENT doc)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar.1
+if (BUILD_DOC_MAN)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar.1
   DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
   COMPONENT doc)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar-msg.1
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar-msg.1
   DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
   COMPONENT doc)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar.5
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/man/polybar.5
   DESTINATION ${CMAKE_INSTALL_MANDIR}/man5
   COMPONENT doc)
+endif()
+


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Skip manpage and html doc installation if they weren't generated

 Otherwise we get errors like this:

 CMake Error at doc/cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/<<PKGBUILDDIR>>/build/doc/html": No such file or
  directory.
 Call Stack (most recent call first):
  cmake_install.cmake:59 (include)
  
I noticed this issue when packaging the latest release on Debian (I should consider building and shipping the html docs BTW).

## Related Issues & Documents
No issue reported AFAIK.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
