### PR TITLE
negative minimum length adds right padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))
 - `internal/backlight`: Detect backlight if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2728`](https://github.com/polybar/polybar/pull/2728))
+- Providing a negative min-width to a token adds right-padding ([`#2789`](https://github.com/polybar/polybar/issues/2789), [`#2801`](https://github.com/polybar/polybar/pull/2801)) by [@VanillaViking](https://github.com/VanillaViking).
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -16,6 +16,7 @@ namespace drawtypes {
     size_t max{0_z};
     string suffix{""s};
     bool zpad{false};
+    bool rpadding{false};
   };
 
   class label : public non_copyable_mixin {

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -86,6 +86,9 @@ namespace drawtypes {
         if (tok.max != 0_z && string_util::char_len(repl) > tok.max) {
           repl = string_util::utf8_truncate(std::move(repl), tok.max) + tok.suffix;
         } else if (tok.min != 0_z && repl.length() < tok.min) {
+          if (tok.rpadding) {
+            repl.append(tok.min - repl.length(), ' ');
+          }
           repl.insert(0_z, tok.min - repl.length(), tok.zpad ? '0' : ' ');
         }
 
@@ -231,6 +234,10 @@ namespace drawtypes {
       text = string_util::replace(text, token_str, token.token);
 
       try {
+        if (token_str[pos + 1] == '-') {
+          token.rpadding = true;
+          pos++;
+        }
         token.min = std::stoul(&token_str[pos + 1], nullptr, 10);
         // When the number starts with 0 the string is 0-padded
         token.zpad = token_str[pos + 1] == '0';

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -88,8 +88,9 @@ namespace drawtypes {
         } else if (tok.min != 0_z && repl.length() < tok.min) {
           if (tok.rpadding) {
             repl.append(tok.min - repl.length(), ' ');
+          } else {
+            repl.insert(0_z, tok.min - repl.length(), tok.zpad ? '0' : ' ');
           }
-          repl.insert(0_z, tok.min - repl.length(), tok.zpad ? '0' : ' ');
         }
 
         /*


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Closes #2789 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)

Mention how to do left alignment (right-padding) in the "Token" section of the "Formatting" wiki page

* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
