### PR TITLE
Added `scroll-interval` option to `internal/backlight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - Added experimental support for positioning the tray like a module
+- `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696))
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - Added experimental support for positioning the tray like a module
-- `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696))
+- `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -48,7 +48,7 @@ namespace modules {
     string m_path_backlight;
     float m_max_brightness;
     bool m_scroll{false};
-	int m_scroll_interval{5};
+    int m_scroll_interval{5};
     bool m_use_actual_brightness{true};
 
     brightness_handle m_val;

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -48,6 +48,7 @@ namespace modules {
     string m_path_backlight;
     float m_max_brightness;
     bool m_scroll{false};
+	int m_scroll_interval{5};
     bool m_use_actual_brightness{true};
 
     brightness_handle m_val;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -33,7 +33,7 @@ namespace modules {
     // Get flag to check if we should add scroll handlers for changing value
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
 
-	m_scroll_interval = m_conf.get(name(), "scroll-interval", m_scroll_interval);
+    m_scroll_interval = m_conf.get(name(), "scroll-interval", m_scroll_interval);
 
     // Add formats and elements
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR, TAG_RAMP});

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -33,6 +33,8 @@ namespace modules {
     // Get flag to check if we should add scroll handlers for changing value
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
 
+	m_scroll_interval = m_conf.get(name(), "scroll-interval", m_scroll_interval);
+
     // Add formats and elements
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR, TAG_RAMP});
 
@@ -120,11 +122,11 @@ namespace modules {
   }
 
   void backlight_module::action_inc() {
-    change_value(5);
+    change_value(m_scroll_interval);
   }
 
   void backlight_module::action_dec() {
-    change_value(-5);
+    change_value(-m_scroll_interval);
   }
 
   void backlight_module::change_value(int value_mod) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Adds the `scroll-interval` option to `internal/backlight`, which allows the user to set the scrolling interval when changing the backlight module.

## Related Issues & Documents
Closes #2696

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

New config option should be described in Wiki.
