### PR TITLE
script: Bump poll timeout to 250ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `enable-struts` option in bar section to enable/disable struts ([`#2769`](https://github.com/polybar/polybar/issues/2769), [`#2844`](https://github.com/polybar/polybar/pull/2844)) by [@VanillaViking](https://github.com/VanillaViking).
 
 ### Changed
-- `custom/script`: No longer produces a completely empty module if the `exec` command failed. It only produces an empty module if the script had a zero exit code. ([`#2857`](https://github.com/polybar/polybar/discussions/2857), [`#2861`](https://github.com/polybar/polybar/pull/2861))
+- `custom/script`:
+  - No longer produces a completely empty module if the `exec` command failed. It only produces an empty module if the script had a zero exit code. ([`#2857`](https://github.com/polybar/polybar/discussions/2857), [`#2861`](https://github.com/polybar/polybar/pull/2861))
+  - Bumped the script polling interval (not related to the `interval` setting) to decrease wakeups. Polybar may take slightly longer to shut down. [`#2879`](https://github.com/polybar/polybar/pull/2879)
 - `internal/fs`: Use `/` as a fallback if no mountpoints are specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2705`](https://github.com/polybar/polybar/pull/2705))
 - `internal/backlight`:
   - Detect backlight if none specified ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2728`](https://github.com/polybar/polybar/pull/2728))

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -109,7 +109,7 @@ script_runner::interval script_runner::run() {
      * For non-tailed scripts, we only use the first line. However, to ensure interruptability when the module shuts
      * down, we still need to continue polling.
      */
-    if (io_util::poll_read(fd, 25) && !got_output) {
+    if (io_util::poll_read(fd, 250) && !got_output) {
       changed = set_output(cmd.readline());
       got_output = true;
     }
@@ -155,7 +155,7 @@ script_runner::interval script_runner::run_tail() {
   assert(fd != -1);
 
   while (!m_stopping && cmd.is_running() && !io_util::poll(fd, POLLHUP, 0)) {
-    if (io_util::poll_read(fd, 25)) {
+    if (io_util::poll_read(fd, 250)) {
       auto changed = set_output(cmd.readline());
 
       if (changed) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
The module has a poll timeout because it needs to periodically check if it is shutting down. Otherwise, it would be stuck polling and the bar couldn't shut down until the script produces a new line.

However, this causes the bar to wake up intermittently (currently ~40/s) due to the 25ms timeout.
Bumping this to 250ms still gives us timely shut downs and caps the number of wake ups to 4/s.

This is only a stop-gap solution, ideally the script runner is integrated into the main event loop and uses its polling handles which don't have to wake up to check for a shutdown.


## Related Issues & Documents

Ref #1778
Ref #2337

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
