### PR TITLE
alsa: include asoundlib.h instead of all alsa headers

### DIFF
--- a/include/adapters/alsa/generic.hpp
+++ b/include/adapters/alsa/generic.hpp
@@ -1,46 +1,6 @@
 #pragma once
 
-#ifdef USE_ALSALIB_H
 #include <alsa/asoundlib.h>
-#else
-#include <assert.h>
-
-#ifndef __FreeBSD__
-#include <endian.h>
-#endif
-
-#include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <poll.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#ifndef __GNUC__
-#define __inline__ inline
-#endif
-
-#include <alsa/asoundef.h>
-#include <alsa/version.h>
-#include <alsa/global.h>
-#include <alsa/input.h>
-#include <alsa/output.h>
-#include <alsa/error.h>
-#include <alsa/conf.h>
-#include <alsa/pcm.h>
-#include <alsa/rawmidi.h>
-#include <alsa/timer.h>
-#include <alsa/hwdep.h>
-#include <alsa/control.h>
-#include <alsa/mixer.h>
-#include <alsa/seq_event.h>
-#include <alsa/seq.h>
-#include <alsa/seqmid.h>
-#include <alsa/seq_midi_event.h>
-#endif
 
 #include "common.hpp"
 #include "settings.hpp"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: Build fix

## Description
In alsa 1.2.10, the `alsa/control.h` header cannot be included on its own because it does not include all symbols it uses.

We are basically duplicating asoundlib.h anyway and there is even a macro variable to switch to it.

## Related Issues & Documents
Ref: #3009
Ref: https://github.com/alsa-project/alsa-lib/issues/348

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
