### PR TITLE
tray: tray no longer pushed off the bar

### DIFF
--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -1167,7 +1167,9 @@ bool tray_manager::on(const signals::ui::update_background&) {
 }
 
 bool tray_manager::on(const signals::ui_tray::tray_pos_change& evt) {
-  m_opts.orig_x = m_bar_opts.inner_area(true).x + evt.cast();
+  m_opts.orig_x =
+      m_bar_opts.inner_area(true).x + std::max(0, std::min(evt.cast(), (int)(m_bar_opts.size.w - calculate_w())));
+
   reconfigure_window();
 
   return true;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Tray is no longer pushed off the bar when the bar overflows.

## Related Issues & Documents
Details in #2689
sample config:
```
[bar/example]
modules-left = text tray

enable-ipc = true

tray-position = adaptive

width = 50%
offset-x = 50%
[module/text]
type = custom/text
content = AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

[module/tray]
type = internal/tray

```
 
## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
