### PR TITLE
fix(script): clear output when exec-if fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `custom/script`: Output clearing when `exec-if` fails ([`#2674`](https://github.com/polybar/polybar/issues/2674))
 
 ## [3.6.2] - 2022-04-03
 ### Fixed

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -45,8 +45,10 @@ script_runner::interval script_runner::process() {
 }
 
 void script_runner::clear_output() {
-  set_output("");
-  m_on_update(m_data);
+  auto changed = set_output("");
+  if (changed) {
+    m_on_update(m_data);
+  }
 }
 
 void script_runner::stop() {

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -46,6 +46,7 @@ script_runner::interval script_runner::process() {
 
 void script_runner::clear_output() {
   set_output("");
+  m_on_update(m_data);
 }
 
 void script_runner::stop() {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Fixes the issue when output is not cleared after `exec-if` failed.

## Related Issues & Documents
Closes #2674

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
