### PR TITLE
feat(temperature): Add `zone-type` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - Added experimental support for positioning the tray like a module
 - `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
+- `internal/temperature`: Added `zone-type` setting ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2752`](https://github.com/polybar/polybar/pull/2752)) by [@xphoniex](https://github.com/xphoniex)
 
 ### Changed
 - `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))

--- a/cmake/02-opts.cmake
+++ b/cmake/02-opts.cmake
@@ -20,3 +20,5 @@ set(SETTING_PATH_MESSAGING_FIFO "/tmp/polybar_mqueue.%pid%"
   CACHE STRING "Path to file containing the current temperature")
 set(SETTING_PATH_TEMPERATURE_INFO "/sys/class/thermal/thermal_zone%zone%/temp"
   CACHE STRING "Path to file containing the current temperature")
+set(SETTING_PATH_THERMAL_ZONE_WILDCARD "/sys/class/thermal/thermal_zone*"
+  CACHE STRING "Wildcard path to different thermal zones")

--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -30,6 +30,7 @@ namespace modules {
     ramp_t m_ramp;
 
     string m_path;
+    string m_zone_type;
     int m_zone = 0;
     // Base temperature used for where to start the ramp
     int m_tempbase = 0;

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -66,6 +66,7 @@ extern const char* const PATH_CPU_INFO;
 extern const char* const PATH_MEMORY_INFO;
 extern const char* const PATH_MESSAGING_FIFO;
 extern const char* const PATH_TEMPERATURE_INFO;
+extern const char* const PATH_THERMAL_ZONE_WILDCARD;
 extern const char* const WIRELESS_LIB;
 
 bool version_details(const std::vector<std::string>& args);

--- a/src/settings.cpp.cmake
+++ b/src/settings.cpp.cmake
@@ -19,6 +19,7 @@ const char* const PATH_CPU_INFO{"@SETTING_PATH_CPU_INFO@"};
 const char* const PATH_MEMORY_INFO{"@SETTING_PATH_MEMORY_INFO@"};
 const char* const PATH_MESSAGING_FIFO{"@SETTING_PATH_MESSAGING_FIFO@"};
 const char* const PATH_TEMPERATURE_INFO{"@SETTING_PATH_TEMPERATURE_INFO@"};
+const char* const PATH_THERMAL_ZONE_WILDCARD{"@SETTING_PATH_THERMAL_ZONE_WILDCARD@"};
 const char* const WIRELESS_LIB{"@WIRELESS_LIB@"};
 
 bool version_details(const std::vector<std::string>& args) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [x] Feature
* [x] Bug Fix

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

CPU's `thermal-zone` changes on every boot on my machine, sometimes it's `1` and other times it's `2`. Others also have had this issue and resorted to scripts updating the `thermal-zone` before starting `polybar`.

This can simply be fixed using a `zone-type` config option:

If you look at the content in `/sys/class/thermal/thermal_zone%zone%/type`, you'll get the name of the sensor and you can easily deduct zone from that. For example for Intel CPUs, you should set `zone-type = x86_pkg_temp` and you'll be set.

## Related Issues & Documents

Ref #2572

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
