### PR TITLE
feat(xworkspaces): Add option to disable scroll wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/temperature`: Added `zone-type` setting ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2752`](https://github.com/polybar/polybar/pull/2752)) by [@xphoniex](https://github.com/xphoniex)
 - `internal/xwindow`: `%class%` and `%instance%` tokens, which show the contents of the `WM_CLASS` property of the active window ([`#2830`](https://github.com/polybar/polybar/pull/2830))
 - Added `enable-struts` option in bar section to enable/disable struts ([`#2769`](https://github.com/polybar/polybar/issues/2769), [`#2844`](https://github.com/polybar/polybar/pull/2844)) by [@VanillaViking](https://github.com/VanillaViking).
+- `internal/xworkspaces`: Added `wrapping-scroll` option ([`#2858`](https://github.com/polybar/polybar/pull/2858)) by [@Cationiz3r](https://github.com/Cationiz3r).
 
 ### Changed
 - `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -104,6 +104,7 @@ namespace modules {
     bool m_click{true};
     bool m_scroll{true};
     bool m_revscroll{false};
+    bool m_wrap{true};
     size_t m_index{0};
   };
 } // namespace modules

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -46,6 +46,7 @@ namespace modules {
     m_click = m_conf.get(name(), "enable-click", m_click);
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
+    m_wrap = m_conf.get(name(), "enable-wrap", m_wrap);
 
     // Add formats and elements
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, {TAG_LABEL_STATE, TAG_LABEL_MONITOR});
@@ -432,7 +433,13 @@ namespace modules {
 
     int offset = next ? 1 : -1;
 
-    int new_index = (current_index + offset + indices.size()) % indices.size();
+    int new_index = current_index + offset;
+    if (!m_wrap && (new_index < 0 || new_index >= indices.size())) {
+      m_log.info("%s: Refusing to wrap desktop", name());
+      return;
+    }
+
+    new_index = (new_index + indices.size()) % indices.size();
     focus_desktop(indices.at(new_index));
   }
 

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -46,7 +46,7 @@ namespace modules {
     m_click = m_conf.get(name(), "enable-click", m_click);
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
-    m_wrap = m_conf.get(name(), "enable-wrap", m_wrap);
+    m_wrap = m_conf.get(name(), "wrapping-scroll", m_wrap);
 
     // Add formats and elements
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, {TAG_LABEL_STATE, TAG_LABEL_MONITOR});
@@ -435,7 +435,7 @@ namespace modules {
 
     int new_index = current_index + offset;
     if (!m_wrap && (new_index < 0 || new_index >= indices.size())) {
-      m_log.info("%s: Refusing to wrap desktop", name());
+      m_log.trace("%s: Refusing to wrap desktop", name());
       return;
     }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Added option `enable-wrap` (enabled by default) for the xworkspaces module. When disable, scrolling the module at the last workspace will not return you to the first, and vice versa.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

You can add this at the end of the **Basic settings** section:
```ini
; Wrap the last workspace to the first one
; Default: true
wrapping-scroll = false
```
