### PR TITLE
fix(bar): Update struts when hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/battery`: `poll-interval` not working ([`#2649`](https://github.com/polybar/polybar/issues/2649), [`#2677`](https://github.com/polybar/polybar/pull/2677))
 - ipc: Polybar failing to open IPC channel after another user already ran polybar, if `XDG_RUNTIME_DIR` is not set ([`#2683`](https://github.com/polybar/polybar/issues/2683), [`#2684`](https://github.com/polybar/polybar/pull/2684))
 - No overlines/underlines being drawn when using offsets ([`#2685`](https://github.com/polybar/polybar/pull/2685))
+- Update struts (`_NET_WM_STRUT_PARTIAL`) when hiding the bar ([`#2702`](https://github.com/polybar/polybar/pull/2702))
 
 ## [3.6.2] - 2022-04-03
 ### Fixed

--- a/src/x11/window.cpp
+++ b/src/x11/window.cpp
@@ -57,14 +57,16 @@ window window::reconfigure_pos(short int x, short int y) {
 window window::reconfigure_struts(uint32_t w, uint32_t strut, uint32_t x, bool bottom) {
   std::array<uint32_t, 12> values{};
 
+  uint32_t end_x = std::max<int>(0, x + w - 1);
+
   if (bottom) {
     values[to_integral(strut::BOTTOM)] = strut;
     values[to_integral(strut::BOTTOM_START_X)] = x;
-    values[to_integral(strut::BOTTOM_END_X)] = x + w - 1;
+    values[to_integral(strut::BOTTOM_END_X)] = end_x;
   } else {
     values[to_integral(strut::TOP)] = strut;
     values[to_integral(strut::TOP_START_X)] = x;
-    values[to_integral(strut::TOP_END_X)] = x + w - 1;
+    values[to_integral(strut::TOP_END_X)] = end_x;
   }
 
   connection().change_property_checked(


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
When the bar is hidden, the struts should be 0 so that WMs can resize
their windows and not leave a gap.



## Related Issues & Documents
Ref #2701

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
