### PR TITLE
fix: error reporting for deprecated config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
+- Error reporting for deprecated config values ([`#2724`](https://github.com/polybar/polybar/issues/2724))
 
 ## [3.6.3] - 2022-05-04
 ### Fixed

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -226,6 +226,11 @@ class config {
     } catch (const key_error& err) {
       return get<T>(section, newkey, fallback);
     }
+    catch (const std::exception& err) {
+      m_log.err("Invalid value for \"%s.%s\", using fallback key \"%s.%s\" (reason: %s)",
+                section, old, section, newkey, err.what());
+      return get<T>(section, newkey, fallback);
+    }
   }
 
   /**

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -131,12 +131,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   m_log.info("Loaded monitor %s (%ix%i+%i+%i)", m_opts.monitor->name, m_opts.monitor->w, m_opts.monitor->h,
       m_opts.monitor->x, m_opts.monitor->y);
 
-  try {
-    m_opts.override_redirect = m_conf.get<bool>(bs, "dock");
-    m_conf.warn_deprecated(bs, "dock", "override-redirect");
-  } catch (const key_error& err) {
-    m_opts.override_redirect = m_conf.get(bs, "override-redirect", m_opts.override_redirect);
-  }
+  m_opts.override_redirect = m_conf.deprecated(bs, "dock", "override-redirect", m_opts.override_redirect);
 
   m_opts.dimvalue = m_conf.get(bs, "dim-value", 1.0);
   m_opts.dimvalue = math_util::cap(m_opts.dimvalue, 0.0, 1.0);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This PR adds error handling for value errors when parsing deprecated config values (e.g. when `convert<double>` throws, like in #2724).

I didn't add `warn_deprecate`, since this warning would be the next thing users see after they fix the original error.

## Related Issues & Documents
Closes #2724 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
