### PR TITLE
Remove space from CPU module

### DIFF
--- a/doc/config.ini
+++ b/doc/config.ini
@@ -134,7 +134,7 @@ label = %percentage_used:2%%
 [module/cpu]
 type = internal/cpu
 interval = 2
-format-prefix = "CPU "
+format-prefix = "CPU"
 format-prefix-foreground = ${colors.primary}
 label = %percentage:2%%
 


### PR DESCRIPTION
The `internal/cpu` module was formatted to have default output as: `CPU {cpu percent}`, but since the percentage itself contains a space at the start there are 2 spaces.

I get this is kinda like typo comment prs but it annoys me so.
If this is intentional then why?
