### PR TITLE
fix(tray): Allow module to disappear for empty tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `internal/tray`: The module must use the `<tray>` tag (this is the default) ([`#3037`](https://github.com/polybar/polybar/pull/3037))
+
+## Fixed
+- `internal/tray`: Fixed `module-margin` and `separator` being applied to completely empty tray module ([`#3036`](https://github.com/polybar/polybar/issues/3036), [`#3037`](https://github.com/polybar/polybar/pull/3037))
 
 ## [3.7.0] - 2023-11-05
 ### Breaking

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -104,9 +104,6 @@ namespace signals {
     struct tray_pos_change : public detail::value_signal<tray_pos_change, int> {
       using base_type::base_type;
     };
-    struct tray_visibility : public detail::value_signal<tray_visibility, bool> {
-      using base_type::base_type;
-    };
   } // namespace ui_tray
 } // namespace signals
 

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -36,7 +36,6 @@ namespace signals {
   } // namespace ui
   namespace ui_tray {
     struct tray_pos_change;
-    struct tray_visibility;
   } // namespace ui_tray
 } // namespace signals
 

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -189,7 +189,7 @@ namespace modules {
     string get_format() const;
     string get_output();
 
-    void set_visible(bool value);
+    virtual void set_visible(bool value);
 
     void action_module_toggle();
     void action_module_show();

--- a/include/modules/tray.hpp
+++ b/include/modules/tray.hpp
@@ -8,10 +8,20 @@
 
 POLYBAR_NS
 namespace modules {
+/**
+ * Wraps the tray_manager in a module.
+ *
+ * The module produces the `%{Pt}` formatting tag, which is used by the renderer
+ * to place the tray.
+ * The visibility of the tray icons is directly tied to the visibility of the
+ * module.
+ */
 class tray_module : public static_module<tray_module> {
  public:
   explicit tray_module(const bar_settings& bar_settings, string name_, const config&);
   string get_format() const;
+
+  void set_visible(bool value) override;
 
   void start() override;
 

--- a/include/x11/legacy_tray_manager.hpp
+++ b/include/x11/legacy_tray_manager.hpp
@@ -116,14 +116,13 @@ class tray_client {
   unsigned int m_height;
 };
 
-class tray_manager
-    : public xpp::event::sink<evt::expose, evt::visibility_notify, evt::client_message, evt::configure_request,
-          evt::resize_request, evt::selection_clear, evt::property_notify, evt::reparent_notify, evt::destroy_notify,
-          evt::map_notify, evt::unmap_notify>,
-      public signal_receiver<SIGN_PRIORITY_TRAY, signals::ui::visibility_change, signals::ui::dim_window,
-          signals::ui::update_background, signals::ui_tray::tray_pos_change, signals::ui_tray::tray_visibility>,
-      public non_copyable_mixin,
-      public non_movable_mixin {
+class tray_manager : public xpp::event::sink<evt::expose, evt::visibility_notify, evt::client_message,
+                         evt::configure_request, evt::resize_request, evt::selection_clear, evt::property_notify,
+                         evt::reparent_notify, evt::destroy_notify, evt::map_notify, evt::unmap_notify>,
+                     public signal_receiver<SIGN_PRIORITY_TRAY, signals::ui::visibility_change, signals::ui::dim_window,
+                         signals::ui::update_background, signals::ui_tray::tray_pos_change>,
+                     public non_copyable_mixin,
+                     public non_movable_mixin {
  public:
   using make_type = unique_ptr<tray_manager>;
   static make_type make(const bar_settings& settings);
@@ -194,7 +193,6 @@ class tray_manager
   bool on(const signals::ui::dim_window& evt) override;
   bool on(const signals::ui::update_background& evt) override;
   bool on(const signals::ui_tray::tray_pos_change& evt) override;
-  bool on(const signals::ui_tray::tray_visibility& evt) override;
 
  private:
   connection& m_connection;

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -76,13 +76,13 @@ struct tray_settings {
 
 using on_update = std::function<void(void)>;
 
-class manager : public xpp::event::sink<evt::expose, evt::client_message, evt::configure_request, evt::resize_request,
-                    evt::selection_clear, evt::property_notify, evt::reparent_notify, evt::destroy_notify,
-                    evt::map_notify, evt::unmap_notify>,
-                public signal_receiver<SIGN_PRIORITY_TRAY, signals::ui::update_background,
-                    signals::ui_tray::tray_pos_change, signals::ui_tray::tray_visibility>,
-                non_copyable_mixin,
-                non_movable_mixin {
+class manager
+    : public xpp::event::sink<evt::expose, evt::client_message, evt::configure_request, evt::resize_request,
+          evt::selection_clear, evt::property_notify, evt::reparent_notify, evt::destroy_notify, evt::map_notify,
+          evt::unmap_notify>,
+      public signal_receiver<SIGN_PRIORITY_TRAY, signals::ui::update_background, signals::ui_tray::tray_pos_change>,
+      non_copyable_mixin,
+      non_movable_mixin {
  public:
   explicit manager(connection& conn, signal_emitter& emitter, const logger& logger, const bar_settings& bar_opts,
       on_update on_update);
@@ -146,7 +146,6 @@ class manager : public xpp::event::sink<evt::expose, evt::client_message, evt::c
 
   bool on(const signals::ui::update_background& evt) override;
   bool on(const signals::ui_tray::tray_pos_change& evt) override;
-  bool on(const signals::ui_tray::tray_visibility& evt) override;
 
  private:
   connection& m_connection;

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -103,6 +103,8 @@ class manager : public xpp::event::sink<evt::expose, evt::client_message, evt::c
 
   bool is_visible() const;
 
+  bool change_visibility(bool visible);
+
  protected:
   void recalculate_width();
   void reconfigure_clients();
@@ -130,7 +132,6 @@ class manager : public xpp::event::sink<evt::expose, evt::client_message, evt::c
   void remove_client(const client& client);
   void remove_client(xcb_window_t win);
   void clean_clients();
-  bool change_visibility(bool visible);
 
   void handle(const evt::expose& evt) override;
   void handle(const evt::client_message& evt) override;

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -839,13 +839,10 @@ bool renderer::on(const signals::ui::request_snapshot& evt) {
 }
 
 void renderer::apply_tray_position(const tags::context& context) {
-  if (context.get_relative_tray_position() != std::pair<alignment, int>()) {
-    int absolute_x = static_cast<int>(
-        block_x(context.get_relative_tray_position().first) + context.get_relative_tray_position().second);
+  auto [alignment, pos] = context.get_relative_tray_position();
+  if (alignment != alignment::NONE) {
+    int absolute_x = static_cast<int>(block_x(alignment) + pos);
     m_sig.emit(signals::ui_tray::tray_pos_change{absolute_x});
-    m_sig.emit(signals::ui_tray::tray_visibility{true});
-  } else {
-    m_sig.emit(signals::ui_tray::tray_visibility{false});
   }
 }
 

--- a/src/modules/tray.cpp
+++ b/src/modules/tray.cpp
@@ -8,13 +8,30 @@ namespace modules {
   template class module<tray_module>;
 
   tray_module::tray_module(const bar_settings& bar_settings, string name_, const config& config)
-      : static_module<tray_module>(bar_settings, move(name_), config)
+      : static_module<tray_module>(bar_settings, std::move(name_), config)
       , m_tray(connection::make(), signal_emitter::make(), m_log, bar_settings, [&] { this->broadcast(); }) {
     m_formatter->add(DEFAULT_FORMAT, TAG_TRAY, {TAG_TRAY});
+
+    /* There are a bunch of edge cases with regards to tray visiblity when the
+     * <tray> tag is not there (in that case the tray icons should under no
+     * circumnstances appear). To avoid this, we simply disallow the situation.
+     * The module is basically useless without that tag anyway.
+     */
+    if (!m_formatter->has(TAG_TRAY, DEFAULT_FORMAT)) {
+      throw module_error("The " + std::string(TAG_TRAY) + " tag is required in " + name() + "." + DEFAULT_FORMAT);
+    }
+
+    // Otherwise the tray does not see the initial module visibility
+    m_tray.change_visibility(visible());
   }
 
   string tray_module::get_format() const {
     return DEFAULT_FORMAT;
+  }
+
+  void tray_module::set_visible(bool value) {
+    m_tray.change_visibility(value);
+    static_module<tray_module>::set_visible(value);
   }
 
   void tray_module::start() {
@@ -23,12 +40,14 @@ namespace modules {
   }
 
   bool tray_module::build(builder* builder, const string& tag) const {
-    if (tag == TAG_TRAY) {
+    // Don't produce any output if the tray is empty so that the module can be hidden
+    if (tag == TAG_TRAY && m_tray.get_width() > 0) {
       builder->control(tags::controltag::t);
       extent_val offset_extent = {extent_type::PIXEL, static_cast<float>(m_tray.get_width())};
       builder->offset(offset_extent);
       return true;
     }
+
     return false;
   }
 

--- a/src/x11/legacy_tray_manager.cpp
+++ b/src/x11/legacy_tray_manager.cpp
@@ -1172,14 +1172,6 @@ bool tray_manager::on(const signals::ui_tray::tray_pos_change& evt) {
   return true;
 }
 
-bool tray_manager::on(const signals::ui_tray::tray_visibility& evt) {
-  if (evt.cast() == m_hidden && m_opts.tray_position == tray_postition::MODULE) {
-    return change_visibility(evt.cast());
-  } else {
-    return true;
-  }
-}
-
 tray_client::tray_client(connection& conn, xcb_window_t win, unsigned int w, unsigned int h)
     : m_connection(conn), m_window(win), m_width(w), m_height(h) {}
 

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -764,10 +764,6 @@ bool manager::on(const signals::ui_tray::tray_pos_change& evt) {
   return true;
 }
 
-bool manager::on(const signals::ui_tray::tray_visibility& evt) {
-  return change_visibility(evt.cast());
-}
-
 } // namespace tray
 
 POLYBAR_NS_END

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -522,7 +522,7 @@ void manager::clean_clients() {
 }
 
 bool manager::change_visibility(bool visible) {
-  if (!is_active() || m_hidden == !visible) {
+  if (m_hidden == !visible) {
     return false;
   }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Modules that don't produce any output are hidden by the controller (don't have margins or separators).
The tray module should also do that for `format = <tray>` when there are no icons.

This required the visibility handling to be tied to the module visibility instead of being handled by the renderer. Otherwise, the renderer would hide the tray (because the %{Pt} tag was never sent) and the tray would not unhide when new icons appeared; it can't differentiate between hidden because empty and hidden because the module is hidden by the user (the latter is the reason the renderer does hiding at all).

Fixes #3036

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
