### PR TITLE
backlight: auto-detect default card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/fs`: Use `/` as a fallback if no mountpoints are
   specified ([`#2572`](https://github.com/polybar/polybar/issues/2572)
   , [`#2705`](https://github.com/polybar/polybar/pull/2705))
-- `internal/backlight`: Detect backlight if none specified ([`#2728`](https://github.com/polybar/polybar/issues/2728))
+- `internal/backlight`: Detect backlight if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572)
+  , [`#2728`](https://github.com/polybar/polybar/pull/2728))
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
 
 ### Changed
-- `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))
-
+- `internal/fs`: Use `/` as a fallback if no mountpoints are
+  specified ([`#2572`](https://github.com/polybar/polybar/issues/2572)
+  , [`#2705`](https://github.com/polybar/polybar/pull/2705))
+- `internal/backlight`: Detect backlight if none specified ([`#2728`](https://github.com/polybar/polybar/issues/2728))
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
 
 ### Changed
-- `internal/fs`: Use `/` as a fallback if no mountpoints are
-  specified ([`#2572`](https://github.com/polybar/polybar/issues/2572)
-  , [`#2705`](https://github.com/polybar/polybar/pull/2705))
-- `internal/backlight`: Detect backlight if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572)
-  , [`#2728`](https://github.com/polybar/polybar/pull/2728))
+- `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))
+- `internal/backlight`: Detect backlight if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2728`](https://github.com/polybar/polybar/pull/2728))
+
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
 

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -42,6 +42,7 @@ namespace modules {
     static constexpr auto TAG_BAR = "<bar>";
     static constexpr auto TAG_RAMP = "<ramp>";
 
+
     ramp_t m_ramp;
     label_t m_label;
     progressbar_t m_progressbar;

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -42,7 +42,6 @@ namespace modules {
     static constexpr auto TAG_BAR = "<bar>";
     static constexpr auto TAG_RAMP = "<ramp>";
 
-
     ramp_t m_ramp;
     label_t m_label;
     progressbar_t m_progressbar;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -27,7 +27,7 @@ namespace modules {
       : inotify_module<backlight_module>(bar, move(name_)) {
     m_router->register_action(EVENT_DEC, [this]() { action_dec(); });
     m_router->register_action(EVENT_INC, [this]() { action_inc(); });
-    string card = m_conf.get(name(), "card");
+    auto card = m_conf.get(name(), "card", ""s);
     if (card.empty()) {
       vector<string> backlight_card_names = file_util::list_files(string_util::replace(PATH_BACKLIGHT, "%card%", ""));
       backlight_card_names.erase(std::remove_if(backlight_card_names.begin(), backlight_card_names.end(),
@@ -45,6 +45,8 @@ namespace modules {
       card = backlight_card_names.at(0);
       if (backlight_card_names.size() > 1) {
         m_log.warn("%s: multiple backlights found, using %s", name(), card);
+      } else {
+        m_log.info("%s: no backlight specified, using `%s`", name(), card);
       }
     }
     // Get flag to check if we should add scroll handlers for changing value

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -27,27 +27,24 @@ namespace modules {
       : inotify_module<backlight_module>(bar, move(name_)) {
     m_router->register_action(EVENT_DEC, [this]() { action_dec(); });
     m_router->register_action(EVENT_INC, [this]() { action_inc(); });
-    string card;
-    try {
-      card = m_conf.get(name(), "card");
-    } catch (const key_error& err) {
-      if (card.empty()) {
-        vector<string> backlight_card_names = file_util::list_files(string_util::replace(PATH_BACKLIGHT, "%card%", ""));
-        backlight_card_names.erase(std::remove_if(backlight_card_names.begin(), backlight_card_names.end(),
-                                       [&](const string& card) -> bool {
-                                         auto dir = string_util::replace(PATH_BACKLIGHT, "%card%", card);
-                                         return !(file_util::is_file(dir + "/actual_brightness") &&
-                                                  file_util::is_file(dir + "/brightness") &&
-                                                  file_util::is_file(dir + "/max_brightness"));
-                                       }),
-            backlight_card_names.end());
+    string card = m_conf.get(name(), "card");
+    if (card.empty()) {
+      vector<string> backlight_card_names = file_util::list_files(string_util::replace(PATH_BACKLIGHT, "%card%", ""));
+      backlight_card_names.erase(std::remove_if(backlight_card_names.begin(), backlight_card_names.end(),
+                                     [&](const string& card) -> bool {
+                                       auto dir = string_util::replace(PATH_BACKLIGHT, "%card%", card);
+                                       return !(file_util::is_file(dir + "/actual_brightness") &&
+                                                file_util::is_file(dir + "/brightness") &&
+                                                file_util::is_file(dir + "/max_brightness"));
+                                     }),
+          backlight_card_names.end());
 
-        if (backlight_card_names.empty()) {
-          throw module_error("no viable default backlight found");
-        } else if (backlight_card_names.size() > 1) {
-          m_log.notice("backlight: multiple backlights found: first one will be used");
-        }
-        card = backlight_card_names.at(0);
+      if (backlight_card_names.empty()) {
+        throw module_error("no viable default backlight found");
+      }
+      card = backlight_card_names.at(0);
+      if (backlight_card_names.size() > 1) {
+        m_log.warn("%s: multiple backlights found, using %s", name(), card);
       }
     }
     // Get flag to check if we should add scroll handlers for changing value


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Implements the automatic detection of cards for the backlight module(See #2572)
When no `card` is specified, the backlight module looks for a viable card  in `/sys/class/backlight/` and uses that.
## Related Issues & Documents
Implements part of  #2572 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
in modules:backlight the following lines should be changed from: 
```
; Use the following command to list available cards:
; $ ls -1 /sys/class/backlight/
card = intel_backlight
```
to:
```
; Use the following command to list available cards:
; $ ls -1 /sys/class/backlight/
; Default: first usable card in /sys/class/backlight
card = intel_backlight
```