### PR TITLE
Added format-x support for ipc_module, tested with demo config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
+-  Added support for format-i for each hook-i defined in ipc module ([`#2775`](https://github.com/polybar/polybar/issues/2775),  [`#2810`](https://github.com/polybar/polybar/pull/2810))  by [@madhavpcm](https://github.com/madhavpcm).
 - `internal/temperature`: `%temperature-k%` token displays the temperature in kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))
 - `internal/pulseaudio`: `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))

--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -29,6 +29,7 @@ namespace modules {
     void start() override;
     void update();
     string get_output();
+    string get_format() const;
     bool build(builder* builder, const string& tag) const;
     void on_message(const string& message);
 

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -110,7 +110,7 @@ namespace modules {
   string ipc_module::get_format() const {
     if (m_current_hook != -1 && (size_t)m_current_hook < m_hooks.size()) {
       string format_i = "format-" + to_string(m_current_hook);
-      if (m_conf.has(m_name, format_i)) {
+      if (m_formatter->has_format(format_i)) {
         return format_i;
       } else {
         return DEFAULT_FORMAT;

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -116,6 +116,7 @@ namespace modules {
         return DEFAULT_FORMAT;
       }
     }
+    return DEFAULT_FORMAT;
   }
   /**
    * Output content retrieved from hook commands

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -61,11 +61,9 @@ namespace modules {
     }
     m_formatter->add(DEFAULT_FORMAT, TAG_OUTPUT, {TAG_OUTPUT});
 
-
-    for(size_t i=0; i < m_hooks.size(); i++){
-        string format_i= "format-" + to_string(i) ;
-        format_i= "format-" + to_string(i) ;
-        m_formatter->add(format_i, TAG_OUTPUT, {TAG_OUTPUT});
+    for (size_t i = 0; i < m_hooks.size(); i++) {
+      string format_i = "format-" + to_string(i);
+      m_formatter->add_optional(format_i, {TAG_OUTPUT});
     }
   }
 
@@ -110,13 +108,14 @@ namespace modules {
   }
 
   string ipc_module::get_format() const {
-      if( m_current_hook != -1 && (size_t)m_current_hook < m_hooks.size()){
-        return "format-" + to_string(m_current_hook);
+    if (m_current_hook != -1 && (size_t)m_current_hook < m_hooks.size()) {
+      string format_i = "format-" + to_string(m_current_hook);
+      if (m_conf.has(m_name, format_i)) {
+        return format_i;
+      } else {
+        return DEFAULT_FORMAT;
       }
-      else{
-        throw module_error("Initial hook out of bounds: '" + to_string(m_initial + 1) +
-                           "'. Defined hooks go from 1 to " + to_string(m_hooks.size()) + ")");
-      }
+    }
   }
   /**
    * Output content retrieved from hook commands
@@ -165,7 +164,8 @@ namespace modules {
       }
     } catch (const std::invalid_argument& err) {
       m_log.err(
-          "%s: Hook action received '%s' cannot be converted to a valid hook index. Defined hooks goes from 0 to %zu.",
+          "%s: Hook action received '%s' cannot be converted to a valid hook index. Defined hooks goes from 0 to "
+          "%zu.",
           name(), data, m_hooks.size() - 1);
     }
   }

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -59,8 +59,14 @@ namespace modules {
     for (auto& hook : m_hooks) {
       hook->command = pid_token(hook->command);
     }
-
     m_formatter->add(DEFAULT_FORMAT, TAG_OUTPUT, {TAG_OUTPUT});
+
+
+    for(size_t i=0; i < m_hooks.size(); i++){
+        string format_i= "format-" + to_string(i) ;
+        format_i= "format-" + to_string(i) ;
+        m_formatter->add(format_i, TAG_OUTPUT, {TAG_OUTPUT});
+    }
   }
 
   /**
@@ -103,6 +109,15 @@ namespace modules {
     return m_builder->flush();
   }
 
+  string ipc_module::get_format() const {
+      if( m_current_hook != -1 && (size_t)m_current_hook < m_hooks.size()){
+        return "format-" + to_string(m_current_hook);
+      }
+      else{
+        throw module_error("Initial hook out of bounds: '" + to_string(m_initial + 1) +
+                           "'. Defined hooks go from 1 to " + to_string(m_hooks.size()) + ")");
+      }
+  }
   /**
    * Output content retrieved from hook commands
    */


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Users can now assign separate formats for different hooks inside the IPC module.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Closes #2775 
## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Changes to documentation
-----
In wiki > Modules > ipc
Examples,
```
[module/demo]
type = custom/ipc
hook-0 = echo foobar
hook-1 = date +%s
hook-2 = whoami
format= <label>
format-0-foreground= ${color.foreground}
format-1-foreground= ${color.foreground}
format-2-foreground= ${color.foreground}
; Based on colors defined by user
format-0-background= ${color.shade1}
format-1-background= ${color.shade2}
format-2-background= ${color.shade3}
initial = 1
click-left = "#demo.hook.0"
click-right = "#demo.hook.1"
double-click-left = "#demo.hook.2"

``` 