### PR TITLE
Regex support for interfaces in network module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
-- Added support for regex in Network::interface types ([`#2551`](https://github.com/polybar/polybar/issues/2551), [`#2852](https://github.com/polybar/polybar/pull/2852)) by [@madhavpcm](https://github.com/madhavpcm).
+- Added support for regex in Network::interface types ([`#2551`](https://github.com/polybar/polybar/issues/2551), [`#2853](https://github.com/polybar/polybar/pull/2853)) by [@madhavpcm](https://github.com/madhavpcm).
 -  Added support for TAG_LABEL (`<label>`) in ipc module  ([`#2841`](https://github.com/polybar/polybar/pull/2841))  by [@madhavpcm](https://github.com/madhavpcm).
 -  Added support for format-i for each hook-i defined in ipc module ([`#2775`](https://github.com/polybar/polybar/issues/2775),  [`#2810`](https://github.com/polybar/polybar/pull/2810))  by [@madhavpcm](https://github.com/madhavpcm).
 - `internal/temperature`: `%temperature-k%` token displays the temperature in kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
+- Added support for regex in Network::interface types ([`#2551`](https://github.com/polybar/polybar/issues/2551), [`#2852](https://github.com/polybar/polybar/pull/2852)) by [@madhavpcm](https://github.com/madhavpcm).
 -  Added support for TAG_LABEL (`<label>`) in ipc module  ([`#2841`](https://github.com/polybar/polybar/pull/2841))  by [@madhavpcm](https://github.com/madhavpcm).
 -  Added support for format-i for each hook-i defined in ipc module ([`#2775`](https://github.com/polybar/polybar/issues/2775),  [`#2810`](https://github.com/polybar/polybar/pull/2810))  by [@madhavpcm](https://github.com/madhavpcm).
 - `internal/temperature`: `%temperature-k%` token displays the temperature in kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <regex>
 
 #include "common.hpp"
 #include "components/logger.hpp"
@@ -42,6 +43,7 @@ namespace net {
   bool is_wireless_interface(const string& ifname);
   std::string find_wireless_interface();
   std::string find_wired_interface();
+  std::string find_interface_regex( const string& regexpr);
 
   // types {{{
 

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <regex>
+#include <net/if.h>
+
 #include "adapters/net.hpp"
 #include "components/config.hpp"
 #include "modules/meta/timer_module.hpp"

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -22,19 +22,15 @@ namespace modules {
 
     // If it is a regex try matching with all interfaces provided by the system
     // The first matched interface is chosen
-    bool found = false;
     for (struct ifaddrs* i = ifaddrs; i != nullptr; i = i->ifa_next) {
       const std::string ifname{i->ifa_name};
       // If found set m_interface as the current
       if (std::regex_match(ifname, interface_regex)) {
-        found = true;
         m_interface = ifname;
         break;
       }
     }
-    if (!found) {
-      // If no match set m_interface as empty
-    }
+
 
     if (m_interface.empty()) {
       std::string type = m_conf.get(name(), "interface-type");

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -15,22 +15,12 @@ namespace modules {
     // Load configuration values
     // m_interface could be a regex as well
     m_interface = m_conf.get(name(), "interface", m_interface);
-    std::regex interface_regex(m_interface);
+    string regexpr = m_interface;
 
-    struct ifaddrs* ifaddrs;
-    getifaddrs(&ifaddrs);
+    m_interface = net::find_interface_regex(m_interface);
 
-    // If it is a regex try matching with all interfaces provided by the system
-    // The first matched interface is chosen
-    for (struct ifaddrs* i = ifaddrs; i != nullptr; i = i->ifa_next) {
-      const std::string ifname{i->ifa_name};
-      // If found set m_interface as the current
-      if (std::regex_match(ifname, interface_regex)) {
-        m_interface = ifname;
-        break;
-      }
-    }
-
+    if (!m_interface.empty())
+      m_log.notice("%s: Matched regex %s with interface %s", name(), regexpr, m_interface);
 
     if (m_interface.empty()) {
       std::string type = m_conf.get(name(), "interface-type");


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
network module interface now supports regex
interface = wl.* will match any adapter named wlan0 wlan1 etc..

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
#2551 
## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
