### PR TITLE
List `systray` module in the default config file

### DIFF
--- a/doc/config.ini
+++ b/doc/config.ini
@@ -51,7 +51,7 @@ separator-foreground = ${colors.disabled}
 font-0 = monospace;2
 
 modules-left = xworkspaces xwindow
-modules-right = filesystem pulseaudio xkeyboard memory cpu wlan eth date
+modules-right = filesystem pulseaudio xkeyboard memory cpu wlan eth date systray
 
 cursor-click = pointer
 cursor-scroll = ns-resize


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: *Fix of possible unintended behavior (not really a bug)*

## Description

After playing around a little with polybar for the first time (default config), I didn't  quite understand why the tray icons didn't appear. I thought there was a bug in the module, but it just wasn't listed. This PR adds tray icon to the right of the bar in the default config so as to make newcomers happier. 

If for some reason such behavior is actually intended, this PR shall be closed.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
