### PR TITLE
Make the event loop return shared_ptrs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: '
         -modernize-raw-string-literal,
         -modernize-use-bool-literals,
         -modernize-use-trailing-return-type,
+        -readability-identifier-length,
         -readability-implicit-bool-cast,
         -readability-else-after-return,
         -readability-named-parameter,
@@ -26,7 +27,8 @@ Checks: '
         -cppcoreguidelines-pro-type-reinterpret-cast,
         -cppcoreguidelines-pro-type-union-access,
         -cppcoreguidelines-pro-type-cstyle-cast,
-        -cppcoreguidelines-pro-bounds-constant-array-index
+        -cppcoreguidelines-pro-bounds-constant-array-index,
+        -cppcoreguidelines-owning-memory,
         '
 
 CheckOptions:

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,7 @@
 .tags
 *.user
 
+# clangd
+/.cache
+
 polybar-*.tar

--- a/cmake/cxx.cmake
+++ b/cmake/cxx.cmake
@@ -24,7 +24,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 set(POLYBAR_FLAGS "" CACHE STRING "C++ compiler flags used for compiling polybar")
 
-list(APPEND cxx_base -Wall -Wextra -Wpedantic)
+list(APPEND cxx_base -Wall -Wextra -Wpedantic -Wdeprecated-copy-dtor)
 list(APPEND cxx_debug -DDEBUG -g2)
 list(APPEND cxx_minsizerel "")
 list(APPEND cxx_sanitize -O0 -g -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls)

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -107,10 +107,10 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   string m_lastinput{};
   std::set<mousebtn> m_dblclicks;
 
-  eventloop::TimerHandle& m_leftclick_timer{m_loop.handle<eventloop::TimerHandle>()};
-  eventloop::TimerHandle& m_middleclick_timer{m_loop.handle<eventloop::TimerHandle>()};
-  eventloop::TimerHandle& m_rightclick_timer{m_loop.handle<eventloop::TimerHandle>()};
-  eventloop::TimerHandle& m_dim_timer{m_loop.handle<eventloop::TimerHandle>()};
+  eventloop::timer_handle_t m_leftclick_timer{m_loop.handle<eventloop::TimerHandle>()};
+  eventloop::timer_handle_t m_middleclick_timer{m_loop.handle<eventloop::TimerHandle>()};
+  eventloop::timer_handle_t m_rightclick_timer{m_loop.handle<eventloop::TimerHandle>()};
+  eventloop::timer_handle_t m_dim_timer{m_loop.handle<eventloop::TimerHandle>()};
 
   bool m_visible{true};
 };

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -55,7 +55,7 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
   void signal_handler(int signum);
 
   void conn_cb();
-  void create_config_watcher(const string& fname);
+  void create_config_watcher(const string& filename);
   void confwatch_handler(const char* fname);
   void notifier_handler();
   void screenshot_handler();

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -109,7 +109,7 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
    * This handle is used to notify the eventloop of changes which are not otherwise covered by other handles.
    * E.g. click actions.
    */
-  eventloop::AsyncHandle& m_notifier{m_loop.handle<eventloop::AsyncHandle>([this]() { notifier_handler(); })};
+  eventloop::async_handle_t m_notifier{m_loop.handle<eventloop::AsyncHandle>([this]() { notifier_handler(); })};
 
   /**
    * Notification data for the controller.

--- a/include/components/eventloop.hpp
+++ b/include/components/eventloop.hpp
@@ -426,7 +426,7 @@ namespace eventloop {
 
   using signal_handle_t = shared_ptr<SignalHandle>;
   using poll_handle_t = shared_ptr<PollHandle>;
-  using fs_event_handle = shared_ptr<FSEventHandle>;
+  using fs_event_handle_t = shared_ptr<FSEventHandle>;
   using timer_handle_t = shared_ptr<TimerHandle>;
   using async_handle_t = shared_ptr<AsyncHandle>;
   using pipe_handle_t = shared_ptr<PipeHandle>;

--- a/include/errors.hpp
+++ b/include/errors.hpp
@@ -8,14 +8,13 @@
 
 POLYBAR_NS
 
-using std::strerror;
 using std::exception;
 using std::runtime_error;
+using std::strerror;
 
 class application_error : public runtime_error {
  public:
   explicit application_error(const string& message, int code = 0) : runtime_error(message), code(code) {}
-  virtual ~application_error() {}
   int code{0};
 };
 
@@ -24,7 +23,6 @@ class system_error : public application_error {
   explicit system_error() : application_error(strerror(errno), errno) {}
   explicit system_error(const string& message)
       : application_error(message + " (reason: " + strerror(errno) + ")", errno) {}
-  virtual ~system_error() {}
 };
 
 #define DEFINE_CHILD_ERROR(error, parent) \

--- a/include/ipc/ipc.hpp
+++ b/include/ipc/ipc.hpp
@@ -42,14 +42,14 @@ namespace ipc {
     const logger& m_log;
     eventloop::loop& m_loop;
 
-    eventloop::PipeHandle& socket;
+    eventloop::pipe_handle_t socket;
 
     class connection : public non_copyable_mixin, public non_movable_mixin {
      public:
       using cb = std::function<void(connection&, uint8_t, type_t, const std::vector<uint8_t>&)>;
       connection(eventloop::loop& loop, cb msg_callback);
       ~connection();
-      eventloop::PipeHandle& client_pipe;
+      eventloop::pipe_handle_t client_pipe;
       decoder dec;
     };
 
@@ -79,7 +79,7 @@ namespace ipc {
     struct fifo {
       fifo(eventloop::loop& loop, ipc& ipc, const string& path);
       ~fifo();
-      eventloop::PipeHandle& pipe_handle;
+      eventloop::pipe_handle_t pipe_handle;
     };
 
     unique_ptr<fifo> ipc_pipe;

--- a/include/modules/meta/inotify_module.hpp
+++ b/include/modules/meta/inotify_module.hpp
@@ -55,7 +55,6 @@ namespace modules {
           watches.back().attach(w.second);
         }
       } catch (const system_error& e) {
-        watches.clear();
         this->m_log.err("%s: Error while creating inotify watch (what: %s)", this->name(), e.what());
         CAST_MOD(Impl)->sleep(0.1s);
         return;
@@ -67,11 +66,6 @@ namespace modules {
 
           if (w.poll(1000 / watches.size())) {
             auto event = w.get_event();
-
-            for (auto&& w : watches) {
-              w.remove(true);
-            }
-
             if (CAST_MOD(Impl)->on_event(event)) {
               CAST_MOD(Impl)->broadcast();
             }
@@ -79,8 +73,9 @@ namespace modules {
             return;
           }
 
-          if (!this->running())
+          if (!this->running()) {
             break;
+}
         }
         CAST_MOD(Impl)->idle();
       }

--- a/include/utils/inotify.hpp
+++ b/include/utils/inotify.hpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 
 #include "common.hpp"
+#include "utils/mixins.hpp"
 
 POLYBAR_NS
 
@@ -18,16 +19,19 @@ struct inotify_event {
   int mask = 0;
 };
 
-class inotify_watch {
+class inotify_watch : public non_copyable_mixin {
  public:
   explicit inotify_watch(string path);
   ~inotify_watch();
+
+  inotify_watch(inotify_watch&& other) noexcept;
+  inotify_watch& operator=(inotify_watch&& other) noexcept;
 
   void attach(int mask = IN_MODIFY);
   void remove(bool force = false);
   bool poll(int wait_ms = 1000) const;
   inotify_event get_event() const;
-  const string path() const;
+  string path() const;
   int get_file_descriptor() const;
 
  protected:

--- a/include/utils/mixins.hpp
+++ b/include/utils/mixins.hpp
@@ -13,8 +13,8 @@ class non_copyable_mixin {
   non_copyable_mixin& operator=(const non_copyable_mixin&) = delete;
 
  protected:
-  non_copyable_mixin() {}
-  ~non_copyable_mixin() {}
+  non_copyable_mixin() = default;
+  ~non_copyable_mixin() = default;
 };
 
 /**
@@ -26,8 +26,8 @@ class non_movable_mixin {
   non_movable_mixin& operator=(non_movable_mixin&&) = delete;
 
  protected:
-  non_movable_mixin() {}
-  ~non_movable_mixin() {}
+  non_movable_mixin() = default;
+  ~non_movable_mixin() = default;
 };
 
 POLYBAR_NS_END

--- a/include/x11/connection.hpp
+++ b/include/x11/connection.hpp
@@ -43,8 +43,6 @@ namespace detail {
       m_root_window = screen_of_display(default_screen())->root;
     }
 
-    virtual ~connection_base() {}
-
     void operator()(const shared_ptr<xcb_generic_error_t>& error) const override {
       check<xpp::x::extension, Extensions...>(error);
     }

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -692,12 +692,12 @@ void bar::handle(const evt::destroy_notify& evt) {
  */
 void bar::handle(const evt::enter_notify&) {
   if (m_opts.dimmed) {
-    m_dim_timer.start(25, 0, [this]() {
+    m_dim_timer->start(25, 0, [this]() {
       m_opts.dimmed = false;
       m_sig.emit(dim_window{1.0});
     });
-  } else if (m_dim_timer.is_active()) {
-    m_dim_timer.stop();
+  } else if (m_dim_timer->is_active()) {
+    m_dim_timer->stop();
   }
 }
 
@@ -711,7 +711,7 @@ void bar::handle(const evt::leave_notify&) {
   // Only trigger dimming, if the dim-value is not fully opaque.
   if (m_opts.dimvalue < 1.0) {
     if (!m_opts.dimmed) {
-      m_dim_timer.start(3000, 0, [this]() {
+      m_dim_timer->start(3000, 0, [this]() {
         m_opts.dimmed = true;
         m_sig.emit(dim_window{double(m_opts.dimvalue)});
       });
@@ -820,11 +820,11 @@ void bar::handle(const evt::button_press& evt) {
   if (!has_dblclick) {
     trigger_click(btn, pos);
   } else if (btn == mousebtn::LEFT) {
-    check_double(m_leftclick_timer, btn, pos);
+    check_double(*m_leftclick_timer, btn, pos);
   } else if (btn == mousebtn::MIDDLE) {
-    check_double(m_middleclick_timer, btn, pos);
+    check_double(*m_middleclick_timer, btn, pos);
   } else if (btn == mousebtn::RIGHT) {
-    check_double(m_rightclick_timer, btn, pos);
+    check_double(*m_rightclick_timer, btn, pos);
   } else {
     trigger_click(btn, pos);
   }

--- a/src/components/eventloop.cpp
+++ b/src/components/eventloop.cpp
@@ -85,8 +85,8 @@ namespace eventloop {
   }
 
   void FSEventHandle::start(const string& path, int flags, cb user_cb, cb_error err_cb) {
-    this->callback = user_cb;
-    this->err_cb = err_cb;
+    this->callback = std::move(user_cb);
+    this->err_cb = std::move(err_cb);
     UV(uv_fs_event_start, get(), fs_event_callback, path.c_str(), flags);
   }
 

--- a/src/components/eventloop.cpp
+++ b/src/components/eventloop.cpp
@@ -51,11 +51,13 @@ namespace eventloop {
   WriteRequest::WriteRequest(cb_write&& user_cb, cb_error&& err_cb)
       : write_callback(std::move(user_cb)), write_err_cb(std::move(err_cb)) {
     get()->data = this;
-  };
+  }
+
   WriteRequest& WriteRequest::create(cb_write&& user_cb, cb_error&& err_cb) {
     auto r = std::make_unique<WriteRequest>(std::move(user_cb), std::move(err_cb));
     return r->leak(std::move(r));
-  };
+  }
+
   uv_write_t* WriteRequest::get() {
     return &req;
   }

--- a/src/components/eventloop.cpp
+++ b/src/components/eventloop.cpp
@@ -1,6 +1,7 @@
 #include "components/eventloop.hpp"
 
 #include <cassert>
+#include <utility>
 
 #include "errors.hpp"
 
@@ -46,14 +47,61 @@ namespace eventloop {
     }
   }
 
+  // WriteRequest {{{
+  WriteRequest::WriteRequest(cb_write&& user_cb, cb_error&& err_cb)
+      : write_callback(std::move(user_cb)), write_err_cb(std::move(err_cb)) {
+    get()->data = this;
+  };
+  WriteRequest& WriteRequest::create(cb_write&& user_cb, cb_error&& err_cb) {
+    auto r = std::make_unique<WriteRequest>(std::move(user_cb), std::move(err_cb));
+    return r->leak(std::move(r));
+  };
+  uv_write_t* WriteRequest::get() {
+    return &req;
+  }
+
+  void WriteRequest::trigger(int status) {
+    if (status < 0) {
+      if (write_err_cb) {
+        write_err_cb(ErrorEvent{status});
+      }
+    } else {
+      if (write_callback) {
+        write_callback();
+      }
+    }
+
+    unleak();
+  }
+
+  WriteRequest& WriteRequest::leak(std::unique_ptr<WriteRequest> h) {
+    lifetime_extender = std::move(h);
+    return *lifetime_extender;
+  }
+
+  void WriteRequest::unleak() {
+    reset_callbacks();
+    lifetime_extender.reset();
+  }
+
+  void WriteRequest::reset_callbacks() {
+    write_callback = nullptr;
+    write_err_cb = nullptr;
+  }
+  // }}}
+
   // SignalHandle {{{
   void SignalHandle::init() {
     UV(uv_signal_init, loop(), get());
   }
 
-  void SignalHandle::start(int signum, cb user_cb) {
-    this->callback = user_cb;
+  void SignalHandle::start(int signum, cb&& user_cb) {
+    this->callback = std::move(user_cb);
     UV(uv_signal_start, get(), event_cb<SignalEvent, &SignalHandle::callback>, signum);
+  }
+
+  void SignalHandle::reset_callbacks() {
+    callback = nullptr;
   }
   // }}}
 
@@ -62,9 +110,9 @@ namespace eventloop {
     UV(uv_poll_init, loop(), get(), fd);
   }
 
-  void PollHandle::start(int events, cb user_cb, cb_error err_cb) {
-    this->callback = user_cb;
-    this->err_cb = err_cb;
+  void PollHandle::start(int events, cb&& user_cb, cb_error&& err_cb) {
+    this->callback = std::move(user_cb);
+    this->err_cb = std::move(err_cb);
     UV(uv_poll_start, get(), events, &poll_callback);
   }
 
@@ -77,6 +125,11 @@ namespace eventloop {
 
     self.callback(PollEvent{(uv_poll_event)events});
   }
+
+  void PollHandle::reset_callbacks() {
+    callback = nullptr;
+    err_cb = nullptr;
+  }
   // }}}
 
   // FSEventHandle {{{
@@ -84,7 +137,7 @@ namespace eventloop {
     UV(uv_fs_event_init, loop(), get());
   }
 
-  void FSEventHandle::start(const string& path, int flags, cb user_cb, cb_error err_cb) {
+  void FSEventHandle::start(const string& path, int flags, cb&& user_cb, cb_error&& err_cb) {
     this->callback = std::move(user_cb);
     this->err_cb = std::move(err_cb);
     UV(uv_fs_event_start, get(), fs_event_callback, path.c_str(), flags);
@@ -100,6 +153,10 @@ namespace eventloop {
     self.callback(FSEvent{path, (uv_fs_event)events});
   }
 
+  void FSEventHandle::reset_callbacks() {
+    callback = nullptr;
+    err_cb = nullptr;
+  }
   // }}}
 
   // PipeHandle {{{
@@ -115,9 +172,9 @@ namespace eventloop {
     UV(uv_pipe_bind, get(), path.c_str());
   }
 
-  void PipeHandle::connect(const string& name, cb_connect user_cb, cb_error err_cb) {
-    this->connect_callback = user_cb;
-    this->connect_err_cb = err_cb;
+  void PipeHandle::connect(const string& name, cb_connect&& user_cb, cb_error&& err_cb) {
+    this->connect_callback = std::move(user_cb);
+    this->connect_err_cb = std::move(err_cb);
     uv_pipe_connect(new uv_connect_t(), get(), name.c_str(), connect_cb);
   }
 
@@ -132,6 +189,12 @@ namespace eventloop {
 
     delete req;
   }
+
+  void PipeHandle::reset_callbacks() {
+    StreamHandle::reset_callbacks();
+    connect_callback = nullptr;
+    connect_err_cb = nullptr;
+  }
   // }}}
 
   // TimerHandle {{{
@@ -139,24 +202,32 @@ namespace eventloop {
     UV(uv_timer_init, loop(), get());
   }
 
-  void TimerHandle::start(uint64_t timeout, uint64_t repeat, cb user_cb) {
-    this->callback = user_cb;
+  void TimerHandle::start(uint64_t timeout, uint64_t repeat, cb&& user_cb) {
+    this->callback = std::move(user_cb);
     UV(uv_timer_start, get(), void_event_cb<&TimerHandle::callback>, timeout, repeat);
   }
 
   void TimerHandle::stop() {
     UV(uv_timer_stop, get());
   }
+
+  void TimerHandle::reset_callbacks() {
+    callback = nullptr;
+  }
   // }}}
 
   // AsyncHandle {{{
-  void AsyncHandle::init(cb user_cb) {
-    this->callback = user_cb;
+  void AsyncHandle::init(cb&& user_cb) {
+    this->callback = std::move(user_cb);
     UV(uv_async_init, loop(), get(), void_event_cb<&AsyncHandle::callback>);
   }
 
   void AsyncHandle::send() {
     UV(uv_async_send, get());
+  }
+
+  void AsyncHandle::reset_callbacks() {
+    callback = nullptr;
   }
   // }}}
 
@@ -165,9 +236,13 @@ namespace eventloop {
     UV(uv_prepare_init, loop(), get());
   }
 
-  void PrepareHandle::start(cb user_cb) {
-    this->callback = user_cb;
+  void PrepareHandle::start(cb&& user_cb) {
+    this->callback = std::move(user_cb);
     UV(uv_prepare_start, get(), void_event_cb<&PrepareHandle::callback>);
+  }
+
+  void PrepareHandle::reset_callbacks() {
+    callback = nullptr;
   }
   // }}}
 
@@ -227,3 +302,4 @@ namespace eventloop {
 } // namespace eventloop
 
 POLYBAR_NS_END
+

--- a/src/ipc/ipc.cpp
+++ b/src/ipc/ipc.cpp
@@ -57,12 +57,12 @@ namespace ipc {
 
     m_log.info("Opening ipc socket at '%s'", sock_path);
     m_log.notice("Listening for IPC messages (PID: %d)", getpid());
-    socket.bind(sock_path);
-    socket.listen(
+    socket->bind(sock_path);
+    socket->listen(
         4, [this]() { on_connection(); },
         [this](const auto& e) {
           m_log.err("libuv error while listening to IPC socket: %s", uv_strerror(e.status));
-          socket.close();
+          socket->close();
         });
   }
 
@@ -124,7 +124,7 @@ namespace ipc {
           } else {
             response = encode(TYPE_ERR, "Unrecognized IPC message type " + to_string(type));
           }
-          c.client_pipe.write(
+          c.client_pipe->write(
               response, [this, &c]() { remove_client(c); },
               [this, &c](const auto& e) {
                 m_log.err("ipc: libuv error while writing to IPC socket: %s", uv_strerror(e.status));
@@ -133,16 +133,16 @@ namespace ipc {
         });
 
     auto& c = *connection;
-    socket.accept(c.client_pipe);
+    socket->accept(*c.client_pipe);
 
-    c.client_pipe.read_start(
+    c.client_pipe->read_start(
         [this, &c](const auto& e) {
           try {
             c.dec.on_read((const uint8_t*)e.data, e.len);
           } catch (const decoder::error& e) {
             m_log.err("ipc: Failed to decode IPC message (reason: %s)", e.what());
 
-            c.client_pipe.write(
+            c.client_pipe->write(
                 encode(TYPE_ERR, "Invalid binary message format: "s + e.what()), [this, &c]() { remove_client(c); },
                 [this, &c](const auto& e) {
                   m_log.err("ipc: libuv error while writing to IPC socket: %s", uv_strerror(e.status));
@@ -171,7 +171,7 @@ namespace ipc {
       }) {}
 
   ipc::connection::~connection() {
-    client_pipe.close();
+    client_pipe->close();
   }
 
   ipc::fifo::fifo(loop& loop, ipc& ipc, const string& path) : pipe_handle(loop.handle<PipeHandle>()) {
@@ -180,8 +180,8 @@ namespace ipc {
       throw system_error("Failed to open pipe '" + path + "'");
     }
 
-    pipe_handle.open(fd);
-    pipe_handle.read_start([&ipc](const auto& e) mutable { ipc.receive_data(string(e.data, e.len)); },
+    pipe_handle->open(fd);
+    pipe_handle->read_start([&ipc](const auto& e) mutable { ipc.receive_data(string(e.data, e.len)); },
         [&ipc]() { ipc.receive_eof(); },
         [&ipc](const auto& e) mutable {
           ipc.m_log.err("libuv error while listening to IPC channel: %s", uv_strerror(e.status));
@@ -190,7 +190,7 @@ namespace ipc {
   }
 
   ipc::fifo::~fifo() {
-    pipe_handle.close();
+    pipe_handle->close();
   }
 
   /**

--- a/src/polybar-msg.cpp
+++ b/src/polybar-msg.cpp
@@ -262,11 +262,11 @@ int run(int argc, char** argv) {
      */
     int idx = decoders.size() - 1;
 
-    auto& conn = loop.handle<PipeHandle>();
-    conn.connect(
+    auto conn = loop.handle<PipeHandle>();
+    conn->connect(
         channel,
         [&conn, &decoders, pid, type, payload, channel, idx]() {
-          on_connection(conn, decoders[idx], pid, type, payload);
+          on_connection(*conn, decoders[idx], pid, type, payload);
         },
         [&](const auto& e) {
           fprintf(stderr, "%s: Failed to connect to '%s' (err: '%s')\n", exec, channel.c_str(), uv_strerror(e.status));

--- a/src/utils/inotify.cpp
+++ b/src/utils/inotify.cpp
@@ -24,6 +24,21 @@ inotify_watch::~inotify_watch() {
   }
 }
 
+inotify_watch::inotify_watch(inotify_watch&& other) noexcept {
+  std::swap(m_path, other.m_path);
+  std::swap(m_wd, other.m_wd);
+  std::swap(m_fd, other.m_fd);
+  std::swap(m_mask, other.m_mask);
+}
+
+inotify_watch& inotify_watch::operator=(inotify_watch&& other) noexcept {
+  std::swap(m_path, other.m_path);
+  std::swap(m_wd, other.m_wd);
+  std::swap(m_fd, other.m_fd);
+  std::swap(m_mask, other.m_mask);
+  return *this;
+}
+
 /**
  * Attach inotify watch
  */
@@ -101,7 +116,7 @@ inotify_event inotify_watch::get_event() const {
 /**
  * Get watch file path
  */
-const string inotify_watch::path() const {
+string inotify_watch::path() const {
   return m_path;
 }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [x] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Having the loop return references is nice but you run the risk of having dangling references.
The caller now owns the handle and can choose to extend its lifetime.
This has the advantage of the pointer being valid, even after the handle is closed.

To avoid memory leaks, after closing the handle, we reset all callbacks to free their captures.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
