### PR TITLE
Adding options to display filesystem storage size output in a specific unit

### DIFF
--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -98,7 +98,9 @@ string filesize_mib(unsigned long long kibibytes, size_t precision = 0, const st
 string filesize_gib(unsigned long long kibibytes, size_t precision = 0, const string& locale = "");
 string filesize_gib_mib(
     unsigned long long kibibytes, size_t precision_mib = 0, size_t precision_gib = 0, const string& locale = "");
-string filesize(unsigned long long kbytes, size_t precision = 0, bool fixed = false, const string& locale = "");
+string filesize(unsigned long long bytes, size_t precision = 0, bool fixed = false, const string& locale = "");
+string filesize_specific(
+    unsigned long long bytes, char target, size_t precision = 0, bool fixed = false, const string& locale = "");
 
 hash_type hash(const string& src);
 } // namespace string_util

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -188,6 +188,14 @@ namespace modules {
           "%total%", string_util::filesize(mount->bytes_total, m_fixed ? 2 : 0, m_fixed, m_bar.locale));
       label->replace_token("%free%", string_util::filesize(mount->bytes_avail, m_fixed ? 2 : 0, m_fixed, m_bar.locale));
       label->replace_token("%used%", string_util::filesize(mount->bytes_used, m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%kb_free%", string_util::filesize_specific(mount->bytes_avail, 'k', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%kb_used%", string_util::filesize_specific(mount->bytes_used, 'k', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%mb_free%", string_util::filesize_specific(mount->bytes_avail, 'm', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%mb_used%", string_util::filesize_specific(mount->bytes_used, 'm', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%gb_free%", string_util::filesize_specific(mount->bytes_avail, 'g', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%gb_used%", string_util::filesize_specific(mount->bytes_used, 'g', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%tb_free%", string_util::filesize_specific(mount->bytes_avail, 't', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
+      label->replace_token("%tb_used%", string_util::filesize_specific(mount->bytes_used, 't', m_fixed ? 2 : 0, m_fixed, m_bar.locale));
     };
 
     if (tag == TAG_BAR_FREE) {

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <sstream>
 #include <utility>
+#include <math.h>
 
 POLYBAR_NS
 
@@ -450,6 +451,33 @@ string filesize(unsigned long long bytes, size_t precision, bool fixed, const st
     value /= 1024.0;
   }
   return floating_point(value, precision, fixed, locale) + " " + suffix;
+}
+
+/**
+ * Create a filesize string with a specific target unit
+ */
+string filesize_specific(unsigned long long bytes, char target, size_t precision, bool fixed, const string& locale) {
+  double value = bytes;
+  switch(target) {
+    case 'k':
+      value /= 1024.0;
+      return floating_point(value, precision, fixed, locale) + " KB";
+      break;
+    case 'm':
+      value /= pow(1024.0, 2);
+      return floating_point(value, precision, fixed, locale) + " MB";
+      break;
+    case 'g':
+      value /= pow(1024.0, 3);
+      return floating_point(value, precision, fixed, locale) + " GB";
+      break;
+    case 't':
+      value /= pow(1024.0, 4);
+      return floating_point(value, precision, fixed, locale) + " TB";
+      break;
+    default:
+      return floating_point(value, precision, fixed, locale) + " B";
+  }
 }
 
 /**

--- a/tests/unit_tests/utils/string.cpp
+++ b/tests/unit_tests/utils/string.cpp
@@ -172,6 +172,8 @@ TEST(String, filesize) {
   EXPECT_EQ("3 MB", string_util::filesize(3 * 1024 * 1024));
   EXPECT_EQ("3 GB", string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024));
   EXPECT_EQ("3 TB", string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024 * 1024));
+  EXPECT_EQ("3 TB", string_util::filesize_specific((unsigned long long)3 * 1024 * 1024 * 1024 * 1024, 't'));
+  EXPECT_EQ("3 GB", string_util::filesize_specific((unsigned long long)3 * 1024 * 1024 * 1024, 'g'));
 }
 
 // utf8_to_ucs4 {{{


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
This adds new formatting options to the filesystem which allow the user to force the displayed storage amount in to be in a specific unit, that does not change depending on amount available. For example the user could specify gb_free and the output would always be in Gigabytes, even when over 1000 or under 1.

While it is inconsistent with how storage device manufacturers market their products, I use the system that each unit is 1024 of the unit immediately smaller than it rather than 1000, to be consistent with existing code.
-->

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The new options would need adding to the wiki