### PR TITLE
dev: Make development easier using Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1648400941,
+        "narHash": "sha256-82VdFzqvRY7oRVQyHW7+BYtwdOVH5hmVysYSV/SecF0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d56076aa39859f675bbdc64ea148664406db3278",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    in {
+      devShell.x86_64-linux =
+        pkgs.mkShell {
+          buildInputs = with pkgs; [
+            alsaLib
+            cairo.dev
+            cmake
+            curl.dev
+            i3
+            jsoncpp.dev
+            libmpdclient
+            libpulseaudio
+            libuv
+            pkg-config
+            sphinx
+            wirelesstools
+            xorg.libxcb
+            xorg.xcbproto
+            xorg.xcbutilimage
+            xorg.xcbutilwm.dev
+          ];
+        };
+    };
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [X] Other: Development environment

## Description
If you have Nix (the package manager, not the OS) installed with the flakes feature enabled, you can enter a dev environment by running `nix develop`. 
This will drop you into a shell with all the dependencies required to build polybar with all the features enabled.

These dependencies are locked in flake.lock, so this build environment will be 100% reproducible regardless of the machine you are running.

It also makes life easier for new devs because now they don't have to figure out what the dependencies are, which versions of them will work and what their package names are in ther distro.

## Related Issues & Documents
Nil

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
  It would be good to mention how to use `nix develop` either in the wiki or the Readme.
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
