### PR TITLE
fix(ipc): Crash when sending to multiple instances

### DIFF
--- a/include/ipc/ipc.hpp
+++ b/include/ipc/ipc.hpp
@@ -42,7 +42,7 @@ namespace ipc {
     const logger& m_log;
     eventloop::loop& m_loop;
 
-    eventloop::pipe_handle_t socket;
+    eventloop::pipe_handle_t m_socket;
 
     class connection : public non_copyable_mixin, public non_movable_mixin {
      public:
@@ -89,7 +89,7 @@ namespace ipc {
      * Buffer for the currently received IPC message over the named pipe
      */
     string m_pipe_buffer{};
-    void receive_data(string buf);
+    void receive_data(const string& buf);
     void receive_eof();
   };
 } // namespace ipc

--- a/src/polybar-msg.cpp
+++ b/src/polybar-msg.cpp
@@ -260,13 +260,13 @@ int run(int argc, char** argv) {
     /*
      * Index to decoder is captured because reference can be invalidated due to the vector being modified.
      */
-    int idx = decoders.size() - 1;
+    auto idx = decoders.size() - 1;
 
     auto conn = loop.handle<PipeHandle>();
     conn->connect(
         channel,
-        [&conn, &decoders, pid, type, payload, channel, idx]() {
-          on_connection(*conn, decoders[idx], pid, type, payload);
+        [&handle = *conn, &decoders, pid, type, payload, channel, idx]() {
+          on_connection(handle, decoders[idx], pid, type, payload);
         },
         [&](const auto& e) {
           fprintf(stderr, "%s: Failed to connect to '%s' (err: '%s')\n", exec, channel.c_str(), uv_strerror(e.status));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
In polybar-msg, the connection handle was captured as a reference to a shared_ptr, but the shared_ptr went out of scope right after.

This probably always caused UB, but was only noticeable for two or more instances.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
