### PR TITLE
fix(script): do not hide failing scripts with constant output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Breaking
+- `custom/script` now doesn't hide failing script if it's output is not changing ([`#2636`](https://github.com/polybar/polybar/issues/2636)). Somewhat similar behaviour can be imitated with `format-fail`, if necessary.
 
 ## [3.6.1] - 2022-03-05
 ### Build

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -106,8 +106,6 @@ script_runner::interval script_runner::run() {
   int fd = cmd.get_stdout(PIPE_READ);
   assert(fd != -1);
 
-  bool changed = false;
-
   bool got_output = false;
   while (!m_stopping && cmd.is_running() && !io_util::poll(fd, POLLHUP, 0)) {
     /**
@@ -115,7 +113,7 @@ script_runner::interval script_runner::run() {
      * down, we still need to continue polling.
      */
     if (io_util::poll_read(fd, 25) && !got_output) {
-      changed = set_output(cmd.readline());
+      set_output(cmd.readline());
       got_output = true;
     }
   }
@@ -126,10 +124,6 @@ script_runner::interval script_runner::run() {
   }
 
   m_exit_status = cmd.wait();
-
-  if (!changed && m_exit_status != 0) {
-    clear_output();
-  }
 
   if (m_exit_status == 0) {
     return m_interval_success;


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
**BREAKING CHANGE:** behaviour is changed for failing scripts with constant output.  
Before this PR they would "blink" due to the `clear_output` call on every other iteration (see #2636).

## Related Issues & Documents
Closes #2636

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
