### PR TITLE
doc: Bump sphinx-rtd-theme to version 2

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,6 +2,6 @@
 # locally works as long as sphinx is installed.
 # For local development, you may want to install some of these though.
 sphinx~=7.2.6
-sphinx-rtd-theme~=1.3.0
+sphinx-rtd-theme~=2.0.0rc2
 sphinx-notfound-page~=1.0.0
 readthedocs-sphinx-search~=0.3.1


### PR DESCRIPTION
The notfound plugin (404 page) does not seem to work with older versions of the theme.

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [x] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
