### PR TITLE
fix: Positioning in awesomeWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `format-offset` being ignored ([`#2643`](https://github.com/polybar/polybar/pull/2643))
 - Negative struts (`margin-bottom`, `margin-top`) being ignored ([`#2642`](https://github.com/polybar/polybar/issues/2642), [`#2644`](https://github.com/polybar/polybar/pull/2644))
+- Positioning in awesomeWM ([`#2651`](https://github.com/polybar/polybar/pull/2651))
 
 ## [3.6.1] - 2022-03-05
 ### Build
@@ -166,8 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Empty color values are no longer treated as invalid and no longer produce an error.
 
-[Unreleased]: https://github.com/polybar/polybar/compare/3.6.1...HEAD
-[3.6.1]: https://github.com/polybar/polybar/releases/tag/3.6.1
+[Unreleased]: https://github.com/polybar/polybar/compare/3.6.0...HEAD
 [3.6.0]: https://github.com/polybar/polybar/releases/tag/3.6.0
 [3.5.7]: https://github.com/polybar/polybar/releases/tag/3.5.7
 [3.5.6]: https://github.com/polybar/polybar/releases/tag/3.5.6

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -65,6 +65,8 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   void reconfigure_wm_hints();
   void broadcast_visibility();
 
+  void map_window();
+
   void trigger_click(mousebtn btn, int pos);
 
   void handle(const evt::client_message& evt) override;

--- a/src/x11/icccm.cpp
+++ b/src/x11/icccm.cpp
@@ -1,4 +1,5 @@
 #include "x11/icccm.hpp"
+
 #include "x11/atoms.hpp"
 
 POLYBAR_NS
@@ -33,14 +34,14 @@ namespace icccm_util {
   bool get_wm_urgency(xcb_connection_t* c, xcb_window_t w) {
     xcb_icccm_wm_hints_t hints;
     if (xcb_icccm_get_wm_hints_reply(c, xcb_icccm_get_wm_hints(c, w), &hints, NULL)) {
-      if(xcb_icccm_wm_hints_get_urgency(&hints) == XCB_ICCCM_WM_HINT_X_URGENCY)
+      if (xcb_icccm_wm_hints_get_urgency(&hints) == XCB_ICCCM_WM_HINT_X_URGENCY)
         return true;
     }
     return false;
   }
 
   void set_wm_size_hints(xcb_connection_t* c, xcb_window_t w, int x, int y, int width, int height) {
-    xcb_size_hints_t hints;
+    xcb_size_hints_t hints{};
 
     xcb_icccm_size_hints_set_size(&hints, false, width, height);
     xcb_icccm_size_hints_set_min_size(&hints, width, height);
@@ -50,6 +51,6 @@ namespace icccm_util {
 
     xcb_icccm_set_wm_size_hints(c, w, XCB_ATOM_WM_NORMAL_HINTS, &hints);
   }
-}
+} // namespace icccm_util
 
 POLYBAR_NS_END


### PR DESCRIPTION

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Since polybar sets WM_NORMAL_HINTS, awesomeWM for some reason no longer
respect the position set by polybar before mapping.

reconfiguring the window position once again after mapping the window,
again positions it correctly.


## Related Issues & Documents
Reported on reddit: https://www.reddit.com/r/Polybar/comments/terkd8/polybar_misplacement_in_awesome_wm/

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
