### PR TITLE
feat(text): Add standard format with label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Breaking
-- `custom/script` now doesn't hide failing script if it's output is not changing ([`#2636`](https://github.com/polybar/polybar/issues/2636)). Somewhat similar behaviour can be imitated with `format-fail`, if necessary.
+- `custom/script`: now doesn't hide failing script if it's output is not changing ([`#2636`](https://github.com/polybar/polybar/issues/2636)). Somewhat similar behaviour can be imitated with `format-fail`, if necessary.
+
+### Deprecated
+- `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
 - `internal/pulseaudio`: `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))
+- `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ## [3.6.2] - 2022-04-03
 ### Fixed

--- a/include/modules/text.hpp
+++ b/include/modules/text.hpp
@@ -12,9 +12,17 @@ namespace modules {
     void update() {}
     string get_format() const;
     string get_output();
+    bool build(builder* builder, const string& tag) const;
 
     static constexpr auto TYPE = "custom/text";
+
+   private:
+    static constexpr const char* TAG_LABEL{"<label>"};
+
+    label_t m_label;
+
+    string m_format{DEFAULT_FORMAT};
   };
-}  // namespace modules
+} // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/text.cpp
+++ b/src/modules/text.cpp
@@ -1,5 +1,6 @@
 #include "modules/text.hpp"
 
+#include "drawtypes/label.hpp"
 #include "modules/meta/base.inl"
 
 POLYBAR_NS
@@ -8,15 +9,28 @@ namespace modules {
   template class module<text_module>;
 
   text_module::text_module(const bar_settings& bar, string name_) : static_module<text_module>(bar, move(name_)) {
-    m_formatter->add("content", "", {});
+    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL});
+    m_formatter->add_optional("content", {});
 
-    if (m_formatter->get("content")->value.empty()) {
-      throw module_error(name() + ".content is empty or undefined");
+    if (m_formatter->has_format("content")) {
+      m_conf.warn_deprecated(name(), "content", "format");
+
+      if (m_formatter->get("content")->value.empty()) {
+        throw module_error(name() + ".content is empty or undefined");
+      }
+
+      m_format = "content";
+    } else {
+      m_format = DEFAULT_FORMAT;
+
+      if (m_formatter->has(TAG_LABEL, DEFAULT_FORMAT)) {
+        m_label = load_label(m_conf, name(), TAG_LABEL);
+      }
     }
   }
 
   string text_module::get_format() const {
-    return "content";
+    return m_format;
   }
 
   string text_module::get_output() {
@@ -51,6 +65,17 @@ namespace modules {
 
     return m_builder->flush();
   }
+
+  bool text_module::build(builder* builder, const string& tag) const {
+    if (tag == TAG_LABEL) {
+      builder->node(m_label);
+    } else {
+      return false;
+    }
+
+    return true;
+  }
+
 } // namespace modules
 
 POLYBAR_NS_END


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Makes the text module use the standard format+label as all other modules in a non-breaking way.

The `content` key is deprecated in favor of `format` which has the exact same functionality, except that it also supports the `<label>` tag.

## Related Issues & Documents
Closes #1331
Closes #1342
Fixes #2673


## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The example under "Additional Formatting" in the wiki should be:

```dosini

; @deprecated Use format and/or label to define the module text
; content = Some random label

; Available tags:
;   <label> (default)
format = <label>
format-background = #000
format-foreground = #fff
format-padding = 4

; No tokens available
label = Some random label
```