### PR TITLE
Add hover actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
+-  Support for actions on hover via `mousebtn::HOVER_START` and `mousebtn::HOVER_END` ([`#1064`](https://github.com/polybar/polybar/issues/1064), [`#2868`](https://github.com/polybar/polybar/pull/2868)).
+-  `custom/script`: `hover-start` and `hover-end` actions ([`#1064`](https://github.com/polybar/polybar/issues/1064), [`#2868`](https://github.com/polybar/polybar/pull/2868)).
 -  Added support for TAG_LABEL (`<label>`) in ipc module  ([`#2841`](https://github.com/polybar/polybar/pull/2841))  by [@madhavpcm](https://github.com/madhavpcm).
 -  Added support for format-i for each hook-i defined in ipc module ([`#2775`](https://github.com/polybar/polybar/issues/2775),  [`#2810`](https://github.com/polybar/polybar/pull/2810))  by [@madhavpcm](https://github.com/madhavpcm).
 - `internal/temperature`: `%temperature-k%` token displays the temperature in kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `custom/text`: The `content` setting and all its properties are deprecated in favor of `format` with the same functionality. ([`#2676`](https://github.com/polybar/polybar/pull/2676))
 
 ### Added
--  Support for actions on hover via `mousebtn::HOVER_START` and `mousebtn::HOVER_END` ([`#1064`](https://github.com/polybar/polybar/issues/1064), [`#2868`](https://github.com/polybar/polybar/pull/2868)).
--  `custom/script`: `hover-start` and `hover-end` actions ([`#1064`](https://github.com/polybar/polybar/issues/1064), [`#2868`](https://github.com/polybar/polybar/pull/2868)).
--  Added support for TAG_LABEL (`<label>`) in ipc module  ([`#2841`](https://github.com/polybar/polybar/pull/2841))  by [@madhavpcm](https://github.com/madhavpcm).
--  Added support for format-i for each hook-i defined in ipc module ([`#2775`](https://github.com/polybar/polybar/issues/2775),  [`#2810`](https://github.com/polybar/polybar/pull/2810))  by [@madhavpcm](https://github.com/madhavpcm).
+- Support for actions on hover via action numbers `9` and `10` ([`#1064`](https://github.com/polybar/polybar/issues/1064), [`#2868`](https://github.com/polybar/polybar/pull/2868)).
+- `custom/script`: `hover-start` and `hover-end` actions ([`#1064`](https://github.com/polybar/polybar/issues/1064), [`#2868`](https://github.com/polybar/polybar/pull/2868)).
+- Added support for TAG_LABEL (`<label>`) in ipc module  ([`#2841`](https://github.com/polybar/polybar/pull/2841))  by [@madhavpcm](https://github.com/madhavpcm).
+- Added support for format-i for each hook-i defined in ipc module ([`#2775`](https://github.com/polybar/polybar/issues/2775),  [`#2810`](https://github.com/polybar/polybar/pull/2810))  by [@madhavpcm](https://github.com/madhavpcm).
 - `internal/temperature`: `%temperature-k%` token displays the temperature in kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))
 - `internal/pulseaudio`: `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -104,6 +104,12 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
    */
   string m_cursor{};
 
+  /**
+   * Action string of last hover action
+   */
+  string m_last_start_hover_action{};
+  string m_last_end_hover_action{};
+
   string m_lastinput{};
   std::set<mousebtn> m_dblclicks;
 

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -39,6 +39,8 @@ enum class mousebtn {
   RIGHT,
   SCROLL_UP,
   SCROLL_DOWN,
+  HOVER_START,
+  HOVER_END,
   DOUBLE_LEFT,
   DOUBLE_MIDDLE,
   DOUBLE_RIGHT,

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -226,6 +226,8 @@ struct bar_settings {
 
   vector<action> actions{};
 
+  bool disable_hover_checking{false};
+
   bool dimmed{false};
   double dimvalue{1.0};
 

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -39,11 +39,11 @@ enum class mousebtn {
   RIGHT,
   SCROLL_UP,
   SCROLL_DOWN,
-  HOVER_START,
-  HOVER_END,
   DOUBLE_LEFT,
   DOUBLE_MIDDLE,
   DOUBLE_RIGHT,
+  HOVER_START,
+  HOVER_END,
   // Terminator value, do not use
   BTN_COUNT,
 };

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -226,7 +226,7 @@ struct bar_settings {
 
   vector<action> actions{};
 
-  bool disable_hover_checking{false};
+  bool enable_hover_checking{false};
 
   bool dimmed{false};
   double dimvalue{1.0};

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -226,7 +226,7 @@ struct bar_settings {
 
   vector<action> actions{};
 
-  bool enable_hover_checking{false};
+  bool enable_hover_actions{false};
 
   bool dimmed{false};
   double dimvalue{1.0};

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -426,7 +426,8 @@ void bar::parse(string&& data, bool force) {
 
   m_dblclicks.clear();
   for (auto&& action : m_opts.actions) {
-    if (action.button == mousebtn::DOUBLE_LEFT || action.button == mousebtn::DOUBLE_MIDDLE || action.button == mousebtn::DOUBLE_RIGHT) {
+    if (action.button == mousebtn::DOUBLE_LEFT || action.button == mousebtn::DOUBLE_MIDDLE ||
+        action.button == mousebtn::DOUBLE_RIGHT) {
       m_dblclicks.insert(action.button);
     }
   }

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -735,7 +735,7 @@ void bar::handle(const evt::leave_notify&) {
     }
   }
 
-  if (!m_last_end_hover_action.empty()) {
+  if (!m_last_end_hover_action.empty() && !m_opts.disable_hover_checking) {
     m_sig.emit(button_press{m_last_end_hover_action});
   }
 
@@ -754,6 +754,10 @@ void bar::handle(const evt::motion_notify& evt) {
   int motion_pos = evt->event_x;
 
   const auto get_hover_str = [&](const mousebtn& button) -> string {
+    if (m_opts.disable_hover_checking) {
+      return ""s;
+    }
+
     tags::action_t action = m_action_ctxt->has_action(button, motion_pos);
     if (action != tags::NO_ACTION) {
       m_log.trace("Found matching input area");

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -426,7 +426,7 @@ void bar::parse(string&& data, bool force) {
 
   m_dblclicks.clear();
   for (auto&& action : m_opts.actions) {
-    if (static_cast<int>(action.button) >= static_cast<int>(mousebtn::DOUBLE_LEFT)) {
+    if (action.button == mousebtn::DOUBLE_LEFT || action.button == mousebtn::DOUBLE_MIDDLE || action.button == mousebtn::DOUBLE_RIGHT) {
       m_dblclicks.insert(action.button);
     }
   }

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -735,7 +735,7 @@ void bar::handle(const evt::leave_notify&) {
     }
   }
 
-  if(!m_last_end_hover_action.empty()) {
+  if (!m_last_end_hover_action.empty()) {
     m_sig.emit(button_press{m_last_end_hover_action});
   }
 
@@ -753,9 +753,9 @@ void bar::handle(const evt::motion_notify& evt) {
 
   int motion_pos = evt->event_x;
 
-  const auto get_hover_str = [&](const mousebtn &button) -> string {
+  const auto get_hover_str = [&](const mousebtn& button) -> string {
     tags::action_t action = m_action_ctxt->has_action(button, motion_pos);
-    if(action != tags::NO_ACTION) {
+    if (action != tags::NO_ACTION) {
       m_log.trace("Found matching input area");
       return m_action_ctxt->get_action(action);
     }
@@ -766,13 +766,13 @@ void bar::handle(const evt::motion_notify& evt) {
   string hover_start_action = get_hover_str(mousebtn::HOVER_START);
   string hover_end_action = get_hover_str(mousebtn::HOVER_END);
 
-  if(hover_start_action != m_last_start_hover_action || hover_end_action != m_last_end_hover_action) {
+  if (hover_start_action != m_last_start_hover_action || hover_end_action != m_last_end_hover_action) {
     m_log.trace("bar: Hover changed");
-    if(!hover_start_action.empty()) {
+    if (!hover_start_action.empty()) {
       m_sig.emit(button_press{hover_start_action});
     }
 
-    if(!m_last_end_hover_action.empty()) {
+    if (!m_last_end_hover_action.empty()) {
       m_sig.emit(button_press{m_last_end_hover_action});
     }
 
@@ -939,7 +939,7 @@ void bar::start(const string& tray_module_name) {
   if (m_opts.dimvalue != 1.0 || !m_opts.disable_hover_checking) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
-  if(!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || !m_opts.disable_hover_checking) {
+  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || !m_opts.disable_hover_checking) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
   }
   m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_STRUCTURE_NOTIFY);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -773,12 +773,12 @@ void bar::handle(const evt::motion_notify& evt) {
 
   if (hover_start_action != m_last_start_hover_action || hover_end_action != m_last_end_hover_action) {
     m_log.trace("bar: Hover changed");
-    if (!hover_start_action.empty()) {
-      m_sig.emit(button_press{hover_start_action});
-    }
-
     if (!m_last_end_hover_action.empty()) {
       m_sig.emit(button_press{m_last_end_hover_action});
+    }
+
+    if (!hover_start_action.empty()) {
+      m_sig.emit(button_press{hover_start_action});
     }
 
     m_last_start_hover_action = hover_start_action;

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -220,6 +220,8 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   m_opts.struts = m_conf.get(bs, "enable-struts", m_opts.struts);
 
+  m_opts.disable_hover_checking = m_conf.get(bs, "disable-hover-checking", m_opts.disable_hover_checking);
+
   if (only_initialize_values) {
     return;
   }
@@ -930,7 +932,9 @@ void bar::start(const string& tray_module_name) {
   if (m_opts.dimvalue != 1.0) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
-  m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
+  if(!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || !m_opts.disable_hover_checking) {
+    m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
+  }
   m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_STRUCTURE_NOTIFY);
 
   m_log.info("Bar window: %s", m_connection.id(m_opts.window));

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -753,7 +753,7 @@ void bar::handle(const evt::motion_notify& evt) {
       return m_action_ctxt->get_action(action);
     }
 
-    return "";
+    return ""s;
   };
 
   string hover_start_action = get_hover_str(mousebtn::HOVER_START);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -220,7 +220,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   m_opts.struts = m_conf.get(bs, "enable-struts", m_opts.struts);
 
-  m_opts.disable_hover_checking = m_conf.get(bs, "disable-hover-checking", m_opts.disable_hover_checking);
+  m_opts.enable_hover_checking = m_conf.get(bs, "enable-hover-checking", m_opts.enable_hover_checking);
 
   if (only_initialize_values) {
     return;
@@ -736,7 +736,7 @@ void bar::handle(const evt::leave_notify&) {
     }
   }
 
-  if (!m_last_end_hover_action.empty() && !m_opts.disable_hover_checking) {
+  if (!m_last_end_hover_action.empty() && m_opts.enable_hover_checking) {
     m_sig.emit(button_press{m_last_end_hover_action});
   }
 
@@ -755,7 +755,7 @@ void bar::handle(const evt::motion_notify& evt) {
   int motion_pos = evt->event_x;
 
   const auto get_hover_str = [&](const mousebtn& button) -> string {
-    if (m_opts.disable_hover_checking) {
+    if (!m_opts.enable_hover_checking) {
       return ""s;
     }
 
@@ -941,10 +941,10 @@ void bar::start(const string& tray_module_name) {
 
   // Subscribe to window enter and leave events
   // if we should dim the window
-  if (m_opts.dimvalue != 1.0 || !m_opts.disable_hover_checking) {
+  if (m_opts.dimvalue != 1.0 || m_opts.enable_hover_checking) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
-  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || !m_opts.disable_hover_checking) {
+  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || m_opts.enable_hover_checking) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
   }
   m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_STRUCTURE_NOTIFY);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -220,7 +220,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
 
   m_opts.struts = m_conf.get(bs, "enable-struts", m_opts.struts);
 
-  m_opts.enable_hover_checking = m_conf.get(bs, "enable-hover-checking", m_opts.enable_hover_checking);
+  m_opts.enable_hover_actions = m_conf.get(bs, "enable-hover", m_opts.enable_hover_actions);
 
   if (only_initialize_values) {
     return;
@@ -736,7 +736,7 @@ void bar::handle(const evt::leave_notify&) {
     }
   }
 
-  if (!m_last_end_hover_action.empty() && m_opts.enable_hover_checking) {
+  if (!m_last_end_hover_action.empty() && m_opts.enable_hover_actions) {
     m_sig.emit(button_press{m_last_end_hover_action});
   }
 
@@ -755,7 +755,7 @@ void bar::handle(const evt::motion_notify& evt) {
   int motion_pos = evt->event_x;
 
   const auto get_hover_str = [&](const mousebtn& button) -> string {
-    if (!m_opts.enable_hover_checking) {
+    if (!m_opts.enable_hover_actions) {
       return ""s;
     }
 
@@ -941,10 +941,10 @@ void bar::start(const string& tray_module_name) {
 
   // Subscribe to window enter and leave events
   // if we should dim the window
-  if (m_opts.dimvalue != 1.0 || m_opts.enable_hover_checking) {
+  if (m_opts.dimvalue != 1.0 || m_opts.enable_hover_actions) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
-  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || m_opts.enable_hover_checking) {
+  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || m_opts.enable_hover_actions) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
   }
   m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_STRUCTURE_NOTIFY);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -737,12 +737,41 @@ void bar::handle(const evt::leave_notify&) {
 /**
  * Event handler for XCB_MOTION_NOTIFY events
  *
- * Used to change the cursor depending on the module
+ * Used to change the cursor depending on the module and handle hover actions
  */
 void bar::handle(const evt::motion_notify& evt) {
   m_log.trace("bar: Detected motion: %i at pos(%i, %i)", evt->detail, evt->event_x, evt->event_y);
-#if WITH_XCURSOR
+
   int motion_pos = evt->event_x;
+
+  const auto get_hover_str = [&](const mousebtn &button) -> string {
+    tags::action_t action = m_action_ctxt->has_action(button, motion_pos);
+    if(action != tags::NO_ACTION) {
+      m_log.trace("Found matching input area");
+      return m_action_ctxt->get_action(action);
+    }
+
+    return "";
+  };
+
+  string hover_start_action = get_hover_str(mousebtn::HOVER_START);
+  string hover_end_action = get_hover_str(mousebtn::HOVER_END);
+
+  if(hover_start_action != m_last_start_hover_action || hover_end_action != m_last_end_hover_action) {
+    m_log.trace("bar: Hover changed");
+    if(!hover_start_action.empty()) {
+      m_sig.emit(button_press{hover_start_action});
+    }
+
+    if(!m_last_end_hover_action.empty()) {
+      m_sig.emit(button_press{m_last_end_hover_action});
+    }
+
+    m_last_start_hover_action = hover_start_action;
+    m_last_end_hover_action = hover_end_action;
+  }
+
+#if WITH_XCURSOR
   // scroll cursor is less important than click cursor, so we shouldn't return until we are sure there is no click
   // action
   bool found_scroll = false;
@@ -901,9 +930,7 @@ void bar::start(const string& tray_module_name) {
   if (m_opts.dimvalue != 1.0) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
-  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty()) {
-    m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
-  }
+  m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
   m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_STRUCTURE_NOTIFY);
 
   m_log.info("Bar window: %s", m_connection.id(m_opts.window));

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -734,6 +734,13 @@ void bar::handle(const evt::leave_notify&) {
       });
     }
   }
+
+  if(!m_last_end_hover_action.empty()) {
+    m_sig.emit(button_press{m_last_end_hover_action});
+  }
+
+  m_last_end_hover_action = ""s;
+  m_last_start_hover_action = ""s;
 }
 
 /**
@@ -929,7 +936,7 @@ void bar::start(const string& tray_module_name) {
 
   // Subscribe to window enter and leave events
   // if we should dim the window
-  if (m_opts.dimvalue != 1.0) {
+  if (m_opts.dimvalue != 1.0 || !m_opts.disable_hover_checking) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
   if(!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() || !m_opts.disable_hover_checking) {

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -25,6 +25,19 @@ namespace modules {
     m_actions[mousebtn::SCROLL_UP] = m_conf.get(name(), "scroll-up", ""s);
     m_actions[mousebtn::SCROLL_DOWN] = m_conf.get(name(), "scroll-down", ""s);
 
+    if(!bar.disable_hover_checking) {
+      m_actions[mousebtn::HOVER_START] = m_conf.get(name(), "hover-start", ""s);
+      m_actions[mousebtn::HOVER_END] = m_conf.get(name(), "hover-end", ""s);
+    } else {
+      if(m_conf.has(name(), "hover-start")) {
+        m_log.warn("Hover checking is disabled, ignoring hover-start");
+      }
+      if(m_conf.has(name(), "hover-end")) {
+        m_log.warn("Hover checking is disabled, ignoring hover-end");
+      }
+    }
+    
+
     // Setup formatting
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL});
     if (m_formatter->has(TAG_LABEL)) {

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -25,7 +25,7 @@ namespace modules {
     m_actions[mousebtn::SCROLL_UP] = m_conf.get(name(), "scroll-up", ""s);
     m_actions[mousebtn::SCROLL_DOWN] = m_conf.get(name(), "scroll-down", ""s);
 
-    if (!bar.disable_hover_checking) {
+    if (bar.enable_hover_checking) {
       m_actions[mousebtn::HOVER_START] = m_conf.get(name(), "hover-start", ""s);
       m_actions[mousebtn::HOVER_END] = m_conf.get(name(), "hover-end", ""s);
     } else {

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -25,18 +25,17 @@ namespace modules {
     m_actions[mousebtn::SCROLL_UP] = m_conf.get(name(), "scroll-up", ""s);
     m_actions[mousebtn::SCROLL_DOWN] = m_conf.get(name(), "scroll-down", ""s);
 
-    if(!bar.disable_hover_checking) {
+    if (!bar.disable_hover_checking) {
       m_actions[mousebtn::HOVER_START] = m_conf.get(name(), "hover-start", ""s);
       m_actions[mousebtn::HOVER_END] = m_conf.get(name(), "hover-end", ""s);
     } else {
-      if(m_conf.has(name(), "hover-start")) {
+      if (m_conf.has(name(), "hover-start")) {
         m_log.warn("Hover checking is disabled, ignoring hover-start");
       }
-      if(m_conf.has(name(), "hover-end")) {
+      if (m_conf.has(name(), "hover-end")) {
         m_log.warn("Hover checking is disabled, ignoring hover-end");
       }
     }
-    
 
     // Setup formatting
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL});

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -25,7 +25,7 @@ namespace modules {
     m_actions[mousebtn::SCROLL_UP] = m_conf.get(name(), "scroll-up", ""s);
     m_actions[mousebtn::SCROLL_DOWN] = m_conf.get(name(), "scroll-down", ""s);
 
-    if (bar.enable_hover_checking) {
+    if (bar.enable_hover_actions) {
       m_actions[mousebtn::HOVER_START] = m_conf.get(name(), "hover-start", ""s);
       m_actions[mousebtn::HOVER_END] = m_conf.get(name(), "hover-end", ""s);
     } else {

--- a/src/tags/parser.cpp
+++ b/src/tags/parser.cpp
@@ -402,20 +402,18 @@ namespace tags {
    * May return mousebtn::NONE if no button was given.
    */
   mousebtn parser::parse_action_btn() {
-    if (has_next()) {
-      if (isdigit(peek())) {
-        char c = next();
-        int num = c - '0';
-
-        if (num < static_cast<int>(mousebtn::NONE) || num >= static_cast<int>(mousebtn::BTN_COUNT)) {
-          throw btn_error(string{c});
-        }
-
-        return static_cast<mousebtn>(num);
-      }
+    int num = 0;
+    while (has_next() && isdigit(peek())) {
+      char c = next();
+      int digit = c - '0';
+      num = num * 10 + digit;
     }
 
-    return mousebtn::NONE;
+    if (num < static_cast<int>(mousebtn::NONE) || num >= static_cast<int>(mousebtn::BTN_COUNT)) {
+      throw btn_error(std::to_string(num));
+    }
+
+    return static_cast<mousebtn>(num);
   }
 
   /**

--- a/src/tags/parser.cpp
+++ b/src/tags/parser.cpp
@@ -403,11 +403,16 @@ namespace tags {
    */
   mousebtn parser::parse_action_btn() {
     int num = 0;
+    string s;
     while (has_next() && isdigit(peek())) {
-      char c = next();
-      int digit = c - '0';
-      num = num * 10 + digit;
+      s += next();
     }
+
+    if(s.empty()) {
+      return mousebtn::NONE;
+    }
+    
+    num = std::stoi(s, nullptr, 10);
 
     if (num < static_cast<int>(mousebtn::NONE) || num >= static_cast<int>(mousebtn::BTN_COUNT)) {
       throw btn_error(std::to_string(num));

--- a/tests/unit_tests/tags/parser.cpp
+++ b/tests/unit_tests/tags/parser.cpp
@@ -225,6 +225,8 @@ vector<single_action> parse_single_action_list = {
     {"%{A6:cmd:}", mousebtn::DOUBLE_LEFT, "cmd"},
     {"%{A7:cmd:}", mousebtn::DOUBLE_MIDDLE, "cmd"},
     {"%{A8:cmd:}", mousebtn::DOUBLE_RIGHT, "cmd"},
+    {"%{A9:cmd:}", mousebtn::HOVER_START, "cmd"},
+    {"%{A10:cmd:}", mousebtn::HOVER_END, "cmd"},
     {"%{A}", mousebtn::NONE, ""},
     {"%{A1}", mousebtn::LEFT, ""},
     {"%{A2}", mousebtn::MIDDLE, ""},
@@ -234,6 +236,8 @@ vector<single_action> parse_single_action_list = {
     {"%{A6}", mousebtn::DOUBLE_LEFT, ""},
     {"%{A7}", mousebtn::DOUBLE_MIDDLE, ""},
     {"%{A8}", mousebtn::DOUBLE_RIGHT, ""},
+    {"%{A9}", mousebtn::HOVER_START, ""},
+    {"%{A10}", mousebtn::HOVER_END, ""},
     {"%{A1:a\\:b:}", mousebtn::LEFT, "a:b"},
     {"%{A1:\\:\\:\\::}", mousebtn::LEFT, ":::"},
     {"%{A1:#apps.open.0:}", mousebtn::LEFT, "#apps.open.0"},
@@ -444,7 +448,7 @@ vector<exception_test> parse_error_test = {
     {"%{O0ptx}", exc::OFFSET},
     {"%{O0a}", exc::OFFSET},
     {"%{A2:cmd:cmd:}", exc::TAG_END},
-    {"%{A9}", exc::BTN},
+    {"%{A11}", exc::BTN},
     {"%{rQ}", exc::TAG_END},
 };
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Modules can now register actions to trigger when the mouse enters or leaves an area with two new `mousbtn` entries: `HOVER_START` and `HOVER_END`.

Script module now accepts `hover-start = ...` and `hover-end = ...` commands.

Bar config now accepts `disable-hover-checking = (true|false)` setting to disable checking for hover. This also factors into whether the bar subscribes to mouse motion and mouse enter/leave events.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Closes #1064 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The Wiki documentation for the script module should include the two new `hover_start` and `hover_end` actions. Also the [formatting section on inline actions](https://github.com/polybar/polybar/wiki/Formatting#action-a) should update to say that action numbers `9` and `10` are now for `hover start` and `hover end`.

The section on [bar settings](https://github.com/polybar/polybar/wiki/Configuration#bar-settings) should also add the new `disable-hover-checking` key and clarify that it's intended use is to improve performance if the user doesn't want actions.