### PR TITLE
fix(pulse): Hanging during connection setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ipc: Polybar failing to open IPC channel after another user already ran polybar, if `XDG_RUNTIME_DIR` is not set ([`#2683`](https://github.com/polybar/polybar/issues/2683), [`#2684`](https://github.com/polybar/polybar/pull/2684))
 - No overlines/underlines being drawn when using offsets ([`#2685`](https://github.com/polybar/polybar/pull/2685))
 - Update struts (`_NET_WM_STRUT_PARTIAL`) when hiding the bar ([`#2702`](https://github.com/polybar/polybar/pull/2702))
+- `internal/pulseaudio`: Hanging during startup ([`#2707`](https://github.com/polybar/polybar/issues/2707), [`#2709`](https://github.com/polybar/polybar/pull/2709))
 
 ## [3.6.2] - 2022-04-03
 ### Fixed

--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -2,6 +2,7 @@
 
 #include <pulse/pulseaudio.h>
 
+#include <atomic>
 #include <queue>
 
 #include "common.hpp"
@@ -57,6 +58,11 @@ class pulseaudio {
   inline void wait_loop(pa_operation* op, pa_threaded_mainloop* loop);
 
   const logger& m_log;
+
+  /**
+   * Has context_state_callback signalled the mainloop during connection.
+   */
+  std::atomic_bool m_state_callback_signal{false};
 
   // used for temporary callback results
   int success{0};


### PR DESCRIPTION


<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

If context_state_callback is called before we call
pa_threaded_mainloop_wait in the main thread, the signal is lost and we
wait forever.

Fixes #2707
Ref #2699
Ref #2697

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
