### PR TITLE
feat(backlight): Add reverse-scroll, logarithmic-scroll and click-toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - Added experimental support for positioning the tray like a module
 - `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
+- `internal/backlight`: Added `logarithmic-scroll`, `reverse-scroll` and `logarithmic-scroll` options
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added experimental support for positioning the tray like a module
 - `internal/backlight`: 
   - `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
-  - Added `logarithmic-scroll`, `reverse-scroll` and `logarithmic-scroll` options [`#2703`](https://github.com/polybar/polybar/pull/2703))
+  - Added `logarithmic-scroll`, `reverse-scroll` and `click-toggle` options [`#2703`](https://github.com/polybar/polybar/pull/2703))
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - Added experimental support for positioning the tray like a module
-- `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
-- `internal/backlight`: Added `logarithmic-scroll`, `reverse-scroll` and `logarithmic-scroll` options
+- `internal/backlight`: 
+  - `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
+  - Added `logarithmic-scroll`, `reverse-scroll` and `logarithmic-scroll` options [`#2703`](https://github.com/polybar/polybar/pull/2703))
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -30,12 +30,17 @@ namespace modules {
 
     static constexpr const char* EVENT_INC = "inc";
     static constexpr const char* EVENT_DEC = "dec";
+    static constexpr const char* EVENT_TOGGLE = "toggle";
 
    protected:
+    inline int get_step();
+
+    void action_toggle();
     void action_inc();
     void action_dec();
 
     void change_value(int value_mod);
+    void set_value(int new_value);
 
    private:
     static constexpr auto TAG_LABEL = "<label>";
@@ -53,6 +58,10 @@ namespace modules {
 
     brightness_handle m_val;
     brightness_handle m_max;
+
+    atomic<bool> m_reverse_scroll{false};
+    atomic<bool> m_log_scroll{false};
+    atomic<bool> m_click_toggle{false};
 
     int m_percentage = 0;
   };

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -36,7 +36,6 @@ namespace modules {
 
     m_scroll_interval = m_conf.get(name(), "scroll-interval", m_scroll_interval);
 
-
     // Clicking allows toggling between MAX and MIN brightness. Enables us to have
     // nice small steps while also being able to increase/decrease brighthess quickly.
     m_click_toggle = m_conf.get(name(), "click-toggle", false);
@@ -52,7 +51,6 @@ namespace modules {
     //  <20% = step 3%
     // >=21% = step <scroll-interval>% (defaults to 5)
     m_log_scroll = m_conf.get(name(), "logarithmic-scroll", false);
-
 
     // Add formats and elements
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR, TAG_RAMP});
@@ -113,14 +111,14 @@ namespace modules {
     // the format prefix/suffix also gets wrapped
     // with the cmd handlers
     string output{module::get_output()};
-    
+
     m_builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "");
 
     // reverse-scroll is handled in change_value() so I don't have to duplicate
     // these lines.
     if (m_scroll) {
-        m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_INC, "");
-        m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_DEC, "");
+      m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_INC, "");
+      m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_DEC, "");
     }
 
     m_builder->node(output);
@@ -145,17 +143,17 @@ namespace modules {
   }
 
   // Get inc/dec step so I don't have to repeat the same code or rewrite logic of
-  // the change_value(). 
-  inline int backlight_module::get_step()
-  {
+  // the change_value().
+  inline int backlight_module::get_step() {
     int step = m_scroll_interval;
 
     // No logarithmic-scroll = use scroll-interval as is
-    if( m_log_scroll == false ) return step;
+    if (m_log_scroll == false)
+      return step;
 
-    if( m_percentage <= 5 ) {
+    if (m_percentage <= 5) {
       step = 1;
-    } else if ( m_percentage <= 20 ) {
+    } else if (m_percentage <= 20) {
       step = 3;
     }
 
@@ -165,11 +163,11 @@ namespace modules {
   // Clicking on backlight results in setting to MIN when not MIN. If already MIN
   // is set, set to MAX.
   void backlight_module::action_toggle() {
-    if( m_click_toggle == false ) {
+    if (m_click_toggle == false) {
       return;
     }
 
-    set_value( (m_percentage > 1 ? 1 : m_max_brightness) );
+    set_value((m_percentage > 1 ? 1 : m_max_brightness));
   }
 
   void backlight_module::action_inc() {
@@ -183,7 +181,7 @@ namespace modules {
   // Relative change of current backlight percentage
   void backlight_module::change_value(int value_mod) {
     // Handle "reverse-scroll"
-    if( m_reverse_scroll ) {
+    if (m_reverse_scroll) {
       value_mod *= -1;
     }
 
@@ -192,20 +190,18 @@ namespace modules {
 
     // Don't disable backlight, just set the minimum. Maybe add some config to set
     // boundaries or atleast (dis)allow value of 0?
-    if( value == 0 ) {
+    if (value == 0) {
       value = 1;
     }
 
-    m_log.info("%s: Backlight  [CURR=%d%%  STEP=%d  NEXT=%d%%=>%d",
-                name(),
-                m_percentage, value_mod, rounded, value);
-    set_value( value );
+    m_log.info("%s: Backlight  [CURR=%d%%  STEP=%d  NEXT=%d%%=>%d", name(), m_percentage, value_mod, rounded, value);
+    set_value(value);
   }
 
   // Setting absolute value by writing in to brightness file
   void backlight_module::set_value(int new_value) {
     try {
-      m_log.info("%s: Setting brighness value to %d",name(),new_value);
+      m_log.info("%s: Setting brighness value to %d", name(), new_value);
       file_util::write_contents(m_path_backlight + "/brightness", to_string(new_value));
     } catch (const exception& err) {
       m_log.err(

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -196,7 +196,7 @@ namespace modules {
       value = 1;
     }
 
-    m_log.notice("%s: Backlight  [CURR=%d%%  STEP=%d  NEXT=%d%%=>%d",
+    m_log.info("%s: Backlight  [CURR=%d%%  STEP=%d  NEXT=%d%%=>%d",
                 name(),
                 m_percentage, value_mod, rounded, value);
     set_value( value );


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [X] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
My laptop does not have xbacklight support so I have to use this module, however it does not support reverse-scroll setting.

I added that and while I was at it, I also ported some features from my custom backlight script:
 - click-toggle: Allows you to left-click module, setting backlight to MIN or MAX quickly.
 - logarithmic-scroll: Allows for pseudo-logarithmic scaling of backlight steps.

Reason behind logarithmic scaling is that human eye is much more perceptive to changes in lower side of the spectrum while not so much on the higher side. Meaning that change from 1% -> 5% seems to bude much bigger that 90% -> 95%. This option basically overrides scroll-interval for lower brightness values like this:
 - <= 20% scroll-interval is overrided to 3%
 - <= 5% scroll-interval is set to 1%

I thought about adding some configuration for this however I'm not sure if polybar wants to have that much options for such a simple module. I can, of course, add them if requested :-)

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The wiki documentation may be updated like this:
```ini
[module/backlight]
type = internal/backlight

; Use the following command to list available cards:
; $ ls -1 /sys/class/backlight/
card = intel_backlight

; Use the `/sys/class/backlight/.../actual-brightness` file
; rather than the regular `brightness` file.
; Defaults to true unless the specified card is an amdgpu backlight.
; New in version 3.6.0
use-actual-brightness = true

; Enable changing the backlight with the scroll wheel
; NOTE: This may require additional configuration on some systems. Polybar will
; write to `/sys/class/backlight/${self.card}/brightness` which requires polybar
; to have write access to that file.
; DO NOT RUN POLYBAR AS ROOT. 
; The recommended way is to add the user to the
; `video` group and give that group write-privileges for the `brightness` file.
; See the ArchWiki for more information:
; https://wiki.archlinux.org/index.php/Backlight#ACPI
; Default: false
enable-scroll = true


; Reverse the scroll direction 
; Default: false
reverse-scroll = true

; Use pseudo-logarithmic scaling of scoll-interval. This setting overrides
; scroll-interval for lower brighntess values like this:
;   >20%: use scroll-interval as is
;   <=20%: set scroll-interval to 3%
;   <=5%: set scroll-interval to 1%
; Default: false
logarithmic-scroll = true

; Allows toggle between MIN and MAX brightness by left-clicking the module
; Default: false
click-toggle = true

; Brightness change step (percents)
; Default: 5
scroll-interval = 10
```

