### PR TITLE
Also monitor include-files for changes when --reload is set

### DIFF
--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -44,6 +44,8 @@ class config {
 
   void set_included(file_list included);
 
+  file_list get_included_files() const;
+
   void warn_deprecated(const string& section, const string& key, string replacement) const;
 
   /**
@@ -225,10 +227,9 @@ class config {
       return value;
     } catch (const key_error& err) {
       return get<T>(section, newkey, fallback);
-    }
-    catch (const std::exception& err) {
-      m_log.err("Invalid value for \"%s.%s\", using fallback key \"%s.%s\" (reason: %s)",
-                section, old, section, newkey, err.what());
+    } catch (const std::exception& err) {
+      m_log.err("Invalid value for \"%s.%s\", using fallback key \"%s.%s\" (reason: %s)", section, old, section, newkey,
+          err.what());
       return get<T>(section, newkey, fallback);
     }
   }
@@ -245,10 +246,6 @@ class config {
     } catch (const key_error& err) {
       return get_list<T>(section, newkey, fallback);
     }
-  }
-
-  file_list get_included_files() const {
-    return m_included;
   }
 
  protected:

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -247,6 +247,10 @@ class config {
     }
   }
 
+  file_list get_included_files() const {
+    return m_included;
+  }
+
  protected:
   void copy_inherited();
 

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -55,6 +55,7 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
   void signal_handler(int signum);
 
   void conn_cb();
+  void create_config_watcher(const char* fname);
   void confwatch_handler(const char* fname);
   void notifier_handler();
   void screenshot_handler();

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -55,7 +55,7 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
   void signal_handler(int signum);
 
   void conn_cb();
-  void create_config_watcher(const char* fname);
+  void create_config_watcher(const string& fname);
   void confwatch_handler(const char* fname);
   void notifier_handler();
   void screenshot_handler();

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -59,6 +59,10 @@ void config::set_included(file_list included) {
   m_included = move(included);
 }
 
+file_list config::get_included_files() const {
+  return m_included;
+}
+
 void config::ignore_key(const string& section, const string& key) const {
   if (has(section, key)) {
     m_log.warn(

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -195,14 +195,14 @@ void controller::signal_handler(int signum) {
   stop(signum == SIGUSR1);
 }
 
-void controller::create_config_watcher(const char* filename) {
+void controller::create_config_watcher(const string& filename) {
   auto& fs_event_handler = m_loop.handle<FSEventHandle>();
-    fs_event_handler.start(
-        filename, 0, [this](const auto& e) { confwatch_handler(e.path); },
-        [this, &fs_event_handler](const auto& e) {
-          m_log.err("libuv error while watching included file for changes: %s", uv_strerror(e.status));
-          fs_event_handler.close();
-        });
+  fs_event_handler.start(
+      filename, 0, [this](const auto& e) { confwatch_handler(e.path); },
+      [this, &fs_event_handler](const auto& e) {
+        m_log.err("libuv error while watching included file for changes: %s", uv_strerror(e.status));
+        fs_event_handler.close();
+      });
 }
 
 void controller::confwatch_handler(const char* filename) {
@@ -261,10 +261,10 @@ void controller::read_events(bool confwatch) {
     }
 
     if (confwatch) {
-      create_config_watcher(m_conf.filepath().c_str());
+      create_config_watcher(m_conf.filepath());
       // also watch the include-files for changes
       for (auto& module_path : m_conf.get_included_files()) {
-        create_config_watcher(module_path.c_str());
+        create_config_watcher(module_path);
       }
     }
 

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -195,6 +195,16 @@ void controller::signal_handler(int signum) {
   stop(signum == SIGUSR1);
 }
 
+void controller::create_config_watcher(const char* filename) {
+  auto& fs_event_handler = m_loop.handle<FSEventHandle>();
+    fs_event_handler.start(
+        filename, 0, [this](const auto& e) { confwatch_handler(e.path); },
+        [this, &fs_event_handler](const auto& e) {
+          m_log.err("libuv error while watching included file for changes: %s", uv_strerror(e.status));
+          fs_event_handler.close();
+        });
+}
+
 void controller::confwatch_handler(const char* filename) {
   m_log.notice("Watched config file changed %s", filename);
   stop(true);
@@ -251,24 +261,10 @@ void controller::read_events(bool confwatch) {
     }
 
     if (confwatch) {
-      auto& fs_event_handle = m_loop.handle<FSEventHandle>();
-      fs_event_handle.start(
-          m_conf.filepath(), 0, [this](const auto& e) { confwatch_handler(e.path); },
-          [this, &fs_event_handle](const auto& e) {
-            m_log.err("libuv error while watching config file for changes: %s", uv_strerror(e.status));
-            fs_event_handle.close();
-          });
-
+      create_config_watcher(m_conf.filepath().c_str());
       // also watch the include-files for changes
-      file_list includes = m_conf.get_included_files();
-      for (auto& module_path : includes) {
-        auto& fs_event_handle_include = m_loop.handle<FSEventHandle>();
-        fs_event_handle_include.start(
-            module_path, 0, [this](const auto& e) { confwatch_handler(e.path); },
-            [this, &fs_event_handle_include](const auto& e) {
-              m_log.err("libuv error while watching included file for changes: %s", uv_strerror(e.status));
-              fs_event_handle_include.close();
-            });
+      for (auto& module_path : m_conf.get_included_files()) {
+        create_config_watcher(module_path.c_str());
       }
     }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [X] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

I fixed this issue by creating event handlers for every include-file present in `m_included`. I also added a method `get_included_files` in the controller class to make this possible.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

Fixes #675

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [X] Does not require documentation changes
