### PR TITLE
fix(doc): %s in extlinks caption before sphinx 4.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,9 @@ def get_version(root_path):
 
     raise RuntimeError("No version found in {}".format(path))
 
+
+sphinx_version = packaging.version.parse(sphinx.__version__)
+
 # -- Project information -----------------------------------------------------
 
 
@@ -117,10 +120,18 @@ highlight_language = 'none'
 smartquotes = False
 
 # Quickly link to issues or PRs using :issue:`...` or :pull:`...`
-extlinks = {
-    "issue": ("https://github.com/polybar/polybar/issues/%s", "#"),
-    "pull": ("https://github.com/polybar/polybar/pull/%s", "PR #"),
-}
+if sphinx_version >= packaging.version.parse("4.0.0"):
+    extlinks = {
+        "issue": ("https://github.com/polybar/polybar/issues/%s", "#%s"),
+        "pull": ("https://github.com/polybar/polybar/pull/%s", "PR #%s"),
+    }
+else:
+    # Versions before 4.0 (e.g. on readthedocs) do not support %s in the
+    # caption and simply append the value
+    extlinks = {
+        "issue": ("https://github.com/polybar/polybar/issues/%s", "#"),
+        "pull": ("https://github.com/polybar/polybar/pull/%s", "PR #"),
+    }
 
 extlinks_detect_hardcoded_links = True
 
@@ -302,7 +313,7 @@ def setup(app):
 # built from master, documentation built for proper releases should not even
 # mention unreleased changes. Because of that it's not that important that this
 # is added to local builds.
-if packaging.version.parse(sphinx.__version__) >= packaging.version.parse("1.8.5"):
+if sphinx_version >= packaging.version.parse("1.8.5"):
 
     from typing import List
     from docutils.nodes import Node


### PR DESCRIPTION
There is no way to support extlinks with a custom caption in both sphinx < 4 and >= 4 at the same time without implementing different behavior per version.

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

The usage of `%s` in extlinks caption strings does not work the same in sphinx < 4 and >= 4. Before sphinx 4, %s wasn't allowed and after it is required.

This failed builds on sphinx >= 4

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
