### PR TITLE
Version 3.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
             const fname = '${{ env.POLYBAR_ARCHIVE }}'
             const url = '${{ steps.upload_archive.outputs.browser_download_url }}'
             const hash = '${{ env.SHA256SUM }}'
-            let body = "## Download:\n\n"
+            let body = "## Download\n\n"
             body += `[${fname}](${url}) (**sha256**: \`${hash}\`)\n\n`
             body += process.env.RELEASE_BODY;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.7.0] - 2023-11-05
 ### Breaking
 - `custom/script`:
-  - now doesn't hide failing script if it's output is not changing ([`#2636`](https://github.com/polybar/polybar/issues/2636)). Somewhat similar behaviour can be imitated with `format-fail`, if necessary.
+  - No longer hides the module if the `exec` command failed and did not change the output from the previous run ([`#2636`](https://github.com/polybar/polybar/issues/2636)). Somewhat similar original behaviour can be imitated with `format-fail`, if necessary.
   - If the `exec` command produced no output and exited with a non-zero exit code the module is no longer completely empty, but just has an empty `%output%` token. If you relied on this behavior to hide the module under certain circumstances, make sure the script exits with an exit code of zero. ([`#2857`](https://github.com/polybar/polybar/discussions/2857), [`#2861`](https://github.com/polybar/polybar/pull/2861))
 
 ### Build
@@ -25,12 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `tray-position`, `tray-detached`, `tray-maxsize`, `tray-scale`, `tray-transparent`, `tray-background`, `tray-foreground`, `tray-padding`, `tray-offset-x`, `tray-offset-y`
 
 ### Added
-- A tray module with type `internal/tray` for positioning the tray like a module
-- Added support for TAG_LABEL (`<label>`) in ipc module ([`#2841`](https://github.com/polybar/polybar/pull/2841)) by [@madhavpcm](https://github.com/madhavpcm).
-- Added support for format-i for each hook-i defined in ipc module ([`#2775`](https://github.com/polybar/polybar/issues/2775), [`#2810`](https://github.com/polybar/polybar/pull/2810)) by [@madhavpcm](https://github.com/madhavpcm).
-- `internal/temperature`: `%temperature-k%` token displays the temperature in kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))
+- A tray module with type `internal/tray` for positioning the tray like a module ([`#2689`](https://github.com/polybar/polybar/issues/2689))
+- `internal/temperature`: `%temperature-k%` token displays the temperature in degrees Kelvin ([`#2774`](https://github.com/polybar/polybar/discussions/2774), [`#2784`](https://github.com/polybar/polybar/pull/2784))
 - `internal/pulseaudio`: `reverse-scroll` option ([`#2664`](https://github.com/polybar/polybar/pull/2664))
 - `custom/script`: Repeat interval for script failure (`interval-fail`) and `exec-if` (`interval-if`) ([`#943`](https://github.com/polybar/polybar/issues/943), [`#2606`](https://github.com/polybar/polybar/issues/2606), [`#2630`](https://github.com/polybar/polybar/pull/2630))
+- `custom/ipc`:
+  - Added support for `<label>` in `format` ([`#2841`](https://github.com/polybar/polybar/pull/2841)) by [@madhavpcm](https://github.com/madhavpcm).
+  - Added support for `format-i` for each defined `hook-i` ([`#2775`](https://github.com/polybar/polybar/issues/2775), [`#2810`](https://github.com/polybar/polybar/pull/2810)) by [@madhavpcm](https://github.com/madhavpcm).
 - `custom/text`: Loads the `format` setting, which supports the `<label>` tag, if the deprecated `content` is not defined ([`#1331`](https://github.com/polybar/polybar/issues/1331), [`#2673`](https://github.com/polybar/polybar/pull/2673), [`#2676`](https://github.com/polybar/polybar/pull/2676))
 - `internal/backlight`:
   - `scroll-interval` option ([`#2696`](https://github.com/polybar/polybar/issues/2696), [`#2700`](https://github.com/polybar/polybar/pull/2700))
@@ -244,7 +247,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Empty color values are no longer treated as invalid and no longer produce an error.
 
-[Unreleased]: https://github.com/polybar/polybar/compare/3.6.3...HEAD
+[Unreleased]: https://github.com/polybar/polybar/compare/3.7.0...HEAD
+[3.7.0]: https://github.com/polybar/polybar/releases/tag/3.7.0
 [3.6.3]: https://github.com/polybar/polybar/releases/tag/3.6.3
 [3.6.2]: https://github.com/polybar/polybar/releases/tag/3.6.2
 [3.6.1]: https://github.com/polybar/polybar/releases/tag/3.6.1

--- a/doc/dev/release-workflow.rst
+++ b/doc/dev/release-workflow.rst
@@ -113,12 +113,12 @@ as follows:
 * A `Release PR`_ is created for the release. This PR MUST NOT be merged in
   GitHub's interface, it is only here for review, merging happens at the
   commandline.
-* After approval, a signed git tag is created locally at the tip of the release
-  branch and pushed:
+* After approval, a signed git tag without message is created locally at the
+  tip of the release branch and pushed:
 
 .. code-block:: shell
 
-  git tag -s X.Y.Z <release-branch>
+  git tag -m "" -s X.Y.Z <release-branch>
   git push --tags
 
 * A `draft release`_ targetting the new tag is created in GitHub's release

--- a/doc/dev/release-workflow.rst
+++ b/doc/dev/release-workflow.rst
@@ -209,6 +209,9 @@ In addition using GitHub's "Auto-generate release notes" feature, the list of
 new contributors should be generated and put at the end of the release notes.
 The generated list of PRs can be removed.
 
+At the bottom, check the two boxes "Set as the latest release" and "Create a
+discussion for this release" (select the category "Announcements").
+
 After-Release Checklist
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/dev/release-workflow.rst
+++ b/doc/dev/release-workflow.rst
@@ -90,8 +90,8 @@ branch and cherry-picks the bugfix commits.
 
   Alternatively, the contributor can also ``git rebase --onto`` to base the
   branch off the previous release tag. However, in most cases it makes sense for
-  a maintainer to create the release branch since they will also need to add a
-  `Release Commit`_ to it.
+  a maintainer to create the release branch since they will also need to create
+  a `Release PR`_ for it.
 
 Once the release branch is created and contains the right commits, the
 maintainer should follow `Publishing a new Release`_ to finish this patch
@@ -110,8 +110,7 @@ Publishing a new Release
 The process for publishing a release is the same for all release types. It goes
 as follows:
 
-* A `Release commit`_ is added to the tip of the release branch.
-* A draft PR is opened for the release branch. This PR MUST NOT be merged in
+* A `Release PR`_ is created for the release. This PR MUST NOT be merged in
   GitHub's interface, it is only here for review, merging happens at the
   commandline.
 * After approval, a signed git tag is created locally at the tip of the release
@@ -143,16 +142,23 @@ as follows:
 Here ``<release-branch>`` is either a ``release/X.Y.0`` branch or a
 ``hotfix/X.Y.Z`` branch.
 
-Release Commit
-~~~~~~~~~~~~~~
+Release PR
+~~~~~~~~~~
 
-When merging, a release commit must be at the tip of the release branch.
+The final state of the release branch is prepared as a draft PR on
+GitHub.
+That PR is not merged from the GitHub interface though.
 
-The release commit needs to update the version number in:
+The release PR must do the following things:
 
-* ``version.txt``
+* Write any missing migration guides for:
 
-The release commit must also finalize the `Changelog`_ for this release.
+  * Deprecated or removed options
+  * New features that it might be worth migrating to
+* Have a release commit at its tip with the message ``Version X.Y.Z`` and the following changes
+
+  * Finalizes the `Changelog`_ for this release
+  * Updates the version number in ``version.txt``
 
 Changelog
 ~~~~~~~~~
@@ -209,6 +215,13 @@ In addition using GitHub's "Auto-generate release notes" feature, the list of
 new contributors should be generated and put at the end of the release notes.
 The generated list of PRs can be removed.
 
+For minor and major releases, add a link to the migration guide directly under
+the ``## Changelog`` header:
+
+.. code-block:: markdown
+
+  **[Migration Guide](https://polybar.readthedocs.io/en/stable/migration/X.Y/index.html)**
+
 At the bottom, check the two boxes "Set as the latest release" and "Create a
 discussion for this release" (select the category "Announcements").
 
@@ -216,9 +229,11 @@ After-Release Checklist
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * Verify the release archive (see `Verify Release`_)
-* Make sure all the new functionality is documented on the wiki
-* Mark deprecated features appropriately (see `Deprecations`_)
-* Remove all unreleased notes from the wiki (not for patch releases)
+* Update the Wiki
+
+  * Make sure all the new functionality is documented
+  * Mark deprecated features appropriately (see `Deprecations`_)
+  * Remove all "unreleased" notes (not for patch releases)
 * Inform packagers of new release in :issue:`1971`. Mention any dependency
   changes and any changes to the build workflow. Also mention any new files are
   created by the installation.

--- a/doc/migration/3.7/index.rst
+++ b/doc/migration/3.7/index.rst
@@ -1,6 +1,39 @@
 Migrating From Version 3.6 to 3.7
 =================================
 
+Text Module (``custom/text``)
+-----------------------------
+
+Using ``content`` to specify the text of the module is deprecated in favor of
+using the same concepts as all other modules (formats and labels).
+
+For example, the following text module:
+
+.. code-block:: dosini
+
+  [module/text]
+  type = custom/text
+  content = Hello World
+  content-foreground = #ff0000
+
+Should now look like this:
+
+.. code-block:: dosini
+
+  [module/text]
+  type = custom/text
+  label = Hello World
+  label-foreground = #ff0000
+
+Because it is set to its default value, the ``format`` setting can also be
+completely left out.
+
+In general, all properties on ``content`` also apply the same on ``label``
+(e.g. ``background``, ``font``), except for ``offset``,
+``prefix``, ``suffix`` (and their sub-properties).
+Those three properties have to instead be applied to ``format`` (e.g.
+``format-offset``).
+
 System Tray
 -----------
 

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
 # Polybar version information
 # Update this on every release
 # This is used to create the version string if a git repo is not available
-3.6.3
+3.7.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] Other: Release

## Description

See `CHANGELOG.md` for full changelog.

Currently, this release is scheduled for *Sunday November 5th*.

The GitHub release draft is [here](https://github.com/polybar/polybar/releases/edit/untagged-f31abffc40b374a3e92e) (members only)

### Release Checklist

* [x] Update Release Workflow docs for the draft release on GitHub:
    * [x] Select "Set as latest release"
    * [x] Select "Create a discussion for this release" (In "Announcements")
* [x] Remove colon after "Download:" in GitHub release workflow
* [x] Finalize changelog
* [x] Write migration guides
* [x] Write release notes
* [x] Write release blog post
  * https://github.com/polybar/polybar.github.io/pull/48
* [x] Rebase to put release commit at the tip
 
### Post-Release Checklist

* [ ] Verify the release archive 
* [ ] Make sure all the new functionality is documented on the wiki
    * [ ] Collect required changes from all merged PRs
* [ ] Mark deprecated features appropriately
* [ ] Remove all unreleased notes from the wiki 
* [ ] Inform packagers of new release in #1971. Mention any dependency changes and any changes to the build workflow. Also mention any new files are created by the installation.
* [ ] Create a PR that updates the AUR PKGBUILD file for the polybar-git package (push after the release archive is uploaded).
* [ ] Close the GitHub Milestone for the new release and move open issues (if any) to a later release.
* [ ] Activate the version on Read the Docs and deactivate all previous versions for the same minor release (e.g. for 3.5.4, deactivate all other 3.5.X versions).
* [ ] Merge release blog post
* [ ] Post blog on all channels

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

The wiki is updated with all changes (as described in all the PRs for this release):

 - https://github.com/polybar/polybar/pull/2630
 - https://github.com/polybar/polybar/pull/2664
 - https://github.com/polybar/polybar/pull/2676
 - https://github.com/polybar/polybar/pull/2595
 - https://github.com/polybar/polybar/pull/2700
 - https://github.com/polybar/polybar/pull/2705
 - https://github.com/polybar/polybar/pull/2728
 - https://github.com/polybar/polybar/pull/2784
 - https://github.com/polybar/polybar/pull/2752
 - https://github.com/polybar/polybar/pull/2801
 - https://github.com/polybar/polybar/pull/2813
 - https://github.com/polybar/polybar/pull/2830
 - https://github.com/polybar/polybar/pull/2831
 - https://github.com/polybar/polybar/pull/2839
 - https://github.com/polybar/polybar/pull/2810
 - https://github.com/polybar/polybar/pull/2844
 - https://github.com/polybar/polybar/pull/2841
 - https://github.com/polybar/polybar/pull/2861
 - https://github.com/polybar/polybar/pull/2917
 - https://github.com/polybar/polybar/pull/2937
 - https://github.com/polybar/polybar/pull/2961 (see below for bspwm strategy)
     -  https://github.com/polybar/polybar/pull/3019
 - https://github.com/polybar/polybar/pull/3002
 - https://github.com/polybar/polybar/pull/3016
 - https://github.com/polybar/polybar/pull/3028
 - https://github.com/polybar/polybar/pull/2926