### PR TITLE
tray: removed tray-module = adaptive option.

### DIFF
--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -43,7 +43,7 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
 
   const bar_settings& settings() const;
 
-  void start(string tray_module_name);
+  void start(const string& tray_module_name);
 
   void parse(string&& data, bool force = false);
 

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -43,7 +43,7 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
 
   const bar_settings& settings() const;
 
-  void start();
+  void start(string tray_module_name);
 
   void parse(string&& data, bool force = false);
 

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -100,6 +100,7 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
   eventloop::loop& m_loop;
   unique_ptr<bar> m_bar;
   bool m_has_ipc;
+  string m_tray_module_name;
 
   /**
    * @brief Async handle to notify the eventloop

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -39,8 +39,10 @@ class connection;
 class background_manager;
 class bg_slice;
 
+enum class tray_postition { NONE = 0, LEFT, CENTER, RIGHT, MODULE };
+
 struct tray_settings {
-  alignment align{alignment::NONE};
+  tray_postition tray_position{tray_postition::NONE};
   bool running{false};
   int rel_x{0};
   int rel_y{0};
@@ -61,7 +63,6 @@ struct tray_settings {
   rgba foreground{};
   bool transparent{false};
   bool detached{false};
-  bool adaptive{false};
 };
 
 class tray_manager : public xpp::event::sink<evt::expose, evt::visibility_notify, evt::client_message,
@@ -80,7 +81,7 @@ class tray_manager : public xpp::event::sink<evt::expose, evt::visibility_notify
 
   const tray_settings settings() const;
 
-  void setup(string tray_module_name);
+  void setup(const string& tray_module_name);
   void activate();
   void activate_delayed(chrono::duration<double, std::milli> delay = 1s);
   void deactivate(bool clear_selection = true);

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -80,7 +80,7 @@ class tray_manager : public xpp::event::sink<evt::expose, evt::visibility_notify
 
   const tray_settings settings() const;
 
-  void setup();
+  void setup(string tray_module_name);
   void activate();
   void activate_delayed(chrono::duration<double, std::milli> delay = 1s);
   void deactivate(bool clear_selection = true);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -393,13 +393,14 @@ void bar::parse(string&& data, bool force) {
 
   auto rect = m_opts.inner_area();
 
-  if (m_tray && !m_tray->settings().detached && m_tray->settings().configured_slots && !m_tray->settings().adaptive) {
-    auto trayalign = m_tray->settings().align;
+  if (m_tray && !m_tray->settings().detached && m_tray->settings().configured_slots &&
+      m_tray->settings().tray_position != tray_postition::MODULE) {
+    auto tray_pos = m_tray->settings().tray_position;
     auto traywidth = m_tray->settings().configured_w;
-    if (trayalign == alignment::LEFT) {
+    if (tray_pos == tray_postition::LEFT) {
       rect.x += traywidth;
       rect.width -= traywidth;
-    } else if (trayalign == alignment::RIGHT) {
+    } else if (tray_pos == tray_postition::RIGHT) {
       rect.width -= traywidth;
     }
   }
@@ -877,7 +878,7 @@ void bar::handle(const evt::configure_notify&) {
   m_sig.emit(signals::ui::update_geometry{});
 }
 
-void bar::start(string tray_module_name) {
+void bar::start(const string& tray_module_name) {
   m_log.trace("bar: Create renderer");
   m_renderer = renderer::make(m_opts, *m_action_ctxt);
   m_opts.window = m_renderer->window();

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -877,7 +877,7 @@ void bar::handle(const evt::configure_notify&) {
   m_sig.emit(signals::ui::update_geometry{});
 }
 
-void bar::start() {
+void bar::start(string tray_module_name) {
   m_log.trace("bar: Create renderer");
   m_renderer = renderer::make(m_opts, *m_action_ctxt);
   m_opts.window = m_renderer->window();
@@ -905,7 +905,7 @@ void bar::start() {
   m_renderer->end();
 
   m_log.trace("bar: Setup tray manager");
-  m_tray->setup();
+  m_tray->setup(tray_module_name);
 
   broadcast_visibility();
 }

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -594,6 +594,9 @@ size_t controller::setup_modules(alignment align) {
       auto type = m_conf.get("module/" + module_name, "type");
 
       if (type == tray_module::TYPE) {
+        if (!m_tray_module_name.empty()) {
+          throw module_error("Multiple trays defined. Using tray `" + m_tray_module_name + "`");
+        }
         m_tray_module_name = module_name;
       }
 

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -267,7 +267,7 @@ void controller::read_events(bool confwatch) {
     }
 
     if (!m_writeback) {
-      m_bar->start();
+      m_bar->start(m_tray_module_name);
     }
 
     /*
@@ -592,6 +592,10 @@ size_t controller::setup_modules(alignment align) {
 
     try {
       auto type = m_conf.get("module/" + module_name, "type");
+
+      if (type == tray_module::TYPE) {
+        m_tray_module_name = module_name;
+      }
 
       if (type == ipc_module::TYPE && !m_has_ipc) {
         throw application_error("Inter-process messaging needs to be enabled");

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -75,17 +75,23 @@ void tray_manager::setup(string tray_module_name) {
   try {
     position = conf.get(bs, "tray-position");
   } catch (const key_error& err) {
-    return m_log.info("Disabling tray manager (reason: missing `tray-position`)");
   }
 
-  if (position == "left") {
+  if (!position.empty() && !tray_module_name.empty()) {
+    m_log.warn("Tray position is manually defined(`tray-position`) and also set by tray module");
+  }
+  if (position.empty() && tray_module_name.empty()) {
+    return m_log.info("Disabling tray manager (reason: tray module not defined)");
+  }
+
+  if (!tray_module_name.empty()) {
+    m_opts.adaptive = true;
+  } else if (position == "left") {
     m_opts.align = alignment::LEFT;
   } else if (position == "right") {
     m_opts.align = alignment::RIGHT;
   } else if (position == "center") {
     m_opts.align = alignment::CENTER;
-  } else if (position == "adaptive") {
-    m_opts.adaptive = true;
   } else if (position != "none") {
     return m_log.err("Disabling tray manager (reason: Invalid position \"" + position + "\")");
   } else {

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -67,7 +67,7 @@ tray_manager::~tray_manager() {
   deactivate();
 }
 
-void tray_manager::setup() {
+void tray_manager::setup(string tray_module_name) {
   const config& conf = config::make();
   auto bs = conf.section();
   string position;

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -70,17 +70,13 @@ tray_manager::~tray_manager() {
 void tray_manager::setup(const string& tray_module_name) {
   const config& conf = config::make();
   auto bs = conf.section();
-  string position = "none";
+  string position = conf.get(bs, "tray-position", string("none"));
 
-  try {
-    position = conf.get(bs, "tray-position");
-  } catch (const key_error& err) {
-  }
-
-  if (!position.empty() && !tray_module_name.empty()) {
+  if (!position.empty() && position != "none" && !tray_module_name.empty()) {
     m_log.warn(
-        "Tray position is manually defined(`tray-position`) and also set by tray module. `tray-position` will be "
-        "ignored");
+        "The tray position is manually defined (`tray-position`) and also set by the tray module (%s). `tray-position` "
+        "will be ignored",
+        tray_module_name);
   }
 
   if (!tray_module_name.empty()) {

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -70,7 +70,7 @@ tray_manager::~tray_manager() {
 void tray_manager::setup(const string& tray_module_name) {
   const config& conf = config::make();
   auto bs = conf.section();
-  string position = conf.get(bs, "tray-position", string("none"));
+  string position = conf.get(bs, "tray-position", "none"s);
 
   if (!position.empty() && position != "none" && !tray_module_name.empty()) {
     m_log.warn(

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -67,10 +67,10 @@ tray_manager::~tray_manager() {
   deactivate();
 }
 
-void tray_manager::setup(string tray_module_name) {
+void tray_manager::setup(const string& tray_module_name) {
   const config& conf = config::make();
   auto bs = conf.section();
-  string position;
+  string position = "none";
 
   try {
     position = conf.get(bs, "tray-position");
@@ -78,20 +78,19 @@ void tray_manager::setup(string tray_module_name) {
   }
 
   if (!position.empty() && !tray_module_name.empty()) {
-    m_log.warn("Tray position is manually defined(`tray-position`) and also set by tray module");
-  }
-  if (position.empty() && tray_module_name.empty()) {
-    return m_log.info("Disabling tray manager (reason: tray module not defined)");
+    m_log.warn(
+        "Tray position is manually defined(`tray-position`) and also set by tray module. `tray-position` will be "
+        "ignored");
   }
 
   if (!tray_module_name.empty()) {
-    m_opts.adaptive = true;
+    m_opts.tray_position = tray_postition::MODULE;
   } else if (position == "left") {
-    m_opts.align = alignment::LEFT;
+    m_opts.tray_position = tray_postition::LEFT;
   } else if (position == "right") {
-    m_opts.align = alignment::RIGHT;
+    m_opts.tray_position = tray_postition::RIGHT;
   } else if (position == "center") {
-    m_opts.align = alignment::CENTER;
+    m_opts.tray_position = tray_postition::CENTER;
   } else if (position != "none") {
     return m_log.err("Disabling tray manager (reason: Invalid position \"" + position + "\")");
   } else {
@@ -125,17 +124,19 @@ void tray_manager::setup(string tray_module_name) {
 
   auto inner_area = m_bar_opts.inner_area(true);
 
-  switch (m_opts.align) {
-    case alignment::NONE:
+  switch (m_opts.tray_position) {
+    case tray_postition::NONE:
       break;
-    case alignment::LEFT:
+    case tray_postition::LEFT:
       m_opts.orig_x = inner_area.x;
       break;
-    case alignment::CENTER:
+    case tray_postition::CENTER:
       m_opts.orig_x = inner_area.x + inner_area.width / 2 - m_opts.width / 2;
       break;
-    case alignment::RIGHT:
+    case tray_postition::RIGHT:
       m_opts.orig_x = inner_area.x + inner_area.width;
+      break;
+    case tray_postition::MODULE:
       break;
   }
 
@@ -807,9 +808,9 @@ void tray_manager::process_docking_request(xcb_window_t win) {
  */
 int tray_manager::calculate_x(unsigned int width) const {
   auto x = m_opts.orig_x;
-  if (m_opts.align == alignment::RIGHT) {
+  if (m_opts.tray_position == tray_postition::RIGHT) {
     x -= ((m_opts.width + m_opts.spacing) * m_clients.size() + m_opts.spacing);
-  } else if (m_opts.align == alignment::CENTER) {
+  } else if (m_opts.tray_position == tray_postition::CENTER) {
     x -= (width / 2) - (m_opts.width / 2);
   }
   return x;


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
This PR removes the `tray-position` option `adaptive` which was temporarily added in #2595.
It's part of a series of changes outlined in #2689 . Now the tray module is automatically activated when it's added as a module

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Part of #2689

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
