### PR TITLE
battery: auto-detect battery if none specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - Added experimental support for positioning the tray like a module
 - `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
-
+- `internal/battery`: `format-absent` option ([`#2572`](https://github.com/polybar/polybar/issues/2572), TODO: Link PR)
 ### Changed
 - `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))
+- `internal/battery`: Detect battery if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), TODO: Link PR)
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -70,6 +70,7 @@ namespace modules {
     static constexpr const char* FORMAT_DISCHARGING{"format-discharging"};
     static constexpr const char* FORMAT_FULL{"format-full"};
     static constexpr const char* FORMAT_LOW{"format-low"};
+    static constexpr const char* FORMAT_ABSENT{"format-absent"};
 
     static constexpr const char* TAG_ANIMATION_CHARGING{"<animation-charging>"};
     static constexpr const char* TAG_ANIMATION_DISCHARGING{"<animation-discharging>"};
@@ -80,6 +81,7 @@ namespace modules {
     static constexpr const char* TAG_LABEL_DISCHARGING{"<label-discharging>"};
     static constexpr const char* TAG_LABEL_FULL{"<label-full>"};
     static constexpr const char* TAG_LABEL_LOW{"<label-low>"};
+    static constexpr const char* TAG_LABEL_ABSENT{"<label-absent>"};
 
     static const size_t SKIP_N_UNCHANGED{3_z};
 
@@ -92,6 +94,7 @@ namespace modules {
     label_t m_label_discharging;
     label_t m_label_full;
     label_t m_label_low;
+    label_t m_label_absent;
     animation_t m_animation_charging;
     animation_t m_animation_discharging;
     animation_t m_animation_low;
@@ -104,6 +107,7 @@ namespace modules {
     string m_frate;
     string m_fvoltage;
 
+    bool m_present{false};
     state m_state{state::DISCHARGING};
     int m_percentage{0};
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other

## Description

When no battery is specified, `/sys/class/power_supply/` is scanned and the first entry is used. If no battery is found or if the `present` file doesn't read `1`, the new formatting `format-absent`, which is PR introduces, is displayed.

## Related Issues & Documents

Implements part of #2572

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

In `Module: battery` the lines

```
; Use the following command to list batteries and adapters:
; $ ls -1 /sys/class/power_supply/
battery = BAT0
adapter = ADP1
```

should be changed to

```
; Use the following command to list batteries and adapters:
; $ ls -1 /sys/class/power_supply/
; Default: First usable battery in /sys/class/power_supply/
battery = BAT0
adapter = ADP1
```

In addition, the following lines should be inserted after the section for `format-low`

```
; Format used when no battery is present
; Available tags:
;   <label-absent> (default)
;format-absent = <label-absent>
