### PR TITLE
Restack refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COLOR: "ON"
     steps:
@@ -29,7 +29,7 @@ jobs:
           make doc
 
   ipc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COLOR: "ON"
     steps:
@@ -60,7 +60,7 @@ jobs:
           make polybar-msg
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         cxx: [g++, clang++]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/temperature`: Added `zone-type` setting ([`#2572`](https://github.com/polybar/polybar/issues/2572), [`#2752`](https://github.com/polybar/polybar/pull/2752)) by [@xphoniex](https://github.com/xphoniex)
 - `internal/xwindow`: `%class%` and `%instance%` tokens, which show the contents of the `WM_CLASS` property of the active window ([`#2830`](https://github.com/polybar/polybar/pull/2830))
 - Added `enable-struts` option in bar section to enable/disable struts ([`#2769`](https://github.com/polybar/polybar/issues/2769), [`#2844`](https://github.com/polybar/polybar/pull/2844)) by [@VanillaViking](https://github.com/VanillaViking).
+- `wm-restack`:
+  - `bottom`: lowers polybar to the bottom of the window stack (same as the previous behavior of `generic`) ([`#2961`](https://github.com/polybar/polybar/pull/2961))
+  - `ewmh`: Tries to use the `_NET_SUPPORTING_WM_CHECK` hint to position the bar ([`#2961`](https://github.com/polybar/polybar/pull/2961))
 
 ### Changed
 - `custom/script`:
@@ -45,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `use-actual-brightness` defaults to `true` for `amdgpu` backlights ([`#2835`](https://github.com/polybar/polybar/issues/2835), [`2839`](https://github.com/polybar/polybar/pull/2839))
 - Providing a negative min-width to a token adds right-padding ([`#2789`](https://github.com/polybar/polybar/issues/2789), [`#2801`](https://github.com/polybar/polybar/pull/2801)) by [@VanillaViking](https://github.com/VanillaViking).
 - Changed fuzzy match option on i3 and bspwm modules to find longest match instead of the first match ([`#2831`](https://github.com/polybar/polybar/pull/2831), [`#2829`](https://github.com/polybar/polybar/issues/2829)) by [@Ron0Studios](https://github.com/ron0studios/).
+- `wm-restack`
+  - `generic`: Is now a best effort combination of other restacking strategies. First tries `ewmh` and then the `bottom` strategy ([`#2961`](https://github.com/polybar/polybar/pull/2961))
+  - `bspwm`: First tries the `ewmh` strategy before falling back to its old behavior ([`#2961`](https://github.com/polybar/polybar/pull/2961))
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))
@@ -57,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Also monitor include-files for changes when --reload is set ([`#675`](https://github.com/polybar/polybar/issues/675), [`#2759`](https://github.com/polybar/polybar/pull/2759))
 - `internal/xwindow`: module does not crash when a tag is not provided in format ([`#2826`](https://github.com/polybar/polybar/issues/2826), [`#2833`](https://github.com/polybar/polybar/pull/2833)) by [@VanillaViking](https://github.com/VanillaViking)
 - `internal/i3`: module errors when i3 has negative gaps ([`#2888`](https://github.com/polybar/polybar/issues/2888), [`#2889`](https://github.com/polybar/polybar/pull/2889))
+- `wm-restack = bspwm`: bar may become unclickable if there are overlapping monitors ([`#2873`](https://github.com/polybar/polybar/issues/2873), [`#2961`](https://github.com/polybar/polybar/pull/2961))
 
 ## [3.6.3] - 2022-05-04
 ### Fixed

--- a/include/utils/bspwm.hpp
+++ b/include/utils/bspwm.hpp
@@ -5,6 +5,7 @@
 
 #include "common.hpp"
 #include "settings.hpp"
+#include "utils/restack.hpp"
 #include "utils/socket.hpp"
 #include "utils/string.hpp"
 #include "x11/extensions/randr.hpp"
@@ -25,7 +26,7 @@ namespace bspwm_util {
   };
 
   vector<xcb_window_t> root_windows(connection& conn);
-  xcb_window_t get_restack_sibling(connection& conn, const monitor_t& mon);
+  restack_util::params get_restack_params(connection& conn, const monitor_t& mon, xcb_window_t bar_window);
 
   string get_socket_path();
 

--- a/include/utils/bspwm.hpp
+++ b/include/utils/bspwm.hpp
@@ -25,7 +25,7 @@ namespace bspwm_util {
   };
 
   vector<xcb_window_t> root_windows(connection& conn);
-  bool restack_to_root(connection& conn, const monitor_t& mon, const xcb_window_t win);
+  xcb_window_t get_restack_sibling(connection& conn, const monitor_t& mon);
 
   string get_socket_path();
 

--- a/include/utils/i3.hpp
+++ b/include/utils/i3.hpp
@@ -3,6 +3,7 @@
 #include <i3ipc++/ipc.hpp>
 
 #include "common.hpp"
+#include "utils/restack.hpp"
 #include "x11/extensions/randr.hpp"
 
 POLYBAR_NS
@@ -19,7 +20,7 @@ namespace i3_util {
   shared_ptr<workspace_t> focused_workspace(const connection_t&);
 
   vector<xcb_window_t> root_windows(connection& conn, const string& output_name = "");
-  xcb_window_t get_restack_sibling(connection& conn);
+  restack_util::params get_restack_params(connection& conn);
 }
 
 namespace {

--- a/include/utils/i3.hpp
+++ b/include/utils/i3.hpp
@@ -19,7 +19,7 @@ namespace i3_util {
   shared_ptr<workspace_t> focused_workspace(const connection_t&);
 
   vector<xcb_window_t> root_windows(connection& conn, const string& output_name = "");
-  bool restack_to_root(connection& conn, const xcb_window_t win);
+  xcb_window_t get_restack_sibling(connection& conn);
 }
 
 namespace {

--- a/include/utils/restack.hpp
+++ b/include/utils/restack.hpp
@@ -8,14 +8,16 @@
 POLYBAR_NS
 
 namespace restack_util {
-  using params = std::pair<xcb_window_t, xcb_stack_mode_t>;
+using params = std::pair<xcb_window_t, xcb_stack_mode_t>;
 
-  void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode);
-  string stack_mode_to_string(xcb_stack_mode_t mode);
-  bool are_siblings(connection& conn, xcb_window_t win, xcb_window_t sibling);
-  params get_bottom_params(connection& conn, xcb_window_t bar_window);
-  params get_ewmh_params(connection& conn);
-  params get_generic_params(connection& conn, xcb_window_t bar_window);
-}
+static constexpr params NONE_PARAMS = {XCB_NONE, XCB_STACK_MODE_ABOVE};
+
+void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode);
+string stack_mode_to_string(xcb_stack_mode_t mode);
+bool are_siblings(connection& conn, xcb_window_t win, xcb_window_t sibling);
+params get_bottom_params(connection& conn, xcb_window_t bar_window);
+params get_ewmh_params(connection& conn);
+params get_generic_params(connection& conn, xcb_window_t bar_window);
+} // namespace restack_util
 
 POLYBAR_NS_END

--- a/include/utils/restack.hpp
+++ b/include/utils/restack.hpp
@@ -8,7 +8,12 @@
 POLYBAR_NS
 
 namespace restack_util {
+  using params = std::pair<xcb_window_t, xcb_stack_mode_t>;
+
   void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode);
+  bool are_siblings(connection& conn, xcb_window_t win, xcb_window_t sibling);
+  params get_bottom_params(connection& conn, xcb_window_t bar_window);
+  params get_generic_params(connection& conn, xcb_window_t bar_window);
 }
 
 POLYBAR_NS_END

--- a/include/utils/restack.hpp
+++ b/include/utils/restack.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <xcb/xcb.h>
+
+#include "x11/connection.hpp"
+#include "x11/ewmh.hpp"
+
+POLYBAR_NS
+
+namespace restack_util {
+  void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode);
+}
+
+POLYBAR_NS_END

--- a/include/utils/restack.hpp
+++ b/include/utils/restack.hpp
@@ -11,8 +11,10 @@ namespace restack_util {
   using params = std::pair<xcb_window_t, xcb_stack_mode_t>;
 
   void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode);
+  string stack_mode_to_string(xcb_stack_mode_t mode);
   bool are_siblings(connection& conn, xcb_window_t win, xcb_window_t sibling);
   params get_bottom_params(connection& conn, xcb_window_t bar_window);
+  params get_ewmh_params(connection& conn);
   params get_generic_params(connection& conn, xcb_window_t bar_window);
 }
 

--- a/include/x11/ewmh.hpp
+++ b/include/x11/ewmh.hpp
@@ -53,6 +53,9 @@ namespace ewmh_util {
   void set_wm_window_opacity(xcb_window_t win, unsigned long int values);
 
   vector<xcb_window_t> get_client_list(int screen = 0);
+
+  xcb_window_t get_supporting_wm_check(xcb_window_t win);
+  xcb_window_t get_ewmh_meta_window(xcb_window_t root);
 } // namespace ewmh_util
 
 POLYBAR_NS_END

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,6 +120,7 @@ set(POLY_SOURCES
   ${src_dir}/utils/inotify.cpp
   ${src_dir}/utils/io.cpp
   ${src_dir}/utils/process.cpp
+  ${src_dir}/utils/restack.cpp
   ${src_dir}/utils/socket.cpp
   ${src_dir}/utils/string.cpp
   ${src_dir}/utils/units.cpp

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -497,20 +497,19 @@ void bar::restack_window() {
 
   xcb_window_t bar_window = m_opts.x_data.window;
 
-  xcb_window_t restack_sibling = XCB_NONE;
-  xcb_stack_mode_t stack_mode = XCB_STACK_MODE_ABOVE;
+  restack_util::params restack_params;
 
   if (wm_restack == "generic") {
-    std::tie(restack_sibling, stack_mode) = restack_util::get_generic_params(m_connection, bar_window);
+    restack_params = restack_util::get_generic_params(m_connection, bar_window);
   } else if (wm_restack == "ewmh") {
-    std::tie(restack_sibling, stack_mode) = restack_util::get_ewmh_params(m_connection);
+    restack_params = restack_util::get_ewmh_params(m_connection);
   } else if (wm_restack == "bottom") {
-    std::tie(restack_sibling, stack_mode) = restack_util::get_bottom_params(m_connection, bar_window);
+    restack_params = restack_util::get_bottom_params(m_connection, bar_window);
   } else if (wm_restack == "bspwm") {
-    restack_sibling = bspwm_util::get_restack_sibling(m_connection, m_opts.monitor);
+    restack_params = bspwm_util::get_restack_params(m_connection, m_opts.monitor, bar_window);
 #if ENABLE_I3
   } else if (wm_restack == "i3" && m_opts.override_redirect) {
-    restack_sibling = i3_util::get_restack_sibling(m_connection);
+    restack_params = i3_util::get_restack_params(m_connection);
   } else if (wm_restack == "i3" && !m_opts.override_redirect) {
     m_log.warn("Ignoring restack of i3 window (not needed when `override-redirect = false`)");
     wm_restack.clear();
@@ -519,6 +518,8 @@ void bar::restack_window() {
     m_log.warn("Ignoring unsupported wm-restack option '%s'", wm_restack);
     wm_restack.clear();
   }
+
+  auto [restack_sibling, stack_mode] = restack_params;
 
   if (restack_sibling != XCB_NONE) {
     try {

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -11,6 +11,7 @@
 #include "events/signal_emitter.hpp"
 #include "tags/dispatch.hpp"
 #include "utils/bspwm.hpp"
+#include "utils/restack.hpp"
 #include "utils/color.hpp"
 #include "utils/math.hpp"
 #include "utils/string.hpp"
@@ -497,9 +498,7 @@ void bar::restack_window() {
     try {
       auto children = m_connection.query_tree(m_connection.root()).children();
       if (children.begin() != children.end() && *children.begin() != m_opts.x_data.window) {
-        const unsigned int value_mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
-        const unsigned int value_list[2]{*children.begin(), XCB_STACK_MODE_BELOW};
-        m_connection.configure_window_checked(m_opts.x_data.window, value_mask, value_list);
+        restack_util::restack_relative(m_connection, m_opts.x_data.window, *children.begin(), XCB_STACK_MODE_BELOW);
       }
       restacked = true;
     } catch (const exception& err) {

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -501,7 +501,9 @@ void bar::restack_window() {
   xcb_stack_mode_t stack_mode = XCB_STACK_MODE_ABOVE;
 
   if (wm_restack == "generic") {
-    std::tie(restack_sibling, stack_mode) = restack_util::get_bottom_params(m_connection, bar_window);
+    std::tie(restack_sibling, stack_mode) = restack_util::get_generic_params(m_connection, bar_window);
+  } else if (wm_restack == "ewmh") {
+    std::tie(restack_sibling, stack_mode) = restack_util::get_ewmh_params(m_connection);
   } else if (wm_restack == "bottom") {
     std::tie(restack_sibling, stack_mode) = restack_util::get_bottom_params(m_connection, bar_window);
   } else if (wm_restack == "bspwm") {
@@ -520,6 +522,8 @@ void bar::restack_window() {
 
   if (restack_sibling != XCB_NONE) {
     try {
+      m_log.info("bar: Restacking bar window relative to %s with stacking mode %s", m_connection.id(restack_sibling),
+          restack_util::stack_mode_to_string(stack_mode));
       restack_util::restack_relative(m_connection, bar_window, restack_sibling, stack_mode);
       m_log.info("Successfully restacked bar window");
     } catch (const exception& err) {

--- a/src/utils/bspwm.cpp
+++ b/src/utils/bspwm.cpp
@@ -36,10 +36,7 @@ vector<xcb_window_t> root_windows(connection& conn) {
 }
 
 /**
- * Restack given window relative to the bspwm root window
- * for the given monitor.
- *
- * Fixes the issue with always-on-top window's
+ * Returns window against which to restack.
  */
 xcb_window_t get_restack_sibling(connection& conn, const monitor_t& mon) {
   for (auto&& root : root_windows(conn)) {

--- a/src/utils/bspwm.cpp
+++ b/src/utils/bspwm.cpp
@@ -5,148 +5,143 @@
 #include "errors.hpp"
 #include "utils/env.hpp"
 #include "x11/connection.hpp"
+#include "x11/ewmh.hpp"
 
 POLYBAR_NS
 
 namespace bspwm_util {
-  /**
-   * Get all bspwm root windows
-   */
-  vector<xcb_window_t> root_windows(connection& conn) {
-    vector<xcb_window_t> roots;
-    auto children = conn.query_tree(conn.root()).children();
+/**
+ * Get all bspwm root windows
+ */
+vector<xcb_window_t> root_windows(connection& conn) {
+  vector<xcb_window_t> roots;
+  auto children = conn.query_tree(conn.root()).children();
 
-    for (auto it = children.begin(); it != children.end(); it++) {
-      xcb_icccm_get_wm_class_reply_t reply{};
-      reply.class_name = reply.instance_name = nullptr;
+  for (auto it = children.begin(); it != children.end(); it++) {
+    xcb_icccm_get_wm_class_reply_t reply{};
+    reply.class_name = reply.instance_name = nullptr;
 
-      if (xcb_icccm_get_wm_class_reply(conn, xcb_icccm_get_wm_class(conn, *it), &reply, nullptr)) {
-        if (string_util::compare("Bspwm", reply.class_name) && string_util::compare("root", reply.instance_name)) {
-          roots.emplace_back(*it);
-        }
-      }
-
-      if (reply.class_name != nullptr || reply.instance_name != nullptr) {
-        xcb_icccm_get_wm_class_reply_wipe(&reply);
+    if (xcb_icccm_get_wm_class_reply(conn, xcb_icccm_get_wm_class(conn, *it), &reply, nullptr)) {
+      if (string_util::compare("Bspwm", reply.class_name) && string_util::compare("root", reply.instance_name)) {
+        roots.emplace_back(*it);
       }
     }
 
-    return roots;
+    if (reply.class_name != nullptr || reply.instance_name != nullptr) {
+      xcb_icccm_get_wm_class_reply_wipe(&reply);
+    }
   }
 
-  /**
-   * Restack given window relative to the bspwm root window
-   * for the given monitor.
-   *
-   * Fixes the issue with always-on-top window's
-   */
-  bool restack_to_root(connection& conn, const monitor_t& mon, const xcb_window_t win) {
-    for (auto&& root : root_windows(conn)) {
-      auto geom = conn.get_geometry(root);
+  return roots;
+}
 
-      if (mon->x != geom->x || mon->y != geom->y) {
-        continue;
-      }
-      if (mon->w != geom->width || mon->h != geom->height) {
-        continue;
-      }
+/**
+ * Restack given window relative to the bspwm root window
+ * for the given monitor.
+ *
+ * Fixes the issue with always-on-top window's
+ */
+xcb_window_t get_restack_sibling(connection& conn, const monitor_t& mon) {
+  for (auto&& root : root_windows(conn)) {
+    auto geom = conn.get_geometry(root);
 
-      const unsigned int value_mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
-      const unsigned int value_list[2]{root, XCB_STACK_MODE_ABOVE};
-
-      conn.configure_window_checked(win, value_mask, value_list);
-      conn.flush();
-
-      return true;
+    if (mon->x != geom->x || mon->y != geom->y) {
+      continue;
+    }
+    if (mon->w != geom->width || mon->h != geom->height) {
+      continue;
     }
 
-    return false;
+    return root;
   }
 
-  /**
-   * Get path to the bspwm socket by the following order
-   *
-   * 1. Value of environment variable BSPWM_SOCKET
-   * 2. Value built from the bspwm socket path template
-   * 3. Value of the macro BSPWM_SOCKET_PATH
-   */
-  string get_socket_path() {
-    string env_path;
+  return XCB_NONE;
+}
 
-    if (!(env_path = env_util::get("BSPWM_SOCKET")).empty()) {
-      return env_path;
-    }
+/**
+ * Get path to the bspwm socket by the following order
+ *
+ * 1. Value of environment variable BSPWM_SOCKET
+ * 2. Value built from the bspwm socket path template
+ * 3. Value of the macro BSPWM_SOCKET_PATH
+ */
+string get_socket_path() {
+  string env_path;
 
-    struct sockaddr_un sa {};
-    char* host = nullptr;
-    int dsp = 0;
-    int scr = 0;
-
-    if (xcb_parse_display(nullptr, &host, &dsp, &scr) == 0) {
-      return BSPWM_SOCKET_PATH;
-    }
-
-    snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/bspwm%s_%i_%i-socket", host, dsp, scr);
-    free(host);
-
-    return sa.sun_path;
+  if (!(env_path = env_util::get("BSPWM_SOCKET")).empty()) {
+    return env_path;
   }
 
-  /**
-   * Generate a payload object with properly formatted data
-   * ready to be sent to the bspwm ipc controller
-   */
-  payload_t make_payload(const string& cmd) {
-    payload_t payload{new payload_t::element_type{}};
-    auto size = sizeof(payload->data);
-    int offset = 0;
-    int chars = 0;
+  struct sockaddr_un sa {};
+  char* host = nullptr;
+  int dsp = 0;
+  int scr = 0;
 
-    for (auto&& word : string_util::split(cmd, ' ')) {
-      chars = snprintf(payload->data + offset, size - offset, "%s%c", word.c_str(), 0);
-      payload->len += chars;
-      offset += chars;
-    }
-
-    return payload;
+  if (xcb_parse_display(nullptr, &host, &dsp, &scr) == 0) {
+    return BSPWM_SOCKET_PATH;
   }
 
-  /**
-   * Create an ipc socket connection
-   *
-   * Example usage:
-   * @code cpp
-   *   auto ipc = make_connection();
-   *   ipc->send(make_payload("desktop -f eDP-1:^1"));
-   * @endcode
-   */
-  connection_t make_connection() {
-    return socket_util::make_unix_connection(get_socket_path());
+  snprintf(sa.sun_path, sizeof(sa.sun_path), "/tmp/bspwm%s_%i_%i-socket", host, dsp, scr);
+  free(host);
+
+  return sa.sun_path;
+}
+
+/**
+ * Generate a payload object with properly formatted data
+ * ready to be sent to the bspwm ipc controller
+ */
+payload_t make_payload(const string& cmd) {
+  payload_t payload{new payload_t::element_type{}};
+  auto size = sizeof(payload->data);
+  int offset = 0;
+  int chars = 0;
+
+  for (auto&& word : string_util::split(cmd, ' ')) {
+    chars = snprintf(payload->data + offset, size - offset, "%s%c", word.c_str(), 0);
+    payload->len += chars;
+    offset += chars;
   }
 
-  /**
-   * Create a connection and subscribe to events
-   * on the bspwm socket
-   *
-   * Example usage:
-   * @code cpp
-   *   auto ipc = make_subscriber();
-   *
-   *   while (!ipc->poll(POLLHUP, 0)) {
-   *     ssize_t bytes_received = 0;
-   *     auto data = ipc->receive(BUFSIZ-1, bytes_received, 0);
-   *     std::cout << data << std::endl;
-   *   }
-   * @endcode
-   */
-  connection_t make_subscriber() {
-    auto conn = make_connection();
-    auto payload = make_payload("subscribe report");
-    if (conn->send(payload->data, payload->len, 0) == 0) {
-      throw system_error("Failed to initialize subscriber");
-    }
-    return conn;
+  return payload;
+}
+
+/**
+ * Create an ipc socket connection
+ *
+ * Example usage:
+ * @code cpp
+ *   auto ipc = make_connection();
+ *   ipc->send(make_payload("desktop -f eDP-1:^1"));
+ * @endcode
+ */
+connection_t make_connection() {
+  return socket_util::make_unix_connection(get_socket_path());
+}
+
+/**
+ * Create a connection and subscribe to events
+ * on the bspwm socket
+ *
+ * Example usage:
+ * @code cpp
+ *   auto ipc = make_subscriber();
+ *
+ *   while (!ipc->poll(POLLHUP, 0)) {
+ *     ssize_t bytes_received = 0;
+ *     auto data = ipc->receive(BUFSIZ-1, bytes_received, 0);
+ *     std::cout << data << std::endl;
+ *   }
+ * @endcode
+ */
+connection_t make_subscriber() {
+  auto conn = make_connection();
+  auto payload = make_payload("subscribe report");
+  if (conn->send(payload->data, payload->len, 0) == 0) {
+    throw system_error("Failed to initialize subscriber");
   }
+  return conn;
+}
 } // namespace bspwm_util
 
 POLYBAR_NS_END

--- a/src/utils/bspwm.cpp
+++ b/src/utils/bspwm.cpp
@@ -38,7 +38,13 @@ vector<xcb_window_t> root_windows(connection& conn) {
 /**
  * Returns window against which to restack.
  */
-xcb_window_t get_restack_sibling(connection& conn, const monitor_t& mon) {
+restack_util::params get_restack_params(connection& conn, const monitor_t& mon, xcb_window_t bar_window) {
+  auto ewmh_params = restack_util::get_ewmh_params(conn);
+
+  if (restack_util::are_siblings(conn, bar_window, ewmh_params.first)) {
+    return ewmh_params;
+  }
+
   for (auto&& root : root_windows(conn)) {
     auto geom = conn.get_geometry(root);
 
@@ -49,10 +55,10 @@ xcb_window_t get_restack_sibling(connection& conn, const monitor_t& mon) {
       continue;
     }
 
-    return root;
+    return {root, XCB_STACK_MODE_ABOVE};
   }
 
-  return XCB_NONE;
+  return restack_util::NONE_PARAMS;
 }
 
 /**

--- a/src/utils/i3.cpp
+++ b/src/utils/i3.cpp
@@ -68,8 +68,8 @@ namespace i3_util {
   /**
    * Returns window against which to restack.
    */
-  xcb_window_t get_restack_sibling(connection& conn) {
-    return root_window(conn);
+  restack_util::params get_restack_params(connection& conn) {
+    return {root_window(conn), XCB_STACK_MODE_ABOVE};
   }
 } // namespace i3_util
 

--- a/src/utils/i3.cpp
+++ b/src/utils/i3.cpp
@@ -71,14 +71,8 @@ namespace i3_util {
    *
    * Fixes the issue with always-on-top window's
    */
-  bool restack_to_root(connection& conn, const xcb_window_t win) {
-    const unsigned int value_mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
-    const unsigned int value_list[2]{root_window(conn), XCB_STACK_MODE_ABOVE};
-    if (value_list[0] != XCB_NONE) {
-      conn.configure_window_checked(win, value_mask, value_list);
-      return true;
-    }
-    return false;
+  xcb_window_t get_restack_sibling(connection& conn) {
+    return root_window(conn);
   }
 } // namespace i3_util
 

--- a/src/utils/i3.cpp
+++ b/src/utils/i3.cpp
@@ -66,10 +66,7 @@ namespace i3_util {
   }
 
   /**
-   * Restack given window relative to the i3 root window
-   * defined for the given monitor
-   *
-   * Fixes the issue with always-on-top window's
+   * Returns window against which to restack.
    */
   xcb_window_t get_restack_sibling(connection& conn) {
     return root_window(conn);

--- a/src/utils/restack.cpp
+++ b/src/utils/restack.cpp
@@ -3,21 +3,69 @@
 POLYBAR_NS
 
 namespace restack_util {
-  /**
-   * Restacks the given window relative to a given sibling with some stack order (above, below)
-   *
-   * Both windows need to be siblings (have the same parent window).
-   *
-   * @param win The window to restack
-   * @param sibling The window relative to which restacking happens
-   * @param stack_mode The restacking mode (above, below)
-   * @throw Some xpp error if restacking fails
-   */
-  void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode) {
-    const unsigned int value_mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
-    const std::array<uint32_t, 2> value_list = {sibling, stack_mode};
-    conn.configure_window_checked(win, value_mask, value_list.data());
-  }
+
+static constexpr params NONE_PARAMS = {XCB_NONE, XCB_STACK_MODE_ABOVE};
+
+/**
+ * Restacks the given window relative to a given sibling with some stack order (above, below)
+ *
+ * Both windows need to be siblings (have the same parent window).
+ *
+ * @param win The window to restack
+ * @param sibling The window relative to which restacking happens
+ * @param stack_mode The restacking mode (above, below)
+ * @throw Some xpp error if restacking fails
+ */
+void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode) {
+  const unsigned int value_mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
+  const std::array<uint32_t, 2> value_list = {sibling, stack_mode};
+  conn.configure_window_checked(win, value_mask, value_list.data());
 }
+
+/**
+ * @return true iff the two given windows are sibings (are different windows and have same parent).
+ */
+bool are_siblings(connection& conn, xcb_window_t win, xcb_window_t sibling) {
+  if (win == XCB_NONE || sibling == XCB_NONE || win == sibling) {
+    return false;
+  }
+
+  auto win_tree = conn.query_tree(win);
+  auto sibling_tree = conn.query_tree(sibling);
+  return win_tree->parent == sibling_tree->parent;
+}
+
+/**
+ * "bottom" restack strategy.
+ *
+ * Moves the bar window to the bottom of the window stack
+ */
+std::pair<xcb_window_t, xcb_stack_mode_t> get_bottom_params(connection& conn, xcb_window_t bar_window) {
+  auto children = conn.query_tree(conn.root()).children();
+  if (children.begin() != children.end() && *children.begin() != bar_window) {
+    return {*children.begin(), XCB_STACK_MODE_BELOW};
+  }
+
+  return NONE_PARAMS;
+}
+
+/**
+ * Generic restack stratgey.
+ *
+ * Tries to provide the best WM-agnostic restacking.
+ *
+ * Currently tries to the following stratgies in order:
+ * * bottom
+ */
+std::pair<xcb_window_t, xcb_stack_mode_t> get_generic_params(connection& conn, xcb_window_t bar_window) {
+  auto [sibling, mode] = get_bottom_params(conn, bar_window);
+
+  if (are_siblings(conn, bar_window, sibling)) {
+    return {sibling, mode};
+  }
+
+  return NONE_PARAMS;
+}
+} // namespace restack_util
 
 POLYBAR_NS_END

--- a/src/utils/restack.cpp
+++ b/src/utils/restack.cpp
@@ -4,8 +4,6 @@ POLYBAR_NS
 
 namespace restack_util {
 
-static constexpr params NONE_PARAMS = {XCB_NONE, XCB_STACK_MODE_ABOVE};
-
 /**
  * Restacks the given window relative to a given sibling with some stack order (above, below)
  *

--- a/src/utils/restack.cpp
+++ b/src/utils/restack.cpp
@@ -1,0 +1,23 @@
+#include "utils/restack.hpp"
+
+POLYBAR_NS
+
+namespace restack_util {
+  /**
+   * Restacks the given window relative to a given sibling with some stack order (above, below)
+   *
+   * Both windows need to be siblings (have the same parent window).
+   *
+   * @param win The window to restack
+   * @param sibling The window relative to which restacking happens
+   * @param stack_mode The restacking mode (above, below)
+   * @throw Some xpp error if restacking fails
+   */
+  void restack_relative(connection& conn, xcb_window_t win, xcb_window_t sibling, xcb_stack_mode_t stack_mode) {
+    const unsigned int value_mask = XCB_CONFIG_WINDOW_SIBLING | XCB_CONFIG_WINDOW_STACK_MODE;
+    const std::array<uint32_t, 2> value_list = {sibling, stack_mode};
+    conn.configure_window_checked(win, value_mask, value_list.data());
+  }
+}
+
+POLYBAR_NS_END

--- a/src/x11/ewmh.cpp
+++ b/src/x11/ewmh.cpp
@@ -11,188 +11,221 @@ POLYBAR_NS
 
 namespace ewmh_util {
 
-  ewmh_connection::ewmh_connection() {
-    xcb_ewmh_init_atoms_replies(&c, xcb_ewmh_init_atoms(connection::make(), &c), nullptr);
-  }
+ewmh_connection::ewmh_connection() {
+  xcb_ewmh_init_atoms_replies(&c, xcb_ewmh_init_atoms(connection::make(), &c), nullptr);
+}
 
-  ewmh_connection::~ewmh_connection() {
-    xcb_ewmh_connection_wipe(&c);
-  }
+ewmh_connection::~ewmh_connection() {
+  xcb_ewmh_connection_wipe(&c);
+}
 
-  xcb_ewmh_connection_t* ewmh_connection::operator->() {
-    return &c;
-  }
+xcb_ewmh_connection_t* ewmh_connection::operator->() {
+  return &c;
+}
 
-  ewmh_connection::operator xcb_ewmh_connection_t*() {
-    return &c;
-  }
+ewmh_connection::operator xcb_ewmh_connection_t*() {
+  return &c;
+}
 
-  ewmh_connection& initialize() {
-    static ewmh_connection c;
-    return c;
-  }
+ewmh_connection& initialize() {
+  static ewmh_connection c;
+  return c;
+}
 
-  bool supports(xcb_atom_t atom, int screen) {
-    auto& conn = initialize();
-    xcb_ewmh_get_atoms_reply_t reply{};
-    if (xcb_ewmh_get_supported_reply(conn, xcb_ewmh_get_supported(conn, screen), &reply, nullptr)) {
-      for (size_t n = 0; n < reply.atoms_len; n++) {
-        if (reply.atoms[n] == atom) {
-          xcb_ewmh_get_atoms_reply_wipe(&reply);
-          return true;
-        }
-      }
-      xcb_ewmh_get_atoms_reply_wipe(&reply);
-    }
-    return false;
-  }
-
-  string get_wm_name(xcb_window_t win) {
-    auto& conn = initialize();
-    xcb_ewmh_get_utf8_strings_reply_t utf8_reply{};
-    if (xcb_ewmh_get_wm_name_reply(conn, xcb_ewmh_get_wm_name(conn, win), &utf8_reply, nullptr)) {
-      return get_reply_string(&utf8_reply);
-    }
-    return "";
-  }
-
-  string get_visible_name(xcb_window_t win) {
-    auto& conn = initialize();
-    xcb_ewmh_get_utf8_strings_reply_t utf8_reply{};
-    if (xcb_ewmh_get_wm_visible_name_reply(conn, xcb_ewmh_get_wm_visible_name(conn, win), &utf8_reply, nullptr)) {
-      return get_reply_string(&utf8_reply);
-    }
-    return "";
-  }
-
-  string get_icon_name(xcb_window_t win) {
-    auto& conn = initialize();
-    xcb_ewmh_get_utf8_strings_reply_t utf8_reply{};
-    if (xcb_ewmh_get_wm_icon_name_reply(conn, xcb_ewmh_get_wm_icon_name(conn, win), &utf8_reply, nullptr)) {
-      return get_reply_string(&utf8_reply);
-    }
-    return "";
-  }
-
-  string get_reply_string(xcb_ewmh_get_utf8_strings_reply_t* reply) {
-    string str;
-    if (reply) {
-      str = string(reply->strings, reply->strings_len);
-      xcb_ewmh_get_utf8_strings_reply_wipe(reply);
-    }
-    return str;
-  }
-
-  unsigned int get_current_desktop(int screen) {
-    auto& conn = initialize();
-    unsigned int desktop = XCB_NONE;
-    xcb_ewmh_get_current_desktop_reply(conn, xcb_ewmh_get_current_desktop(conn, screen), &desktop, nullptr);
-    return desktop;
-  }
-
-  unsigned int get_number_of_desktops(int screen) {
-    auto& conn = initialize();
-    unsigned int desktops = XCB_NONE;
-    xcb_ewmh_get_number_of_desktops_reply(conn, xcb_ewmh_get_number_of_desktops(conn, screen), &desktops, nullptr);
-    return desktops;
-  }
-
-  vector<position> get_desktop_viewports(int screen) {
-    auto& conn = initialize();
-    vector<position> viewports;
-    xcb_ewmh_get_desktop_viewport_reply_t reply{};
-    if (xcb_ewmh_get_desktop_viewport_reply(conn, xcb_ewmh_get_desktop_viewport(conn, screen), &reply, nullptr)) {
-      for (size_t n = 0; n < reply.desktop_viewport_len; n++) {
-        viewports.emplace_back(position{
-            static_cast<short int>(reply.desktop_viewport[n].x), static_cast<short int>(reply.desktop_viewport[n].y)});
+bool supports(xcb_atom_t atom, int screen) {
+  auto& conn = initialize();
+  xcb_ewmh_get_atoms_reply_t reply{};
+  if (xcb_ewmh_get_supported_reply(conn, xcb_ewmh_get_supported(conn, screen), &reply, nullptr)) {
+    for (size_t n = 0; n < reply.atoms_len; n++) {
+      if (reply.atoms[n] == atom) {
+        xcb_ewmh_get_atoms_reply_wipe(&reply);
+        return true;
       }
     }
-    return viewports;
+    xcb_ewmh_get_atoms_reply_wipe(&reply);
   }
+  return false;
+}
 
-  vector<string> get_desktop_names(int screen) {
-    auto& conn = initialize();
-    xcb_ewmh_get_utf8_strings_reply_t reply{};
-    if (xcb_ewmh_get_desktop_names_reply(conn, xcb_ewmh_get_desktop_names(conn, screen), &reply, nullptr)) {
-      return string_util::split(string(reply.strings, reply.strings_len), '\0');
+string get_wm_name(xcb_window_t win) {
+  auto& conn = initialize();
+  xcb_ewmh_get_utf8_strings_reply_t utf8_reply{};
+  if (xcb_ewmh_get_wm_name_reply(conn, xcb_ewmh_get_wm_name(conn, win), &utf8_reply, nullptr)) {
+    return get_reply_string(&utf8_reply);
+  }
+  return "";
+}
+
+string get_visible_name(xcb_window_t win) {
+  auto& conn = initialize();
+  xcb_ewmh_get_utf8_strings_reply_t utf8_reply{};
+  if (xcb_ewmh_get_wm_visible_name_reply(conn, xcb_ewmh_get_wm_visible_name(conn, win), &utf8_reply, nullptr)) {
+    return get_reply_string(&utf8_reply);
+  }
+  return "";
+}
+
+string get_icon_name(xcb_window_t win) {
+  auto& conn = initialize();
+  xcb_ewmh_get_utf8_strings_reply_t utf8_reply{};
+  if (xcb_ewmh_get_wm_icon_name_reply(conn, xcb_ewmh_get_wm_icon_name(conn, win), &utf8_reply, nullptr)) {
+    return get_reply_string(&utf8_reply);
+  }
+  return "";
+}
+
+string get_reply_string(xcb_ewmh_get_utf8_strings_reply_t* reply) {
+  string str;
+  if (reply) {
+    str = string(reply->strings, reply->strings_len);
+    xcb_ewmh_get_utf8_strings_reply_wipe(reply);
+  }
+  return str;
+}
+
+unsigned int get_current_desktop(int screen) {
+  auto& conn = initialize();
+  unsigned int desktop = XCB_NONE;
+  xcb_ewmh_get_current_desktop_reply(conn, xcb_ewmh_get_current_desktop(conn, screen), &desktop, nullptr);
+  return desktop;
+}
+
+unsigned int get_number_of_desktops(int screen) {
+  auto& conn = initialize();
+  unsigned int desktops = XCB_NONE;
+  xcb_ewmh_get_number_of_desktops_reply(conn, xcb_ewmh_get_number_of_desktops(conn, screen), &desktops, nullptr);
+  return desktops;
+}
+
+vector<position> get_desktop_viewports(int screen) {
+  auto& conn = initialize();
+  vector<position> viewports;
+  xcb_ewmh_get_desktop_viewport_reply_t reply{};
+  if (xcb_ewmh_get_desktop_viewport_reply(conn, xcb_ewmh_get_desktop_viewport(conn, screen), &reply, nullptr)) {
+    for (size_t n = 0; n < reply.desktop_viewport_len; n++) {
+      viewports.emplace_back(position{
+          static_cast<short int>(reply.desktop_viewport[n].x), static_cast<short int>(reply.desktop_viewport[n].y)});
     }
-    return {};
+  }
+  return viewports;
+}
+
+vector<string> get_desktop_names(int screen) {
+  auto& conn = initialize();
+  xcb_ewmh_get_utf8_strings_reply_t reply{};
+  if (xcb_ewmh_get_desktop_names_reply(conn, xcb_ewmh_get_desktop_names(conn, screen), &reply, nullptr)) {
+    return string_util::split(string(reply.strings, reply.strings_len), '\0');
+  }
+  return {};
+}
+
+xcb_window_t get_active_window(int screen) {
+  auto& conn = initialize();
+  unsigned int win = XCB_NONE;
+  xcb_ewmh_get_active_window_reply(conn, xcb_ewmh_get_active_window(conn, screen), &win, nullptr);
+  return win;
+}
+
+void change_current_desktop(unsigned int desktop) {
+  auto& conn = initialize();
+  xcb_ewmh_request_change_current_desktop(conn, 0, desktop, XCB_CURRENT_TIME);
+  xcb_flush(conn->connection);
+}
+
+unsigned int get_desktop_from_window(xcb_window_t window) {
+  auto& conn = initialize();
+  unsigned int desktop = XCB_NONE;
+  xcb_ewmh_get_wm_desktop_reply(conn, xcb_ewmh_get_wm_desktop(conn, window), &desktop, nullptr);
+  return desktop;
+}
+
+void set_wm_window_type(xcb_window_t win, vector<xcb_atom_t> types) {
+  auto& conn = initialize();
+  xcb_ewmh_set_wm_window_type(conn, win, types.size(), types.data());
+  xcb_flush(conn->connection);
+}
+
+void set_wm_state(xcb_window_t win, vector<xcb_atom_t> states) {
+  auto& conn = initialize();
+  xcb_ewmh_set_wm_state(conn, win, states.size(), states.data());
+  xcb_flush(conn->connection);
+}
+
+vector<xcb_atom_t> get_wm_state(xcb_window_t win) {
+  auto& conn = initialize();
+  xcb_ewmh_get_atoms_reply_t reply;
+  if (xcb_ewmh_get_wm_state_reply(conn, xcb_ewmh_get_wm_state(conn, win), &reply, nullptr)) {
+    return {reply.atoms, reply.atoms + reply.atoms_len};
+  }
+  return {};
+}
+
+void set_wm_pid(xcb_window_t win) {
+  auto& conn = initialize();
+  xcb_ewmh_set_wm_pid(conn, win, getpid());
+  xcb_flush(conn->connection);
+}
+
+void set_wm_pid(xcb_window_t win, unsigned int pid) {
+  auto& conn = initialize();
+  xcb_ewmh_set_wm_pid(conn, win, pid);
+  xcb_flush(conn->connection);
+}
+
+void set_wm_desktop(xcb_window_t win, unsigned int desktop) {
+  auto& conn = initialize();
+  xcb_ewmh_set_wm_desktop(conn, win, desktop);
+  xcb_flush(conn->connection);
+}
+
+void set_wm_window_opacity(xcb_window_t win, unsigned long int values) {
+  auto& conn = initialize();
+  xcb_change_property(
+      conn->connection, XCB_PROP_MODE_REPLACE, win, _NET_WM_WINDOW_OPACITY, XCB_ATOM_CARDINAL, 32, 1, &values);
+  xcb_flush(conn->connection);
+}
+
+vector<xcb_window_t> get_client_list(int screen) {
+  auto& conn = initialize();
+  xcb_ewmh_get_windows_reply_t reply;
+  if (xcb_ewmh_get_client_list_reply(conn, xcb_ewmh_get_client_list(conn, screen), &reply, nullptr)) {
+    return {reply.windows, reply.windows + reply.windows_len};
+  }
+  return {};
+}
+
+/**
+ * Retrieves the _NET_SUPPORTING_WM_CHECK atom on the given window
+ *
+ * @return The _NET_SUPPORTING_WM_CHECK window id or XCB_NONE in case of an error
+ */
+xcb_window_t get_supporting_wm_check(xcb_window_t win) {
+  auto& conn = initialize();
+  xcb_window_t result{};
+  if (xcb_ewmh_get_supporting_wm_check_reply(conn, xcb_ewmh_get_supporting_wm_check(conn, win), &result, nullptr)) {
+    return result;
+  }
+  return XCB_NONE;
+}
+
+/**
+ * Searches for the meta window spawned by the WM to indicate a compliant WM is active.
+ *
+ * The window has the following properties:
+ * * It's pointed to by the root window's _NET_SUPPORTING_WM_CHECK atom
+ * * Its own _NET_SUPPORTING_WM_CHECK atom is set and points to itself
+ *
+ * @return The meta window id or XCB_NONE if it wasn't found
+ */
+xcb_window_t get_ewmh_meta_window(xcb_window_t root) {
+  xcb_window_t wm_meta_window = ewmh_util::get_supporting_wm_check(root);
+
+  if (wm_meta_window != XCB_NONE && ewmh_util::get_supporting_wm_check(wm_meta_window) == wm_meta_window) {
+    return wm_meta_window;
   }
 
-  xcb_window_t get_active_window(int screen) {
-    auto& conn = initialize();
-    unsigned int win = XCB_NONE;
-    xcb_ewmh_get_active_window_reply(conn, xcb_ewmh_get_active_window(conn, screen), &win, nullptr);
-    return win;
-  }
-
-  void change_current_desktop(unsigned int desktop) {
-    auto& conn = initialize();
-    xcb_ewmh_request_change_current_desktop(conn, 0, desktop, XCB_CURRENT_TIME);
-    xcb_flush(conn->connection);
-  }
-
-  unsigned int get_desktop_from_window(xcb_window_t window) {
-    auto& conn = initialize();
-    unsigned int desktop = XCB_NONE;
-    xcb_ewmh_get_wm_desktop_reply(conn, xcb_ewmh_get_wm_desktop(conn, window), &desktop, nullptr);
-    return desktop;
-  }
-
-  void set_wm_window_type(xcb_window_t win, vector<xcb_atom_t> types) {
-    auto& conn = initialize();
-    xcb_ewmh_set_wm_window_type(conn, win, types.size(), types.data());
-    xcb_flush(conn->connection);
-  }
-
-  void set_wm_state(xcb_window_t win, vector<xcb_atom_t> states) {
-    auto& conn = initialize();
-    xcb_ewmh_set_wm_state(conn, win, states.size(), states.data());
-    xcb_flush(conn->connection);
-  }
-
-  vector<xcb_atom_t> get_wm_state(xcb_window_t win) {
-    auto& conn = initialize();
-    xcb_ewmh_get_atoms_reply_t reply;
-    if (xcb_ewmh_get_wm_state_reply(conn, xcb_ewmh_get_wm_state(conn, win), &reply, nullptr)) {
-      return {reply.atoms, reply.atoms + reply.atoms_len};
-    }
-    return {};
-  }
-
-  void set_wm_pid(xcb_window_t win) {
-    auto& conn = initialize();
-    xcb_ewmh_set_wm_pid(conn, win, getpid());
-    xcb_flush(conn->connection);
-  }
-
-  void set_wm_pid(xcb_window_t win, unsigned int pid) {
-    auto& conn = initialize();
-    xcb_ewmh_set_wm_pid(conn, win, pid);
-    xcb_flush(conn->connection);
-  }
-
-  void set_wm_desktop(xcb_window_t win, unsigned int desktop) {
-    auto& conn = initialize();
-    xcb_ewmh_set_wm_desktop(conn, win, desktop);
-    xcb_flush(conn->connection);
-  }
-
-  void set_wm_window_opacity(xcb_window_t win, unsigned long int values) {
-    auto& conn = initialize();
-    xcb_change_property(
-        conn->connection, XCB_PROP_MODE_REPLACE, win, _NET_WM_WINDOW_OPACITY, XCB_ATOM_CARDINAL, 32, 1, &values);
-    xcb_flush(conn->connection);
-  }
-
-  vector<xcb_window_t> get_client_list(int screen) {
-    auto& conn = initialize();
-    xcb_ewmh_get_windows_reply_t reply;
-    if (xcb_ewmh_get_client_list_reply(conn, xcb_ewmh_get_client_list(conn, screen), &reply, nullptr)) {
-      return {reply.windows, reply.windows + reply.windows_len};
-    }
-    return {};
-  }
+  return XCB_NONE;
+}
 } // namespace ewmh_util
 
 POLYBAR_NS_END


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [x] Refactor
* [x] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Refactors the restacking algorithms and adds new ones.

The restacking algorithms now only have to provide the sibling window and stacking mode.

**New strategies**

* `ewmh`: Tries to put the bar window above the _NET_SUPPORTING_WM_CHECK window
* `bottom`: Puts the bar window at the bottom of the window stack (same as the old generic strategy)

The generic strategy is now a best effort strategy which simply tries out other strategy until it finds a suitable one. Currently it first tries ewmh, then bottom.

Additionally, the `bspwm` strategy also first tries ewmh before falling back to searching for the dedicated root windows for each monitor.

## Related Issues & Documents

Fixes #2873

May also work for #2543

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Add the new strategies as well as the changes to the strategy to the wiki.
Also mention that generic is best-effort, it may change in the future, and all its component strategies are available on their own.