### PR TITLE
fix: display invalid tags as they are instead of hiding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
+- Display invalid format tags on the bar instead of hiding them ([`#2713`](https://github.com/polybar/polybar/issues/2713), [`#2714`](https://github.com/polybar/polybar/pull/2714))
 
 ## [3.6.3] - 2022-05-04
 ### Fixed

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <map>
 #include <mutex>
+#include <set>
 
 #include "common.hpp"
 #include "components/types.hpp"
@@ -58,7 +59,7 @@ namespace modules {
 
   struct module_format {
     string value{};
-    vector<string> tags{};
+    std::set<string> tags{};
     label_t prefix{};
     label_t suffix{};
     rgba fg{};
@@ -83,15 +84,15 @@ namespace modules {
    public:
     explicit module_formatter(const config& conf, string modname) : m_conf(conf), m_modname(modname) {}
 
-    void add(string name, string fallback, vector<string>&& tags, vector<string>&& whitelist = {});
-    void add_optional(string name, vector<string>&& tags, vector<string>&& whitelist = {});
+    void add(string name, string fallback, std::set<string>&& tags);
+    void add_optional(string name, std::set<string>&& tags);
     bool has(const string& tag, const string& format_name);
     bool has(const string& tag);
     bool has_format(const string& format_name);
     shared_ptr<module_format> get(const string& format_name);
 
    protected:
-    void add_value(string&& name, string&& value, vector<string>&& tags, vector<string>&& whitelist);
+    void add_value(string&& name, string&& value, std::set<string>&& tags);
 
     const config& m_conf;
     string m_modname;

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -63,7 +63,7 @@ namespace modules {
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
 
     // Add formats and create components
-    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, {TAG_LABEL_STATE}, {TAG_LABEL_MONITOR, TAG_LABEL_MODE});
+    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, {TAG_LABEL_STATE, TAG_LABEL_MONITOR, TAG_LABEL_MODE});
 
     if (m_formatter->has(TAG_LABEL_MONITOR)) {
       m_monitorlabel = load_optional_label(m_conf, name(), "label-monitor", DEFAULT_MONITOR_LABEL);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other

## Description

If a formatting string contains an invalid/unsupported tag, it is displayed on the bar as-is in order to make the user aware that there's a mistake in their config.
Before, invalid tags would just be hidden.

## Related Issues & Documents

Fixes #2713

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
