### PR TITLE
fix(script): output timing inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Positioning in awesomeWM ([`#2651`](https://github.com/polybar/polybar/pull/2651))
 - `internal/xworkspaces`: The module sometimes crashed polybar when windows were closed. ([`#2655`](https://github.com/polybar/polybar/pull/2655))
 - Mouseover error when only one cursor is defined ([`#2656`](https://github.com/polybar/polybar/pull/2656))
+- Timing inconsistencies with `custom/script` output ([`#2650`](https://github.com/polybar/polybar/issues/2650), first described at [`#2630`](https://github.com/polybar/polybar/pull/2630))
 
 ## [3.6.1] - 2022-03-05
 ### Build

--- a/include/adapters/script_runner.hpp
+++ b/include/adapters/script_runner.hpp
@@ -11,9 +11,18 @@ POLYBAR_NS
 
 class script_runner {
  public:
+  struct data {
+    int counter{0};
+    int pid{-1};
+    int exit_status{0};
+    string output;
+  };
+
+  using on_update = std::function<void(const data&)>;
   using interval = std::chrono::duration<double>;
-  script_runner(std::function<void(void)> on_update, const string& exec, const string& exec_if, bool tail,
-      interval interval, const vector<pair<string, string>>& env);
+
+  script_runner(on_update on_update, const string& exec, const string& exec_if, bool tail, interval interval,
+      const vector<pair<string, string>>& env);
 
   bool check_condition() const;
   interval process();
@@ -22,16 +31,11 @@ class script_runner {
 
   void stop();
 
-  int get_pid() const;
-  int get_counter() const;
-  int get_exit_status() const;
-
-  string get_output();
-
   bool is_stopping() const;
 
  protected:
   bool set_output(string&&);
+  bool set_exit_status(int);
 
   interval run_tail();
   interval run();
@@ -39,7 +43,7 @@ class script_runner {
  private:
   const logger& m_log;
 
-  const std::function<void(void)> m_on_update;
+  const on_update m_on_update;
 
   const string m_exec;
   const string m_exec_if;
@@ -47,13 +51,8 @@ class script_runner {
   const interval m_interval;
   const vector<pair<string, string>> m_env;
 
-  std::mutex m_output_lock;
-  string m_output;
-
-  std::atomic_int m_counter{0};
-  std::atomic_bool m_stopping{false};
-  std::atomic_int m_pid{-1};
-  std::atomic_int m_exit_status{0};
+  data m_data;
+  bool m_stopping{false};
 };
 
 POLYBAR_NS_END

--- a/include/adapters/script_runner.hpp
+++ b/include/adapters/script_runner.hpp
@@ -52,7 +52,7 @@ class script_runner {
   const vector<pair<string, string>> m_env;
 
   data m_data;
-  bool m_stopping{false};
+  std::atomic_bool m_stopping{false};
 };
 
 POLYBAR_NS_END

--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -26,6 +26,13 @@ namespace modules {
     bool check_condition();
 
    private:
+    string get_script_output() const;
+    int get_exit_status() const;
+    int get_counter() const;
+    int get_pid() const;
+
+    void handle_runner_update(const script_runner::data&);
+
     static constexpr auto TAG_LABEL = "<label>";
     static constexpr auto TAG_LABEL_FAIL = "<label-fail>";
     static constexpr auto FORMAT_FAIL = "format-fail";
@@ -39,7 +46,10 @@ namespace modules {
 
     label_t m_label;
     label_t m_label_fail;
+
+    script_runner::data m_data;
+    mutable std::mutex m_data_mutex;
   };
-}  // namespace modules
+} // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -26,11 +26,6 @@ namespace modules {
     bool check_condition();
 
    private:
-    string get_script_output() const;
-    int get_exit_status() const;
-    int get_counter() const;
-    int get_pid() const;
-
     void handle_runner_update(const script_runner::data&);
 
     static constexpr auto TAG_LABEL = "<label>";
@@ -47,8 +42,9 @@ namespace modules {
     label_t m_label;
     label_t m_label_fail;
 
+    int m_exit_status{0};
     script_runner::data m_data;
-    mutable std::mutex m_data_mutex;
+    std::mutex m_data_mutex;
   };
 } // namespace modules
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This PR fixes timing inconsistencies of `script` module output, first described at #2630.  
Module now receives updates from corresponding runner callback, instead of directly calling `get_*` methods of the runner.

Synchronization had to be moved to the module itself. I don't quite like the way I did it here as it still leaves a possibility for inconsistencies to occur (e.g. if runner calls update handler during `get_output` execution).  
The alternative would be to hold lock for the whole execution of `get_output`. It heavily relies on (only) `module::get_output` calling `get_format`, since explicit locking inside `get_format` would lead to deadlock. Although this implementation would eliminate any inconsistencies, I find it unstable architecture-wise. Maybe I've missed some other obvious solutions here.

## Related Issues & Documents
Closes #2650 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
