### PR TITLE
fix mouseover error when only one cursor is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Negative struts (`margin-bottom`, `margin-top`) being ignored ([`#2642`](https://github.com/polybar/polybar/issues/2642), [`#2644`](https://github.com/polybar/polybar/pull/2644))
 - Positioning in awesomeWM ([`#2651`](https://github.com/polybar/polybar/pull/2651))
 - `internal/xworkspaces`: The module sometimes crashed polybar when windows were closed. ([`#2655`](https://github.com/polybar/polybar/pull/2655))
+- Mouseover error when only one cursor is defined ([`#2656`](https://github.com/polybar/polybar/pull/2656))
 
 ## [3.6.1] - 2022-03-05
 ### Build

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -101,10 +101,6 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   string m_lastinput{};
   bool m_dblclicks{false};
 
-#if WITH_XCURSOR
-  int m_motion_pos{0};
-#endif
-
   eventloop::TimerHandle& m_leftclick_timer{m_loop.handle<eventloop::TimerHandle>()};
   eventloop::TimerHandle& m_middleclick_timer{m_loop.handle<eventloop::TimerHandle>()};
   eventloop::TimerHandle& m_rightclick_timer{m_loop.handle<eventloop::TimerHandle>()};

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -31,12 +31,7 @@ namespace tags {
 
 class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::property_notify, evt::enter_notify,
                 evt::leave_notify, evt::motion_notify, evt::destroy_notify, evt::client_message, evt::configure_notify>,
-            public signal_receiver<SIGN_PRIORITY_BAR, signals::ui::dim_window
-#if WITH_XCURSOR
-                ,
-                signals::ui::cursor_change
-#endif
-                > {
+            public signal_receiver<SIGN_PRIORITY_BAR, signals::ui::dim_window> {
  public:
   using make_type = unique_ptr<bar>;
   static make_type make(eventloop::loop&, bool only_initialize_values = false);
@@ -80,8 +75,14 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   void handle(const evt::configure_notify& evt) override;
 
   bool on(const signals::ui::dim_window&) override;
+
 #if WITH_XCURSOR
-  bool on(const signals::ui::cursor_change&) override;
+  /**
+   * Change cursor to the given cursor name.
+   *
+   * The cursor name must be valid (cursor_util::valid)
+   */
+  void change_cursor(const string& name);
 #endif
 
  private:

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -99,6 +99,11 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
 
   bar_settings m_opts{};
 
+  /**
+   * Name of currently active cursor
+   */
+  string m_cursor{};
+
   string m_lastinput{};
   bool m_dblclicks{false};
 

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -211,8 +211,19 @@ struct bar_settings {
 
   int double_click_interval{400};
 
+  /**
+   * Name of currently active cursor
+   */
   string cursor{};
+
+  /**
+   * Name of cursor to use for clickable areas
+   */
   string cursor_click{};
+
+  /**
+   * Name of cursor to use for scrollable areas
+   */
   string cursor_scroll{};
 
   vector<action> actions{};

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -212,11 +212,6 @@ struct bar_settings {
   int double_click_interval{400};
 
   /**
-   * Name of currently active cursor
-   */
-  string cursor{};
-
-  /**
    * Name of cursor to use for clickable areas
    */
   string cursor_click{};

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -45,7 +45,7 @@ namespace signals {
      private:
       const void* m_ptr;
     };
-  }  // namespace detail
+  } // namespace detail
 
   namespace eventqueue {
     struct exit_reload : public detail::base_signal<exit_reload> {
@@ -60,7 +60,7 @@ namespace signals {
     struct check_state : public detail::base_signal<check_state> {
       using base_type::base_type;
     };
-  }  // namespace eventqueue
+  } // namespace eventqueue
 
   namespace ipc {
     struct command : public detail::value_signal<command, string> {
@@ -72,16 +72,13 @@ namespace signals {
     struct action : public detail::value_signal<action, string> {
       using base_type::base_type;
     };
-  }  // namespace ipc
+  } // namespace ipc
 
   namespace ui {
     struct changed : public detail::base_signal<changed> {
       using base_type::base_type;
     };
     struct button_press : public detail::value_signal<button_press, string> {
-      using base_type::base_type;
-    };
-    struct cursor_change : public detail::value_signal<cursor_change, string> {
       using base_type::base_type;
     };
     struct visibility_change : public detail::value_signal<visibility_change, bool> {
@@ -101,13 +98,13 @@ namespace signals {
     struct update_geometry : public detail::base_signal<update_geometry> {
       using base_type::base_type;
     };
-  }  // namespace ui
+  } // namespace ui
 
   namespace ui_tray {
     struct mapped_clients : public detail::value_signal<mapped_clients, unsigned int> {
       using base_type::base_type;
     };
-  }  // namespace ui_tray
-}  // namespace signals
+  } // namespace ui_tray
+} // namespace signals
 
 POLYBAR_NS_END

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -19,25 +19,24 @@ namespace signals {
     struct notify_change;
     struct notify_forcechange;
     struct check_state;
-  }  // namespace eventqueue
+  } // namespace eventqueue
   namespace ipc {
     struct command;
     struct hook;
     struct action;
-  }  // namespace ipc
+  } // namespace ipc
   namespace ui {
     struct changed;
     struct button_press;
-    struct cursor_change;
     struct visibility_change;
     struct dim_window;
     struct request_snapshot;
     struct update_background;
     struct update_geometry;
-  }  // namespace ui
+  } // namespace ui
   namespace ui_tray {
     struct mapped_clients;
   }
-}  // namespace signals
+} // namespace signals
 
 POLYBAR_NS_END

--- a/include/x11/cursor.hpp
+++ b/include/x11/cursor.hpp
@@ -9,19 +9,21 @@
 #include <xcb/xcb_cursor.h>
 
 #include "common.hpp"
-#include "x11/connection.hpp"
 #include "utils/string.hpp"
+#include "x11/connection.hpp"
 
 POLYBAR_NS
 
 namespace cursor_util {
   static const std::map<string, vector<string>> cursors = {
-    {"pointer", {"pointing_hand", "pointer", "hand", "hand1", "hand2", "e29285e634086352946a0e7090d73106", "9d800788f1b08800ae810202380a0822"}},
-    {"default", {"left_ptr", "arrow", "dnd-none", "op_left_arrow"}},
-    {"ns-resize", {"size_ver", "sb_v_double_arrow", "v_double_arrow", "n-resize", "s-resize", "col-resize", "top_side", "bottom_side", "base_arrow_up", "base_arrow_down", "based_arrow_down", "based_arrow_up", "00008160000006810000408080010102"}}
-  };
-  bool valid(string name);
-  bool set_cursor(xcb_connection_t *c, xcb_screen_t *screen, xcb_window_t w, string name);
-}
+      {"pointer", {"pointing_hand", "pointer", "hand", "hand1", "hand2", "e29285e634086352946a0e7090d73106",
+                      "9d800788f1b08800ae810202380a0822"}},
+      {"default", {"left_ptr", "arrow", "dnd-none", "op_left_arrow"}},
+      {"ns-resize", {"size_ver", "sb_v_double_arrow", "v_double_arrow", "n-resize", "s-resize", "col-resize",
+                        "top_side", "bottom_side", "base_arrow_up", "base_arrow_down", "based_arrow_down",
+                        "based_arrow_up", "00008160000006810000408080010102"}}};
+  bool valid(const string& name);
+  bool set_cursor(xcb_connection_t* c, xcb_screen_t* screen, xcb_window_t w, const string& name);
+} // namespace cursor_util
 
 POLYBAR_NS_END

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -924,7 +924,7 @@ void bar::change_cursor(const string& name) {
 
   m_opts.cursor = name;
   if (!cursor_util::set_cursor(m_connection, m_connection.screen(), m_opts.window, name)) {
-    m_log.warn("Failed to create cursor context");
+    m_log.warn("Failed to create cursor context for cursor name '%s'", name);
   }
   m_connection.flush();
 }

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -918,11 +918,11 @@ bool bar::on(const signals::ui::dim_window& sig) {
 #if WITH_XCURSOR
 void bar::change_cursor(const string& name) {
   // This is already the same cursor, no need to update
-  if (m_opts.cursor == name) {
+  if (m_cursor == name) {
     return;
   }
+  m_cursor = name;
 
-  m_opts.cursor = name;
   if (!cursor_util::set_cursor(m_connection, m_connection.screen(), m_opts.window, name)) {
     m_log.warn("Failed to create cursor context for cursor name '%s'", name);
   }

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -180,7 +180,6 @@ void controller::conn_cb() {
     } catch (const exception& err) {
       // IDs for events are defined in xproto.h
       m_log.err("Error in X event loop while handling event %d: %s", evt->response_type, err.what());
-      stop(false);
     }
   }
 

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -178,7 +178,8 @@ void controller::conn_cb() {
       m_log.err("X connection error, terminating... (what: %s)", m_connection.error_str(err.code()));
       stop(false);
     } catch (const exception& err) {
-      m_log.err("Error in X event loop: %s", err.what());
+      // IDs for events are defined in xproto.h
+      m_log.err("Error in X event loop while handling event %d: %s", evt->response_type, err.what());
       stop(false);
     }
   }

--- a/src/x11/cursor.cpp
+++ b/src/x11/cursor.cpp
@@ -1,31 +1,43 @@
 #include "x11/cursor.hpp"
 
+#include "utils/scope.hpp"
+
 POLYBAR_NS
 
 namespace cursor_util {
-  bool valid(string name) {
+  bool valid(const string& name) {
     return (cursors.find(name) != cursors.end());
   }
 
-  bool set_cursor(xcb_connection_t *c, xcb_screen_t *screen, xcb_window_t w, string name) {
+  bool set_cursor(xcb_connection_t* c, xcb_screen_t* screen, xcb_window_t w, const string& name) {
     if (!valid(name)) {
       throw std::runtime_error("Tried to set cursor to invalid name: '" + name + "'");
     }
 
-    xcb_cursor_t cursor = XCB_CURSOR_NONE;
-    xcb_cursor_context_t *ctx;
+    xcb_cursor_context_t* ctx;
 
     if (xcb_cursor_context_new(c, screen, &ctx) < 0) {
       return false;
     }
-    for (auto&& cursor_name : cursors.at(name)) {
+
+    scope_util::on_exit<> handler([&] { xcb_cursor_context_free(ctx); });
+
+    xcb_cursor_t cursor = XCB_CURSOR_NONE;
+    for (const auto& cursor_name : cursors.at(name)) {
       cursor = xcb_cursor_load_cursor(ctx, cursor_name.c_str());
-      if (cursor != XCB_CURSOR_NONE)
+      if (cursor != XCB_CURSOR_NONE) {
         break;
+      }
     }
+
+    if (cursor == XCB_CURSOR_NONE) {
+      return false;
+    }
+
     xcb_change_window_attributes(c, w, XCB_CW_CURSOR, &cursor);
-    xcb_cursor_context_free(ctx);
+    xcb_free_cursor(c, cursor);
+
     return true;
   }
-}
+} // namespace cursor_util
 POLYBAR_NS_END

--- a/src/x11/cursor.cpp
+++ b/src/x11/cursor.cpp
@@ -8,6 +8,10 @@ namespace cursor_util {
   }
 
   bool set_cursor(xcb_connection_t *c, xcb_screen_t *screen, xcb_window_t w, string name) {
+    if (!valid(name)) {
+      throw std::runtime_error("Tried to set cursor to invalid name: '" + name + "'");
+    }
+
     xcb_cursor_t cursor = XCB_CURSOR_NONE;
     xcb_cursor_context_t *ctx;
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

If only cursor-click or cursor-scroll is defined, but not the other, the
bar could try to set the cursor to the empty string which resulted in an
error.

Minimal example:

```dosini
[bar/example]
modules-left = text

enable-ipc = true

; cursor-click = pointer
cursor-scroll = ns-resize

[module/text]
type = custom/text
content = %{A1:true:}Click%{A1}%{A4:true:}Scroll%{A4}
```

When mousing over `Scroll` and then over `Click`, polybar produces an error because it tries to change the cursor from `ns-resize` to the empty string (which is not valid).

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
