### PR TITLE
xworkspaces: Add enable-wraparound option

### DIFF
--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -105,6 +105,7 @@ namespace modules {
     bool m_click{true};
     bool m_scroll{true};
     bool m_revscroll{false};
+    bool m_wraparound{true};
     size_t m_index{0};
   };
 } // namespace modules

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -40,6 +40,7 @@ namespace modules {
     m_click = m_conf.get(name(), "enable-click", m_click);
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
+    m_wraparound = m_conf.get(name(), "enable-wraparound", m_wraparound);
 
     // Add formats and elements
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, {TAG_LABEL_STATE, TAG_LABEL_MONITOR});
@@ -426,8 +427,13 @@ namespace modules {
 
     int offset = next ? 1 : -1;
 
-    int new_index = (current_index + offset + indices.size()) % indices.size();
-    focus_desktop(indices.at(new_index));
+    int new_index = current_index + offset;
+
+    if (m_wraparound) {
+      focus_desktop(indices.at((new_index + indices.size()) % indices.size()));
+    } else if (new_index >= 0 && new_index < indices.size()) {
+      focus_desktop(indices.at(new_index));
+    }
   }
 
   void xworkspaces_module::focus_desktop(unsigned new_desktop) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

This adds the option to enable (default, current behavior) or disable the wraparound happening when scrolling the workspaces indicator (for example: scrolling after the last workspace moves you to the first workspace). I think this is a good option to have to cover different preferences, and it helps addressing the points in https://github.com/polybar/polybar/discussions/2925 (the scroll precision is a different issue to discuss). This has been tested with the three possible options (default, true, false) on a single monitor.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Well described in https://github.com/polybar/polybar/discussions/2925.

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (configuration option for [xworkspaces module](https://github.com/polybar/polybar/wiki/Module:-xworkspaces))
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
