### PR TITLE
Add `fixed-right` config option

### DIFF
--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -135,6 +135,7 @@ class renderer : public renderer_interface,
   alignment m_align;
 
   bool m_fixedcenter;
+  bool m_fixedright;
   string m_snapshot_dst;
 };
 

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -156,6 +156,7 @@ renderer::renderer(connection& conn, signal_emitter& sig, const config& conf, co
   m_comp_border = m_conf.get<cairo_operator_t>("settings", "compositing-border", m_comp_border);
 
   m_fixedcenter = m_conf.get(m_conf.section(), "fixed-center", true);
+  m_fixedright = m_conf.get(m_conf.section(), "fixed-right", false);
 }
 
 /**
@@ -458,10 +459,14 @@ double renderer::block_x(alignment a) const {
       }
 
       // The minimum x position this block can start at
-      double min_pos = block_x(left_barrier) + block_w(left_barrier);
+      double min_pos{0.0};
 
-      if (block_w(left_barrier) != 0) {
-        min_pos += BLOCK_GAP;
+      if (!m_fixedright) {
+        min_pos = block_x(left_barrier) + block_w(left_barrier);
+
+        if (block_w(left_barrier) != 0) {
+          min_pos += BLOCK_GAP;
+        }
       }
 
       return std::max(m_rect.width - block_w(a), min_pos);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
### Changes
This patch adds a new config option (namely `fixed-right`). Enabling this option changes the default behavior for the alignment of  `modules-right` in certain cases.

### Motivation
In my personal config, I use the `xwindow` module, normally there is no problem with this:
![2023-06-25_20-40](https://github.com/polybar/polybar/assets/59585724/53544499-9738-427b-872c-651af91cea04)

However, if either the left or center modules take up too much space (this is not specific to `xwindow`, but in general), the right modules are pushed off the screen.

With `fixed-right = false` (current bevahior):
![2023-06-25_20-41](https://github.com/polybar/polybar/assets/59585724/24d85fd8-14b0-44d1-9118-e3201d61a586)

With `fixed-right = true`:
![2023-06-25_20-41_1](https://github.com/polybar/polybar/assets/59585724/66afb078-a451-41cf-b88c-dd45a9a2eb64)

This patch is useful for my personal config, so I figured it might be useful for others as well. Feedback is appreciated.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

I couldn't find any open issues related to this.

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)

Add a description for the new `fixed-right` option in the [Bar settings](https://github.com/polybar/polybar/wiki/Configuration#bar-settings) section.

* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).

Potentially a changelog entry.

* [ ] Does not require documentation changes
