### PR TITLE
Instantiate tray in module

### DIFF
--- a/include/modules/tray.hpp
+++ b/include/modules/tray.hpp
@@ -2,6 +2,7 @@
 
 #include "common.hpp"
 #include "components/bar.hpp"
+#include "x11/tray_manager.hpp"
 #include "modules/meta/static_module.hpp"
 
 POLYBAR_NS
@@ -11,6 +12,8 @@ namespace modules {
    public:
     explicit tray_module(const bar_settings& bar_settings, string name_);
     string get_format() const;
+
+    void start() override;
 
     bool build(builder* builder, const string& tag) const;
     void update() {}
@@ -22,6 +25,8 @@ namespace modules {
 
    private:
     static constexpr const char* TAG_TRAY{"<tray>"};
+
+    tray_manager m_tray;
 
     int m_width{0};
   };

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -73,7 +73,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
     , m_action_ctxt(forward<decltype(action_ctxt)>(action_ctxt)) {
   string bs{m_conf.section()};
 
-  m_tray = tray_manager::make(m_opts);
+  // m_tray = tray_manager::make(m_opts);
 
   // Get available RandR outputs
   auto monitor_name = m_conf.get(bs, "monitor", ""s);
@@ -837,9 +837,7 @@ void bar::handle(const evt::button_press& evt) {
  */
 void bar::handle(const evt::expose& evt) {
   if (evt->window == m_opts.window && evt->count == 0) {
-    if (m_tray->settings().running) {
-      broadcast_visibility();
-    }
+    broadcast_visibility();
 
     m_log.trace("bar: Received expose event");
     m_renderer->flush();
@@ -901,7 +899,7 @@ void bar::start(const string& tray_module_name) {
   m_renderer->end();
 
   m_log.trace("bar: Setup tray manager");
-  m_tray->setup(tray_module_name);
+  // m_tray->setup(tray_module_name);
 
   broadcast_visibility();
 }

--- a/src/modules/tray.cpp
+++ b/src/modules/tray.cpp
@@ -1,19 +1,27 @@
 #include "modules/tray.hpp"
 
 #include "modules/meta/base.inl"
+#include "x11/background_manager.hpp"
 
 POLYBAR_NS
 namespace modules {
   template class module<tray_module>;
 
   tray_module::tray_module(const bar_settings& bar_settings, string name_)
-      : static_module<tray_module>(bar_settings, move(name_)) {
+      : static_module<tray_module>(bar_settings, move(name_))
+      , m_tray(connection::make(), signal_emitter::make(), logger::make(), background_manager::make(), bar_settings) {
     m_formatter->add(DEFAULT_FORMAT, TAG_TRAY, {TAG_TRAY});
     m_sig.attach(this);
   }
 
   string tray_module::get_format() const {
     return DEFAULT_FORMAT;
+  }
+
+  void tray_module::start() {
+    // TODO do this AFTER the bar window is created
+    m_tray.setup(name_raw());
+    this->static_module<tray_module>::start();
   }
 
   bool tray_module::build(builder* builder, const string& tag) const {
@@ -36,5 +44,5 @@ namespace modules {
     m_sig.detach(this);
   }
 
-}  // namespace modules
+} // namespace modules
 POLYBAR_NS_END


### PR DESCRIPTION

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [x] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Make tray module instantiate tray. bar.cpp should only start a tray if
`tray-position` is set.

**TODO**

* [ ] Start modules after starting bar -> tray module has access to bar window id

## Related Issues & Documents
Requirement for #2609

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
