### PR TITLE
feat(xworkspaces): Add group-by-monitor flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wm-restack`:
   - `bottom`: lowers polybar to the bottom of the window stack (same as the previous behavior of `generic`) ([`#2961`](https://github.com/polybar/polybar/pull/2961))
   - `ewmh`: Tries to use the `_NET_SUPPORTING_WM_CHECK` hint to position the bar ([`#2961`](https://github.com/polybar/polybar/pull/2961))
+- `internal/xworkspaces`: `group-by-monitor` setting to decide whether `_NET_DESKTOP_VIEWPORT` should be used to group workspaces by monitor; ([`#2603`](https://github.com/polybar/polybar/issues/2603), [`#2926`](https://github.com/polybar/polybar/pull/2926)) by [@slotThe](https://github.com/slotThe/).
 
 ### Changed
 - `custom/script`:

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -105,6 +105,7 @@ namespace modules {
     bool m_click{true};
     bool m_scroll{true};
     bool m_revscroll{false};
+    bool m_group_by_monitor{true};
     size_t m_index{0};
   };
 } // namespace modules


### PR DESCRIPTION
We had someone else get bit by this, so I figured why not pick up the (pretty much already done) patch by @scaramangado from #2603 and add some docs.

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

By default, we group workspaces by monitor with the help of _NET_DESKTOP_VIEWPORT.  However, some users may experience this as an unpredictable "shuffling" of workspaces.  While WMs could disable advertising the property itself, it seems more sensible to handle this at the level of polybar.  Hence, introduce a new group-by-monitor flag—defaulting to true—which can be used to disable this behaviour.

## Related Issues & Documents

Closes: https://github.com/polybar/polybar/issues/2603
Related: https://github.com/xmonad/xmonad-contrib/pull/791
Related: https://github.com/qtile/qtile/issues/3375

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)

  I suppose documentation of the flag, as well as the incompatibility with `monitor-label` should be put into the relevant [xworkspaces page](https://github.com/polybar/polybar/wiki/Module:-xworkspaces).  Possibly with references to some of the above issues (although I don't know whether that'd help user find it).

* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).

  I added a changelog entry, not sure if there's anything else to be done.

* [ ] Does not require documentation changes
