### PR TITLE
fix(bspwm): Restack against topmost root window.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed fuzzy match option on i3 and bspwm modules to find longest match instead of the first match ([`#2831`](https://github.com/polybar/polybar/pull/2831), [`#2829`](https://github.com/polybar/polybar/issues/2829)) by [@Ron0Studios](https://github.com/ron0studios/).
 - `wm-restack`
   - `generic`: Is now a best effort combination of other restacking strategies. First tries `ewmh` and then the `bottom` strategy ([`#2961`](https://github.com/polybar/polybar/pull/2961))
-  - `bspwm`: First tries the `ewmh` strategy before falling back to its old behavior ([`#2961`](https://github.com/polybar/polybar/pull/2961))
+  - `bspwm`: Will restack above the topmost bspwm root window instead of the root window associated with the monitor polybar is on ([`#3019`](https://github.com/polybar/polybar/pull/3019))
 
 ### Fixed
 - Waiting for double click interval on modules that don't have a double click action ([`#2663`](https://github.com/polybar/polybar/issues/2663), [`#2695`](https://github.com/polybar/polybar/pull/2695))

--- a/include/utils/bspwm.hpp
+++ b/include/utils/bspwm.hpp
@@ -1,38 +1,30 @@
 #pragma once
 
-#include <xcb/xcb.h>
-#include <xcb/xcb_icccm.h>
-
 #include "common.hpp"
-#include "settings.hpp"
 #include "utils/restack.hpp"
 #include "utils/socket.hpp"
-#include "utils/string.hpp"
-#include "x11/extensions/randr.hpp"
-#include "x11/window.hpp"
 
 POLYBAR_NS
 
 class connection;
 
 namespace bspwm_util {
-  struct payload;
-  using connection_t = unique_ptr<socket_util::unix_connection>;
-  using payload_t = unique_ptr<payload>;
+using connection_t = unique_ptr<socket_util::unix_connection>;
 
-  struct payload {
-    char data[BUFSIZ]{'\0'};
-    size_t len = 0;
-  };
+struct payload {
+  char data[BUFSIZ]{'\0'};
+  size_t len = 0;
+};
 
-  vector<xcb_window_t> root_windows(connection& conn);
-  restack_util::params get_restack_params(connection& conn, const monitor_t& mon, xcb_window_t bar_window);
+using payload_t = unique_ptr<payload>;
 
-  string get_socket_path();
+restack_util::params get_restack_params(connection& conn);
 
-  payload_t make_payload(const string& cmd);
-  connection_t make_connection();
-  connection_t make_subscriber();
-}
+string get_socket_path();
+
+payload_t make_payload(const string& cmd);
+connection_t make_connection();
+connection_t make_subscriber();
+} // namespace bspwm_util
 
 POLYBAR_NS_END

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -506,7 +506,7 @@ void bar::restack_window() {
   } else if (wm_restack == "bottom") {
     restack_params = restack_util::get_bottom_params(m_connection, bar_window);
   } else if (wm_restack == "bspwm") {
-    restack_params = bspwm_util::get_restack_params(m_connection, m_opts.monitor, bar_window);
+    restack_params = bspwm_util::get_restack_params(m_connection);
 #if ENABLE_I3
   } else if (wm_restack == "i3" && m_opts.override_redirect) {
     restack_params = i3_util::get_restack_params(m_connection);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
The ewmh strategy has to be dropped because the
`_NET_SUPPORTING_WM_CHECK` window may (at least in bspwm) appear anywhere in the window stack.

To fix the overlapping monitors issue in #2873, we simply restack against the topmost of these root windows.

## Related Issues & Documents

Fixes #2972
Fixes #2873 (again)

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The `bspwm` strategy documentation has to be revised slightly.