### PR TITLE
feat(xwindow): %instance%, %class% from WM_CLASS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added experimental support for positioning the tray like a module
 - `internal/backlight`: `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
 - `internal/temperature`: Added `zone-type` setting ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2752`](https://github.com/polybar/polybar/pull/2752)) by [@xphoniex](https://github.com/xphoniex)
+- `internal/xwindow`: `%class%` and `%instance%` tokens, which show the contents of the `WM_CLASS` property of the active window ([`#2830`](https://github.com/polybar/polybar/pull/2830))
 
 ### Changed
 - `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))

--- a/include/modules/xwindow.hpp
+++ b/include/modules/xwindow.hpp
@@ -11,13 +11,15 @@ POLYBAR_NS
 class connection;
 
 namespace modules {
-  class active_window {
+  class active_window : public non_copyable_mixin, public non_movable_mixin {
    public:
     explicit active_window(xcb_connection_t* conn, xcb_window_t win);
     ~active_window();
 
-    bool match(const xcb_window_t win) const;
+    bool match(xcb_window_t win) const;
     string title() const;
+    string instance_name() const;
+    string class_name() const;
 
    private:
     xcb_connection_t* m_connection{nullptr};
@@ -33,13 +35,15 @@ namespace modules {
     enum class state { NONE, ACTIVE, EMPTY };
     explicit xwindow_module(const bar_settings&, string);
 
-    void update(bool force = false);
+    void update();
     bool build(builder* builder, const string& tag) const;
 
     static constexpr auto TYPE = "internal/xwindow";
 
    protected:
     void handle(const evt::property_notify& evt) override;
+
+    void reset_active_window();
 
    private:
     static constexpr const char* TAG_LABEL{"<label>"};
@@ -49,6 +53,6 @@ namespace modules {
     map<state, label_t> m_statelabels;
     label_t m_label;
   };
-}  // namespace modules
+} // namespace modules
 
 POLYBAR_NS_END

--- a/include/x11/atoms.hpp
+++ b/include/x11/atoms.hpp
@@ -10,7 +10,7 @@ struct cached_atom {
   xcb_atom_t& atom;
 };
 
-extern std::array<cached_atom, 37> ATOMS;
+extern std::array<cached_atom, 38> ATOMS;
 
 extern xcb_atom_t _NET_SUPPORTED;
 extern xcb_atom_t _NET_CURRENT_DESKTOP;
@@ -49,3 +49,4 @@ extern xcb_atom_t _COMPTON_SHADOW;
 extern xcb_atom_t _NET_WM_WINDOW_OPACITY;
 extern xcb_atom_t WM_HINTS;
 extern xcb_atom_t WM_NAME;
+extern xcb_atom_t WM_CLASS;

--- a/include/x11/icccm.hpp
+++ b/include/x11/icccm.hpp
@@ -8,6 +8,7 @@ POLYBAR_NS
 
 namespace icccm_util {
   string get_wm_name(xcb_connection_t* c, xcb_window_t w);
+  pair<string, string> get_wm_class(xcb_connection_t* c, xcb_window_t w);
   string get_reply_string(xcb_icccm_get_text_property_reply_t* reply);
 
   void set_wm_name(xcb_connection_t* c, xcb_window_t w, const char* wmname, size_t l, const char* wmclass, size_t l2);
@@ -15,6 +16,6 @@ namespace icccm_util {
   bool get_wm_urgency(xcb_connection_t* c, xcb_window_t w);
 
   void set_wm_size_hints(xcb_connection_t* c, xcb_window_t w, int x, int y, int width, int height);
-}
+} // namespace icccm_util
 
 POLYBAR_NS_END

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -58,6 +58,14 @@ namespace modules {
     }
   }
 
+  string active_window::instance_name() const {
+    return icccm_util::get_wm_class(m_connection, m_window).first;
+  }
+
+  string active_window::class_name() const {
+    return icccm_util::get_wm_class(m_connection, m_window).second;
+  }
+
   /**
    * Construct module
    */
@@ -85,10 +93,13 @@ namespace modules {
    */
   void xwindow_module::handle(const evt::property_notify& evt) {
     if (evt->atom == _NET_ACTIVE_WINDOW) {
-      update(true);
+      reset_active_window();
+      update();
     } else if (evt->atom == _NET_CURRENT_DESKTOP) {
-      update(true);
-    } else if (evt->atom == _NET_WM_NAME || evt->atom == _NET_WM_VISIBLE_NAME || evt->atom == WM_NAME) {
+      reset_active_window();
+      update();
+    } else if (evt->atom == _NET_WM_NAME || evt->atom == _NET_WM_VISIBLE_NAME || evt->atom == WM_NAME ||
+               evt->atom == WM_CLASS) {
       update();
     } else {
       return;
@@ -97,24 +108,27 @@ namespace modules {
     broadcast();
   }
 
+  void xwindow_module::reset_active_window() {
+    m_active.reset();
+  }
+
   /**
    * Update the currently active window and query its title
    */
-  void xwindow_module::update(bool force) {
-    xcb_window_t win;
-
-    if (force) {
-      m_active.reset();
-    }
-
-    if (!m_active && (win = ewmh_util::get_active_window()) != XCB_NONE) {
-      m_active = make_unique<active_window>(m_connection, win);
+  void xwindow_module::update() {
+    if (!m_active) {
+      xcb_window_t win = ewmh_util::get_active_window();
+      if (win != XCB_NONE) {
+        m_active = make_unique<active_window>(m_connection, win);
+      }
     }
 
     if (m_active) {
       m_label = m_statelabels.at(state::ACTIVE)->clone();
       m_label->reset_tokens();
       m_label->replace_token("%title%", m_active->title());
+      m_label->replace_token("%instance%", m_active->instance_name());
+      m_label->replace_token("%class%", m_active->class_name());
     } else {
       m_label = m_statelabels.at(state::EMPTY)->clone();
     }

--- a/src/x11/atoms.cpp
+++ b/src/x11/atoms.cpp
@@ -40,9 +40,10 @@ xcb_atom_t _COMPTON_SHADOW;
 xcb_atom_t _NET_WM_WINDOW_OPACITY;
 xcb_atom_t WM_HINTS;
 xcb_atom_t WM_NAME;
+xcb_atom_t WM_CLASS;
 
 // clang-format off
-std::array<cached_atom, 37> ATOMS = {{
+std::array<cached_atom, 38> ATOMS = {{
   {"_NET_SUPPORTED", _NET_SUPPORTED},
   {"_NET_CURRENT_DESKTOP", _NET_CURRENT_DESKTOP},
   {"_NET_ACTIVE_WINDOW", _NET_ACTIVE_WINDOW},
@@ -80,5 +81,6 @@ std::array<cached_atom, 37> ATOMS = {{
   {"_NET_WM_WINDOW_OPACITY", _NET_WM_WINDOW_OPACITY},
   {"WM_HINTS", WM_HINTS},
   {"WM_NAME", WM_NAME},
+  {"WM_CLASS", WM_CLASS},
 }};
 // clang-format on

--- a/src/x11/icccm.cpp
+++ b/src/x11/icccm.cpp
@@ -13,6 +13,16 @@ namespace icccm_util {
     return "";
   }
 
+  pair<string, string> get_wm_class(xcb_connection_t* c, xcb_window_t w) {
+    pair<string, string> result{"", ""};
+    xcb_icccm_get_wm_class_reply_t reply{};
+    if (xcb_icccm_get_wm_class_reply(c, xcb_icccm_get_wm_class(c, w), &reply, nullptr)) {
+      result = {string(reply.instance_name), string(reply.class_name)};
+      xcb_icccm_get_wm_class_reply_wipe(&reply);
+    }
+    return result;
+  }
+
   string get_reply_string(xcb_icccm_get_text_property_reply_t* reply) {
     string str;
     if (reply) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

The xwindow module can now show the contents of the `WM_CLASS` property of the active window. `%instance%` shows the first value and `%class%` shows the second.

Some examples of what applications actually show:

| Application | `%instance%` | `%class%` |
|-|-|-|
|Firefox|Navigator|firefox|
|Thunderbird|Mail|thunderbird|
|Steam|Steam|Steam|
|Spotify|spotify|Spotify|
|rxvt-unicode|urxvt|URxvt|
|xterm|xterm|XTerm|
|Alacritty|Alacritty|Alacritty|
|Vlc|vlc|vlc|


## Related Issues & Documents

ICCCM Spec: https://x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#wm_class_property

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The new tokens need to be added to the xwindow page. Also describe what they actually do.