### PR TITLE
fix: check if double click action associated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - Added experimental support for positioning the tray like a module
 
+### Fixed
+- Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
+
 ## [3.6.2] - 2022-04-03
 ### Fixed
 - `format-offset` being ignored ([`#2643`](https://github.com/polybar/polybar/pull/2643))

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <set>
 
 #include "common.hpp"
 #include "components/eventloop.hpp"
@@ -104,7 +105,7 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   string m_cursor{};
 
   string m_lastinput{};
-  bool m_dblclicks{false};
+  std::set<mousebtn> m_dblclicks;
 
   eventloop::TimerHandle& m_leftclick_timer{m_loop.handle<eventloop::TimerHandle>()};
   eventloop::TimerHandle& m_middleclick_timer{m_loop.handle<eventloop::TimerHandle>()};

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -415,19 +415,12 @@ void bar::parse(string&& data, bool force) {
 
   m_renderer->end();
 
-  const auto check_dblclicks = [&]() -> bool {
-    if (m_action_ctxt->has_double_click()) {
-      return true;
+  m_dblclicks.clear();
+  for (auto&& action : m_opts.actions) {
+    if (static_cast<int>(action.button) >= static_cast<int>(mousebtn::DOUBLE_LEFT)) {
+      m_dblclicks.insert(action.button);
     }
-
-    for (auto&& action : m_opts.actions) {
-      if (static_cast<int>(action.button) >= static_cast<int>(mousebtn::DOUBLE_LEFT)) {
-        return true;
-      }
-    }
-    return false;
-  };
-  m_dblclicks = check_dblclicks();
+  }
 }
 
 /**
@@ -818,9 +811,12 @@ void bar::handle(const evt::button_press& evt) {
     }
   };
 
+  mousebtn double_btn = mousebtn_get_double(btn);
+  bool has_dblclick = m_dblclicks.count(double_btn) || m_action_ctxt->has_action(double_btn, pos) != tags::NO_ACTION;
+
   // If there are no double click handlers defined we can
   // just by-pass the click timer handling
-  if (!m_dblclicks) {
+  if (!has_dblclick) {
     trigger_click(btn, pos);
   } else if (btn == mousebtn::LEFT) {
     check_double(m_leftclick_timer, btn, pos);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

When a module is clicked, only wait for the double click interval if a double click action is associated with that module. Otherwise trigger the click right away.
The check is button specific, so if the user performs a _right_ click on an area that has an action for a double _left_ click, the right click is triggered immediately.

## Related Issues & Documents

Fixes: #2663

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
