### PR TITLE
feat(pulseaudio): define invert-scroll option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/script` now doesn't hide failing script if it's output is not changing ([`#2636`](https://github.com/polybar/polybar/issues/2636)). Somewhat similar behaviour can be imitated with `format-fail`, if necessary.
 
 ### Added
-- pulseaudio: Added `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
+- `internal/pulseaudio`: `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
 
 ## [3.6.1] - 2022-03-05
 ### Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 - `custom/script` now doesn't hide failing script if it's output is not changing ([`#2636`](https://github.com/polybar/polybar/issues/2636)). Somewhat similar behaviour can be imitated with `format-fail`, if necessary.
 
+### Added
+- pulseaudio: Added `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
+
 ## [3.6.1] - 2022-03-05
 ### Build
 - Fixed compiler warning in Clang 13 ([`#2613`](https://github.com/polybar/polybar/pull/2613))

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -53,6 +53,7 @@ namespace modules {
     atomic<bool> m_muted{false};
     atomic<int> m_volume{0};
     atomic<double> m_decibels{0};
+    atomic<bool> m_reverse_scroll{false};
   };
 }  // namespace modules
 

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -26,6 +26,7 @@ namespace modules {
 
     auto sink_name = m_conf.get(name(), "sink", ""s);
     bool m_max_volume = m_conf.get(name(), "use-ui-max", true);
+    m_reverse_scroll = m_conf.get(name(), "reverse-scroll", false);
 
     try {
       m_pulseaudio = std::make_unique<pulseaudio>(m_log, move(sink_name), m_max_volume);
@@ -124,8 +125,13 @@ namespace modules {
       }
 
       m_builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "");
-      m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_INC, "");
-      m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_DEC, "");
+      if (!m_reverse_scroll) {
+        m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_INC, "");
+        m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_DEC, "");
+      } else {
+        m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_DEC, "");
+        m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_INC, "");
+      }
     }
 
     m_builder->append(output);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
When we enable natural scrolling option in libinput, it sends scroll down even when we swipe up on the touchpad.  
This makes the pulseaudio module feel weird.  
This option fixes that.


## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Add the following to the wiki under Pulseaudio:

```ini
# Reverses the increment/decrement on scroll event. Set this to true if you are using natural scrolling option on your touchpad.
reverse-scroll = false
```
