### PR TITLE
Fix hint message when using deprecated `polybar-msg hook`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `tray-offset-x`, `tray-offset-y`, `offset-x`, and `offset-y` were mistakenly capped below at 0 ([`#2620`](https://github.com/polybar/polybar/pull/2620))
 - `custom/script`: Polybar shutdown being stalled by hanging script ([`#2621`](https://github.com/polybar/polybar/pull/2621))
+- `polybar-msg`: Wrong hint when using deprecated `hook` ([`#2624`](https://github.com/polybar/polybar/pull/2624))
 
 ## [3.6.0] - 2022-03-01
 ### Breaking

--- a/src/polybar-msg.cpp
+++ b/src/polybar-msg.cpp
@@ -141,7 +141,7 @@ static std::pair<ipc::type_t, string> parse_message(deque<string> args) {
 
       fprintf(stderr,
           "Warning: Using IPC hook commands is deprecated, use the hook action on the ipc module: %s %s \"%s\"\n", exec,
-          ipc_type.c_str(), ipc_payload.c_str());
+          "action", ipc_payload.c_str());
     }
   }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

As stated in the 3.6.0 changelog, 
> polybar-msg hook is deprecated in favor of using the hook action. polybar-msg will tell you the correct command to use.

However, it instructs to use another `polybar-msg hook` command, instead of `polybar-msg action`.

Current :
```bash
$ polybar-msg hook count-updates_ipc 1
Warning: Using IPC hook commands is deprecated, use the hook action on the ipc module: polybar-msg hook "#count-updates_ipc.hook.0"
Successfully wrote action '#count-updates_ipc.hook.0' to PID 33971
```
Fixed :
```bash
$ /usr/local/bin/polybar-msg hook count-updates_ipc 1
Warning: Using IPC hook commands is deprecated, use the hook action on the ipc module: /usr/local/bin/polybar-msg action "#count-updates_ipc.hook.0"
Successfully wrote action '#count-updates_ipc.hook.0' to PID 33971
```

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
/

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
