### PR TITLE
fix: reapply colors for padding after suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - renderer:
   - Small gaps when rendering emojis ([`#2785`](https://github.com/polybar/polybar/issues/2785), [`#2802`](https://github.com/polybar/polybar/pull/2802))
   - Crash when using pseudo-transparency with certain wallpapers ([`#2798`](https://github.com/polybar/polybar/issues/2798), [`#2813`](https://github.com/polybar/polybar/pull/2813))
+  - Correctly apply padding colors on both sides ([`#2814`](https://github.com/polybar/polybar/issues/2814))
 - config:
   - Error reporting for deprecated config values ([`#2724`](https://github.com/polybar/polybar/issues/2724))
   - Also monitor include-files for changes when --reload is set ([`#675`](https://github.com/polybar/polybar/issues/675), [`#2759`](https://github.com/polybar/polybar/pull/2759))

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -15,24 +15,29 @@ namespace modules {
       builder->flush();
       return "";
     }
+
+    auto apply_colors = [this](polybar::builder* builder){
+      if (bg.has_color()) {
+        builder->background(bg);
+      }
+      if (fg.has_color()) {
+        builder->foreground(fg);
+      }
+      if (ul.has_color()) {
+        builder->underline(ul);
+      }
+      if (ol.has_color()) {
+        builder->overline(ol);
+      }
+    };
+
     if (offset) {
       builder->offset(offset);
     }
     if (margin) {
       builder->spacing(margin);
     }
-    if (bg.has_color()) {
-      builder->background(bg);
-    }
-    if (fg.has_color()) {
-      builder->foreground(fg);
-    }
-    if (ul.has_color()) {
-      builder->underline(ul);
-    }
-    if (ol.has_color()) {
-      builder->overline(ol);
-    }
+    apply_colors(builder);
     if (font > 0) {
       builder->font(font);
     }
@@ -41,22 +46,11 @@ namespace modules {
     }
 
     builder->node(prefix);
-
-    if (bg.has_color()) {
-      builder->background(bg);
-    }
-    if (fg.has_color()) {
-      builder->foreground(fg);
-    }
-    if (ul.has_color()) {
-      builder->underline(ul);
-    }
-    if (ol.has_color()) {
-      builder->overline(ol);
-    }
+    apply_colors(builder);
 
     builder->node(output);
     builder->node(suffix);
+    apply_colors(builder);
 
     if (padding) {
       builder->spacing(padding);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Not the prettiest, but straightforward solution for #2814.

I've read #544 and #729 and figured that prefixes do respect "parent" colors, while suffixes don't. 

```ini
format-prefix = "prefix"
; format-prefix-background = #ff0000
format-suffix = "suffix"
; format-suffix-background = #00ff00
; format-suffix-foreground= #000000
format-background = #0000ff
format-padding = 15px
```
![image](https://user-images.githubusercontent.com/4711112/213225043-2e28b3a8-960f-45fb-bdd9-ba155d4623c9.png)

We can fix this in the same PR by reapplying colors before suffix, but this is somewhat breaking.

## Related Issues & Documents
Closes #2814

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
