### PR TITLE
fix code in order to support cmake unity builds

### DIFF
--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -1,3 +1,4 @@
+#pragma once
 #include <cassert>
 
 #include "components/builder.hpp"

--- a/src/ipc/encoder.cpp
+++ b/src/ipc/encoder.cpp
@@ -11,11 +11,11 @@ namespace ipc {
     size_t total_size = HEADER_SIZE + payload.size();
     std::vector<uint8_t> data(total_size);
 
-    auto* header = reinterpret_cast<ipc::header*>(data.data());
-    std::copy(ipc::MAGIC.begin(), ipc::MAGIC.end(), header->s.magic);
-    header->s.version = ipc::VERSION;
-    header->s.size = payload.size();
-    header->s.type = type;
+    auto* msg_header = reinterpret_cast<header*>(data.data());
+    std::copy(MAGIC.begin(), MAGIC.end(), msg_header->s.magic);
+    msg_header->s.version = VERSION;
+    msg_header->s.size = payload.size();
+    msg_header->s.type = type;
 
     std::copy(payload.begin(), payload.end(), data.begin() + HEADER_SIZE);
     return data;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [X] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

I tired building polybar with `CMAKE_UNITY_BUILD":"ON"` and the build failed.

The `#pragma once` in base.inl is needed because it is included multiple times when passed to the compiler.

I am not exactly sure why the changes in encoder.cpp are needed. However, both gcc and clang fail. The variable `header` could be renamed Instead of adding `polybar::` to `ipc::header`. However, this would change more lines.

Both changes should have no impact on the runtime ore a normal build.


## Related Issues & Documents

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [X] Does not require documentation changes
