### PR TITLE
filesystem: Use fallback if no mountpoints are specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added experimental support for positioning the tray like a module
 - `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
 
+### Changed
+- `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))
+
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
 

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -27,7 +27,11 @@ namespace modules {
    * setting up required components
    */
   fs_module::fs_module(const bar_settings& bar, string name_) : timer_module<fs_module>(bar, move(name_)) {
-    m_mountpoints = m_conf.get_list(name(), "mount");
+    m_mountpoints = m_conf.get_list(name(), "mount", {});
+    if (m_mountpoints.empty()) {
+      m_log.info("%s: No mountpoints specified, using fallback \"/\"", name());
+      m_mountpoints.emplace_back("/");
+    }
     m_remove_unmounted = m_conf.get(name(), "remove-unmounted", m_remove_unmounted);
     m_perc_used_warn = m_conf.get(name(), "warn-percentage", 90);
     m_fixed = m_conf.get(name(), "fixed-values", m_fixed);


### PR DESCRIPTION
## What type of PR is this?

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other

## Description

When no mountpoints are specified for an `internal/fs` module, use `/` as a fallback and display a warning.

## Related Issues & Documents

Impelements a part of #2572 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

In 'Module: filesystem', in the section 'Basic settings', the lines
```
; Mountpoints to display
mount-0 = /
mount-1 = /home
mount-2 = /var
```
should be changed to 
```
; Mountpoints to display
; Default: /
mount-0 = /
mount-1 = /home
mount-2 = /var
```

