### PR TITLE
Fix a Clang 13 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Build
+- Compiler warning in clang-13 ([`#2613`](https://github.com/polybar/polybar/pull/2613))
 
 ## [3.6.0] - 2022-03-01
 ### Breaking

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -40,9 +40,6 @@ class background_manager;
 class bg_slice;
 
 struct tray_settings {
-  tray_settings() = default;
-  tray_settings& operator=(const tray_settings& o) = default;
-
   alignment align{alignment::NONE};
   bool running{false};
   int rel_x{0};


### PR DESCRIPTION


<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [X] Optimization?
* [ ] Documentation Update
* [X] Other: Remove a compiler warning

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

`-Wdeprecated-copy` found this copy-assignment operator, which it
complains about. Since it is just `= default`, we should be able to
remove both it and the default constructor, leaving the struct as just its
data members.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [X] Does not require documentation changes
