### PR TITLE
tray: Rework module settings

### DIFF
--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -48,6 +48,11 @@ struct tray_settings {
   unsigned spacing{0U};
 
   /**
+   * Number of pixels added before and after each tray icon
+   */
+  unsigned padding{0U};
+
+  /**
    * Background color used in the client wrapper window
    *
    * If transparent, pseudo-transparency is used for the icon.
@@ -114,12 +119,10 @@ class manager : public xpp::event::sink<evt::expose, evt::client_message, evt::c
   void track_selection_owner(xcb_window_t owner);
   void process_docking_request(xcb_window_t win);
 
-  /**
-   * Final x-position of the tray window relative to the very top-left bar window.
-   */
   int calculate_x() const;
 
   unsigned calculate_w() const;
+  unsigned calculate_w(unsigned count) const;
 
   int calculate_client_y();
 

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -122,7 +122,6 @@ class manager : public xpp::event::sink<evt::expose, evt::client_message, evt::c
   int calculate_x() const;
 
   unsigned calculate_w() const;
-  unsigned calculate_w(unsigned count) const;
 
   int calculate_client_y();
 

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -12,6 +12,7 @@
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
 #include "utils/concurrency.hpp"
+#include "utils/mixins.hpp"
 #include "x11/atoms.hpp"
 #include "x11/connection.hpp"
 #include "x11/tray_client.hpp"
@@ -45,7 +46,19 @@ struct tray_settings {
    * Number of pixels added between tray icons
    */
   unsigned spacing{0U};
+
+  /**
+   * Background color used in the client wrapper window
+   *
+   * If transparent, pseudo-transparency is used for the icon.
+   */
   rgba background{};
+
+  /**
+   * Used for `_NET_SYSTEM_TRAY_COLORS` atom
+   *
+   * Is only a hint to the tray applications.
+   */
   rgba foreground{};
 
   /**
@@ -62,7 +75,9 @@ class manager : public xpp::event::sink<evt::expose, evt::client_message, evt::c
                     evt::selection_clear, evt::property_notify, evt::reparent_notify, evt::destroy_notify,
                     evt::map_notify, evt::unmap_notify>,
                 public signal_receiver<SIGN_PRIORITY_TRAY, signals::ui::update_background,
-                    signals::ui_tray::tray_pos_change, signals::ui_tray::tray_visibility> {
+                    signals::ui_tray::tray_pos_change, signals::ui_tray::tray_visibility>,
+                non_copyable_mixin,
+                non_movable_mixin {
  public:
   explicit manager(connection& conn, signal_emitter& emitter, const logger& logger, const bar_settings& bar_opts,
       on_update on_update);

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -61,10 +61,6 @@ void manager::setup(const config& conf, const string& section_name) {
     client_height = maxsize;
   }
 
-  // Apply user-defined scaling
-  auto scale = conf.get(section_name, "tray-scale", 1.0);
-  client_height *= scale;
-
   m_opts.client_size = {client_height, client_height};
 
   // Set user-defined foreground and background colors.


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [x] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Reworks settings in the tray module:

* `tray-spacing` (px or pt, default: 0): Space added between tray icons (but not at the beginning or end)
* `tray-padding` (px or pt, default: 0): Space added before and after each tray icon
* `tray-size` (percentage with offset, relative to bar height, default: 66%): Width and height of tray icons, capped at bar height
* `tray-background` (default: bar bg): Background of tray icons. Should really not be altered, only affects the icon itself and not any of the space around it.
* `tray-foreground` (default: bar fg): Hint to the tray applications. Sets the non-standard `_NET_SYSTEM_TRAY_COLORS`

Any other tray settings that used to work in the bar section, do not work in the tray module.

Since the tray module is not yet released, we can do that without it being a breaking change. Migration from the legacy tray implementation to the module will require more config changes though.

## Related Issues & Documents

Ref #2689
Fixes #1207 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes


Documentation updates will come in a separate PR