### PR TITLE
fix(tray): check for visibility when docking

### DIFF
--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -423,6 +423,7 @@ void manager::process_docking_request(xcb_window_t win) {
 
     cl->add_to_save_set();
 
+    cl->hidden(m_hidden);
     cl->ensure_state();
 
     cl->notify_xembed();


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Fixes an issue where the tray docking logic does not account for the tray's visibility when docking new clients. 

The fix is relatively simple as it just sets `client->hidden` to the tray's manager's before calling `ensure_state`. 

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Fixes #2968 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
