### PR TITLE
feat(network): Add option to change network unit type

### DIFF
--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -88,15 +88,15 @@ namespace net {
     string ip() const;
     string ip6() const;
     string mac() const;
-    string downspeed(int minwidth = 3, const string& unit = "B/s") const;
-    string upspeed(int minwidth = 3, const string& unit = "B/s") const;
-    string netspeed(int minwidth = 3, const string& unit = "B/s") const;
+    string downspeed(int minwidth = 3, const string& unit = "B/s", bool metric_units = false) const;
+    string upspeed(int minwidth = 3, const string& unit = "B/s", bool metric_units = false) const;
+    string netspeed(int minwidth = 3, const string& unit = "B/s", bool metric_units = false) const;
     void set_unknown_up(bool unknown = true);
 
    protected:
     void check_tuntap_or_bridge();
     bool test_interface() const;
-    string format_speedrate(float bytes_diff, int minwidth, const string& unit) const;
+    string format_speedrate(float bytes_diff, int minwidth, const string& unit, bool metric_units) const;
     void query_ip6();
 
     const logger& m_log;

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -55,6 +55,7 @@ namespace modules {
     int m_udspeed_minwidth{0};
     bool m_accumulate{false};
     bool m_unknown_up{false};
+    bool m_metric_units{true};
     string m_udspeed_unit{"B/s"};
   };
 }  // namespace modules

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -262,26 +262,26 @@ namespace net {
   /**
    * Get download speed rate
    */
-  string network::downspeed(int minwidth, const string& unit) const {
+  string network::downspeed(int minwidth, const string& unit, bool metric_units) const {
     float bytes_diff = m_status.current.received - m_status.previous.received;
-    return format_speedrate(bytes_diff, minwidth, unit);
+    return format_speedrate(bytes_diff, minwidth, unit, metric_units);
   }
 
   /**
    * Get upload speed rate
    */
-  string network::upspeed(int minwidth, const string& unit) const {
+  string network::upspeed(int minwidth, const string& unit, bool metric_units) const {
     float bytes_diff = m_status.current.transmitted - m_status.previous.transmitted;
-    return format_speedrate(bytes_diff, minwidth, unit);
+    return format_speedrate(bytes_diff, minwidth, unit, metric_units);
   }
 
   /**
    * Get total net speed rate
    */
-  string network::netspeed(int minwidth, const string& unit) const {
+  string network::netspeed(int minwidth, const string& unit, bool metric_units) const {
     float bytes_diff = m_status.current.received - m_status.previous.received + m_status.current.transmitted -
                        m_status.previous.transmitted;
-    return format_speedrate(bytes_diff, minwidth, unit);
+    return format_speedrate(bytes_diff, minwidth, unit, metric_units);
   }
 
   /**
@@ -341,7 +341,7 @@ namespace net {
   /**
    * Format up- and download speed
    */
-  string network::format_speedrate(float bytes_diff, int minwidth, const string& unit) const {
+  string network::format_speedrate(float bytes_diff, int minwidth, const string& unit, bool metric_units) const {
     // Get time difference in seconds as a float
     const std::chrono::duration<float> duration = m_status.current.time - m_status.previous.time;
     float time_diff = duration.count();
@@ -350,8 +350,9 @@ namespace net {
     vector<pair<string, int>> units{make_pair("G", 2), make_pair("M", 1)};
     string suffix{"K"};
     int precision = 0;
+    int kilo = metric_units ? 1000 : 1024;
 
-    while ((speedrate /= 1000) > 999) {
+    while ((speedrate /= kilo) > kilo - 1) {
       suffix = units.back().first;
       precision = units.back().second;
       units.pop_back();

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -57,6 +57,7 @@ namespace modules {
     m_accumulate = m_conf.get(name(), "accumulate-stats", m_accumulate);
     set_interval(1s);
     m_unknown_up = m_conf.get<bool>(name(), "unknown-as-up", false);
+    m_metric_units = m_conf.get<bool>(name(), "metric-units", m_metric_units);
     m_udspeed_unit = m_conf.get<string>(name(), "speed-unit", m_udspeed_unit);
 
     m_conf.warn_deprecated(name(), "udspeed-minwidth", "%downspeed:min:max% and %upspeed:min:max%");
@@ -146,9 +147,9 @@ namespace modules {
       m_counter = 0;
     }
 
-    auto upspeed = network->upspeed(m_udspeed_minwidth, m_udspeed_unit);
-    auto downspeed = network->downspeed(m_udspeed_minwidth, m_udspeed_unit);
-    auto netspeed = network->netspeed(m_udspeed_minwidth, m_udspeed_unit);
+    auto upspeed = network->upspeed(m_udspeed_minwidth, m_udspeed_unit, m_metric_units);
+    auto downspeed = network->downspeed(m_udspeed_minwidth, m_udspeed_unit, m_metric_units);
+    auto netspeed = network->netspeed(m_udspeed_minwidth, m_udspeed_unit, m_metric_units);
 
     // Update label contents
     const auto replace_tokens = [&](label_t& label) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [X] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
As a continuation of [PR `#2859`](https://github.com/polybar/polybar/pull/2859), an option `metric-units` (`enabled` by default) is added to the `internal/network` module to make it possible to choose whether 1000 or 1024 should be used to divide the network volume.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The documentation update is included in the `feature/network-unit-types` branch of the repository [https://github.com/Cationiz3r/polybar.wiki.git](https://github.com/Cationiz3r/polybar.wiki.git)
