### PR TITLE
feat(xkeyboard): add %shortname% token

### DIFF
--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -112,6 +112,9 @@ namespace modules {
     if (m_layout) {
       m_layout->reset_tokens();
       m_layout->replace_token("%name%", m_keyboard->group_name(m_keyboard->current()));
+      auto short_group_name = m_keyboard->group_name(m_keyboard->current());
+      std::transform(short_group_name.begin(), short_group_name.end(), short_group_name.begin(), ::tolower);
+      m_layout->replace_token("%shortname%", short_group_name.substr(0, 2));
       m_layout->replace_token("%variant%", m_keyboard->variant_name(m_keyboard->current()));
 
       auto const current_layout = m_keyboard->layout_name(m_keyboard->current());


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This takes a string like `English (US)` or `Hebrew` that is produced
by `%name%` and shortens it into a `en` or `he`. This is the same behavior
that used to occur before some upstream changes made `%layout%` useless
on some systems. `%variant%` is *not* a valid replacement due to some layouts 
seemingly not having a variant. (I do not usually touch this, it just annoyed me enough to go patch it out)

## Related Issues & Documents
A quick search didn't find any. 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
  - Need to add to the available tokens list for `label-layout` [here](https://github.com/polybar/polybar/wiki/Module:-xkeyboard#additional-formatting).
* [ ] (I don't know) This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
