### PR TITLE
fix(build): Do not replace CMAKE_EXE_LINKER_FLAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Build
 - Fixed compiler warning in Clang 13 ([`#2613`](https://github.com/polybar/polybar/pull/2613))
 - Fixed compiler error in GCC 12 ([`#2616`](https://github.com/polybar/polybar/pull/2616), [`#2614`](https://github.com/polybar/polybar/issues/2614))
-- Fixed installation of docs when some are not generated (man, html...) ([`#2612`](https://github.com/polybar/polybar/pull/2612)
+- Fixed installation of docs when some are not generated (man, html...) ([`#2612`](https://github.com/polybar/polybar/pull/2612))
+- Fix `LDFLAGS` not being respected ([`#2619`](https://github.com/polybar/polybar/pull/2619))
 
 ## [3.6.0] - 2022-03-01
 ### Breaking

--- a/cmake/cxx.cmake
+++ b/cmake/cxx.cmake
@@ -108,4 +108,4 @@ string(REPLACE ";" " " cxx_flags_str "${cxx_flags}")
 string(REPLACE ";" " " cxx_linker_flags_str "${cxx_linker_flags}")
 
 # TODO use target_link_options once min cmake version is >= 3.13
-set(CMAKE_EXE_LINKER_FLAGS "${cxx_linker_flags_str}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${cxx_linker_flags_str}")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: *Replace this with a description of the type of this PR*

## Description
CMAKE_EXE_LINKER_FLAGS contains, among other things, the LDFLAGS which
many distros use to universally apply linker flags.
When completely replacing CMAKE_EXE_LINKER_FLAGS, these flags are lost.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
