### PR TITLE
fix: No overlines/underlines being drawn when using offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/script`: Output clearing when `exec-if` fails ([`#2674`](https://github.com/polybar/polybar/issues/2674))
 - `internal/battery`: `poll-interval` not working ([`#2649`](https://github.com/polybar/polybar/issues/2649), [`#2677`](https://github.com/polybar/polybar/pull/2677))
 - ipc: Polybar failing to open IPC channel after another user already ran polybar, if `XDG_RUNTIME_DIR` is not set ([`#2683`](https://github.com/polybar/polybar/issues/2683), [`#2684`](https://github.com/polybar/polybar/pull/2684))
+- No overlines/underlines being drawn when using offsets ([`#2685`](https://github.com/polybar/polybar/pull/2685))
 
 ## [3.6.2] - 2022-04-03
 ### Fixed

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -72,7 +72,7 @@ class renderer : public renderer_interface,
   void fill_overline(rgba color, double x, double w);
   void fill_underline(rgba color, double x, double w);
   void fill_borders();
-  void draw_offset(rgba color, double x, double w);
+  void draw_offset(const tags::context& ctxt, rgba color, double x, double w);
 
   double block_x(alignment a) const;
   double block_y(alignment a) const;

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -728,8 +728,12 @@ void renderer::render_text(const tags::context& ctxt, const string&& contents) {
   }
 }
 
-void renderer::draw_offset(rgba color, double x, double w) {
-  if (w > 0 && color != m_bar.background) {
+void renderer::draw_offset(const tags::context& ctxt, rgba color, double x, double w) {
+  if (w <= 0) {
+    return;
+  }
+
+  if (color != m_bar.background) {
     m_log.trace_x("renderer: offset(x=%f, w=%f)", x, w);
     m_context->save();
     *m_context << m_comp_bg;
@@ -739,6 +743,14 @@ void renderer::draw_offset(rgba color, double x, double w) {
     m_context->fill();
     m_context->restore();
   }
+
+  if (ctxt.has_underline()) {
+    fill_underline(ctxt.get_ul(), x, w);
+  }
+
+  if (ctxt.has_overline()) {
+    fill_overline(ctxt.get_ol(), x, w);
+  }
 }
 
 void renderer::render_offset(const tags::context& ctxt, const extent_val offset) {
@@ -746,7 +758,7 @@ void renderer::render_offset(const tags::context& ctxt, const extent_val offset)
 
   int offset_width = units_utils::extent_to_pixel(offset, m_bar.dpi_x);
   rgba bg = ctxt.get_bg();
-  draw_offset(bg, m_blocks[m_align].x, offset_width);
+  draw_offset(ctxt, bg, m_blocks[m_align].x, offset_width);
   increase_x(offset_width);
 }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Minimal example

```dosini
[bar/example]
modules-left = text
line-size = 2
width = 100

[module/text]
type = custom/text
content = Foo %{O10} Bar
content-underline = #ff0000
```

*Broken:*

![broken](https://user-images.githubusercontent.com/2452038/162813156-c9fb90c6-b7e1-483d-a70f-687e8eedb035.png)

*Fixed:*

![fixed](https://user-images.githubusercontent.com/2452038/162813159-5bb393b5-980e-4c90-b963-076040c5e175.png)


## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
