### PR TITLE
fix(tag parser): use %% to get a literal percent sign (%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
 - Error reporting for deprecated config values ([`#2724`](https://github.com/polybar/polybar/issues/2724))
+- Use `%%` to get a literal percent sign (`%`) in format tags
 
 ## [3.6.3] - 2022-05-04
 ### Fixed

--- a/src/tags/parser.cpp
+++ b/src/tags/parser.cpp
@@ -65,7 +65,11 @@ namespace tags {
 
     try {
       while ((c = next())) {
-        // TODO here we could think about how to escape an action tag
+        if (c == '%' && has_next() && peek() == '%') {
+          push_char(c);
+          text_parsed = true;
+          consume('%');
+        } else
         if (c == '%' && has_next() && peek() == '{') {
           /*
            * If we have already parsed text, encountering a tag opening means

--- a/tests/unit_tests/tags/parser.cpp
+++ b/tests/unit_tests/tags/parser.cpp
@@ -157,6 +157,12 @@ TEST_F(TagParserTest, text) {
   p.expect_done();
 }
 
+TEST_F(TagParserTest, comment) {
+  p.setup_parser_test("%%{B-}");
+  p.expect_text("%{B-}");
+  p.expect_done();
+}
+
 // Single Tag {{{
 
 // Parse Single Color {{{


### PR DESCRIPTION
As described in the lemonbar docs: https://github.com/LemonBoy/bar#formatting

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [X] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

The [lemonbar documentation](https://github.com/LemonBoy/bar#formatting) says that you can

> Use `%%` to get a literal percent sign (`%`).

That was not implemented in polybar.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [X] Does not require documentation changes
