### PR TITLE
fix:  tray isn't visible when a module updates

### DIFF
--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -1183,7 +1183,11 @@ bool tray_manager::on(const signals::ui_tray::tray_pos_change& evt) {
 }
 
 bool tray_manager::on(const signals::ui_tray::tray_visibility& evt) {
-  return change_visibility(evt.cast());
+  if (m_opts.tray_position == tray_postition::MODULE) {
+    return change_visibility(evt.cast());
+  } else {
+    return true;
+  }
 }
 
 POLYBAR_NS_END


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
I decided to check for the status in the tray_manager since we have the tray_position there. This still results in unnecessary signals being sent but I couldn't find a cleaner way to do it without complicating the code by a bit. 

## Related Issues & Documents
Fixes #2741 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
