### PR TITLE
backlight: Remove actual_brightness amdgpu check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))
-- `internal/backlight`: Detect backlight if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2728`](https://github.com/polybar/polybar/pull/2728))
+- `internal/backlight`:
+  - Detect backlight if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2728`](https://github.com/polybar/polybar/pull/2728))
+  - `use-actual-brightness` defaults to `true` for `amdgpu` backlights ([`#2835`](https://github.com/polybar/polybar/issues/2835), [`2839`](https://github.com/polybar/polybar/pull/2839))
 - Providing a negative min-width to a token adds right-padding ([`#2789`](https://github.com/polybar/polybar/issues/2789), [`#2801`](https://github.com/polybar/polybar/pull/2801)) by [@VanillaViking](https://github.com/VanillaViking).
 
 ### Fixed

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -70,13 +70,7 @@ namespace modules {
     // Build path to the sysfs folder the current/maximum brightness values are located
     m_path_backlight = string_util::replace(PATH_BACKLIGHT, "%card%", card);
 
-    /*
-     * amdgpu drivers set the actual_brightness in a different scale than [0, max_brightness]
-     * The only sensible way is to use the 'brightness' file instead
-     * Ref: https://github.com/Alexays/Waybar/issues/335
-     */
-    bool card_is_amdgpu = (card.substr(0, 9) == "amdgpu_bl");
-    m_use_actual_brightness = m_conf.get(name(), "use-actual-brightness", !card_is_amdgpu);
+    m_use_actual_brightness = m_conf.get(name(), "use-actual-brightness", m_use_actual_brightness);
 
     std::string brightness_type = (m_use_actual_brightness ? "actual_brightness" : "brightness");
     auto path_backlight_val = m_path_backlight + "/" + brightness_type;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
The issue has been fixed in the linux kernel version 5.9 and above so we are removing our workaround for this from polybar. Users with older versions can still work around this by explicitly setting `use-actual-brightness` to false, it is just not done by default anymore.


## Related Issues & Documents

Closes #2835
Ref https://bugzilla.kernel.org/show_bug.cgi?id=203905
Ref https://github.com/torvalds/linux/commit/69d9f4278d0f9d24607645f10e5ac5c59c77a4ac

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Remove note for default value of `use-actual-brightness`