### PR TITLE
i3 pin-workspaces behaviour for a named monitor output.

### DIFF
--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -96,6 +96,7 @@ namespace modules {
     bool m_show_urgent{false};
     bool m_strip_wsnumbers{false};
     bool m_fuzzy_match{false};
+    string m_pinned_output;
 
     unique_ptr<i3_util::connection_t> m_ipc;
   };

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -96,7 +96,7 @@ namespace modules {
     bool m_show_urgent{false};
     bool m_strip_wsnumbers{false};
     bool m_fuzzy_match{false};
-    string m_pinned_output;
+    string m_pin_output;
 
     unique_ptr<i3_util::connection_t> m_ipc;
   };

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -32,6 +32,7 @@ namespace modules {
     m_wrap = m_conf.get(name(), "wrapping-scroll", m_wrap);
     m_indexsort = m_conf.get(name(), "index-sort", m_indexsort);
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
+    m_pinned_output = m_conf.get(name(), "output", m_bar.monitor->name);
     m_show_urgent = m_conf.get(name(), "show-urgent", m_show_urgent);
     m_strip_wsnumbers = m_conf.get(name(), "strip-wsnumbers", m_strip_wsnumbers);
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
@@ -137,7 +138,7 @@ namespace modules {
       vector<shared_ptr<i3_util::workspace_t>> workspaces;
 
       if (m_pinworkspaces) {
-        workspaces = i3_util::workspaces(ipc, m_bar.monitor->name, m_show_urgent);
+        workspaces = i3_util::workspaces(ipc, m_pinned_output, m_show_urgent);
       } else {
         workspaces = i3_util::workspaces(ipc);
       }

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -32,7 +32,7 @@ namespace modules {
     m_wrap = m_conf.get(name(), "wrapping-scroll", m_wrap);
     m_indexsort = m_conf.get(name(), "index-sort", m_indexsort);
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
-    m_pinned_output = m_conf.get(name(), "output", m_bar.monitor->name);
+    m_pin_output = m_conf.get(name(), "pin-output", m_bar.monitor->name);
     m_show_urgent = m_conf.get(name(), "show-urgent", m_show_urgent);
     m_strip_wsnumbers = m_conf.get(name(), "strip-wsnumbers", m_strip_wsnumbers);
     m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
@@ -138,7 +138,7 @@ namespace modules {
       vector<shared_ptr<i3_util::workspace_t>> workspaces;
 
       if (m_pinworkspaces) {
-        workspaces = i3_util::workspaces(ipc, m_pinned_output, m_show_urgent);
+        workspaces = i3_util::workspaces(ipc, m_pin_output, m_show_urgent);
       } else {
         workspaces = i3_util::workspaces(ipc);
       }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Adds a new configuration for module i3:
* `pin-output` - If `pin-workspaces` is set, will pin workspaces associated with the named monitor instead of the current monitor

## Related Issues & Documents
Closes [#1625](https://github.com/polybar/polybar/issues/1625)

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Documentation to be added to [i3 module page](https://github.com/polybar/polybar/wiki/Module:-i3) - under description of pin-output configuration:
```
; Pin workspaces defined on monitor 'DP-1' instead of the same output as the bar
;
; Default: empty
pin-output = DP-1
```