### PR TITLE
Kelvin option for module internal/temperature and more accurate calculation of the temperature in °F

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
+- `internal/temperature`: `temperature-k` option displays the temperature in kelvin ([`#2784`](https://github.com/polybar/polybar/pull/2784))
 - `internal/pulseaudio`: `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
-- `internal/temperature`: `temperature-k` option displays the temperature in kelvin ([`#2784`](https://github.com/polybar/polybar/pull/2784))
+- `internal/temperature`: `%temperature-k%` token displays the temperature in kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))
 - `internal/pulseaudio`: `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -53,20 +53,24 @@ namespace modules {
   bool temperature_module::update() {
     m_temp = std::strtol(file_util::contents(m_path).c_str(), nullptr, 10) / 1000.0f + 0.5f;
     int temp_f = floor(((1.8 * m_temp) + 32) + 0.5);
+    int temp_k = m_temp + 273;
 
     string temp_c_string = to_string(m_temp);
     string temp_f_string = to_string(temp_f);
+    strung temp_k_string = to_string(temp_k);
 
     // Add units if `units = true` in config
     if(m_units) {
       temp_c_string += "°C";
       temp_f_string += "°F";
+      temp_k_string += "K";
     }
 
     const auto replace_tokens = [&](label_t& label) {
       label->reset_tokens();
       label->replace_token("%temperature-f%", temp_f_string);
       label->replace_token("%temperature-c%", temp_c_string);
+      laber->replace_token("%temperature-k%", temp_k_string);
 
       // DEPRECATED: Will be removed in later release
       label->replace_token("%temperature%", temp_c_string);

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -51,9 +51,10 @@ namespace modules {
   }
 
   bool temperature_module::update() {
-    m_temp = std::strtol(file_util::contents(m_path).c_str(), nullptr, 10) / 1000.0f + 0.5f;
-    int temp_f = floor(((1.8 * m_temp) + 32) + 0.5);
-    int temp_k = m_temp + 273;
+    int temp = std::strtol(file_util::contents(m_path).c_str(), nullptr, 10);
+    int m_temp = temp / 1000 + 0.5;
+    int temp_f = (temp * 1.8) / 1000 + 32.5;
+    int temp_k = (temp + 273150) / 1000 + 0.5;
 
     string temp_c_string = to_string(m_temp);
     string temp_f_string = to_string(temp_f);

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -57,7 +57,7 @@ namespace modules {
 
     string temp_c_string = to_string(m_temp);
     string temp_f_string = to_string(temp_f);
-    strung temp_k_string = to_string(temp_k);
+    string temp_k_string = to_string(temp_k);
 
     // Add units if `units = true` in config
     if(m_units) {
@@ -70,7 +70,7 @@ namespace modules {
       label->reset_tokens();
       label->replace_token("%temperature-f%", temp_f_string);
       label->replace_token("%temperature-c%", temp_c_string);
-      laber->replace_token("%temperature-k%", temp_k_string);
+      label->replace_token("%temperature-k%", temp_k_string);
 
       // DEPRECATED: Will be removed in later release
       label->replace_token("%temperature%", temp_c_string);

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -51,10 +51,10 @@ namespace modules {
   }
 
   bool temperature_module::update() {
-    int temp = std::strtol(file_util::contents(m_path).c_str(), nullptr, 10);
-    int m_temp = temp / 1000 + 0.5;
-    int temp_f = (temp * 1.8) / 1000 + 32.5;
-    int temp_k = (temp + 273150) / 1000 + 0.5;
+    float temp = float(std::strtol(file_util::contents(m_path).c_str(), nullptr, 10)) / 1000.0;
+    m_temp     = std::round( temp );
+    int temp_f = std::round( (temp * 1.8) + 32.0 );
+    int temp_k = std::round( temp + 273.15 );
 
     string temp_c_string = to_string(m_temp);
     string temp_f_string = to_string(temp_f);

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -52,9 +52,9 @@ namespace modules {
 
   bool temperature_module::update() {
     float temp = float(std::strtol(file_util::contents(m_path).c_str(), nullptr, 10)) / 1000.0;
-    m_temp     = std::round( temp );
-    int temp_f = std::round( (temp * 1.8) + 32.0 );
-    int temp_k = std::round( temp + 273.15 );
+    m_temp     = std::lround( temp );
+    int temp_f = std::lround( (temp * 1.8) + 32.0 );
+    int temp_k = std::lround( temp + 273.15 );
 
     string temp_c_string = to_string(m_temp);
     string temp_f_string = to_string(temp_f);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
implements temperature in Kelvin for the temperature module
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
implements idea #2774

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
    - just 2 lines for the formatting options of internal/temperature, I can do that, if you want
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
