### PR TITLE
Audio unmute on scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- An option `unmute-on-scroll` for `internal/pulseaudio` and `internal/alsa` to unmute audio when the user scrolls on the widget.
 
 ## [3.7.1] - 2023-11-27
 ### Build

--- a/doc/user/actions.rst
+++ b/doc/user/actions.rst
@@ -153,6 +153,9 @@ internal/alsa
   ``interval`` is the config setting in the module. Volume changed like this
   will never go above 100%.
 
+  if ``unmute-on-scroll`` is turned on, the sound will also be unmuted when
+  this action is called.
+
 :``toggle``:
   Toggles between muted and unmuted.
 
@@ -164,6 +167,9 @@ internal/pulseaudio
   ``interval`` is the config setting in the module. Volume changed like this
   will never go above ~153% (if ``use-ui-max`` is set to ``true``) or 100% (if
   not).
+
+  if ``unmute-on-scroll`` is turned on, the sound will also be unmuted when
+  this action is called.
 
 :``toggle``:
   Toggles between muted and unmuted.

--- a/include/modules/alsa.hpp
+++ b/include/modules/alsa.hpp
@@ -67,6 +67,7 @@ namespace modules {
     map<control, control_t> m_ctrl;
     int m_headphoneid{0};
     bool m_mapped{false};
+    bool m_unmute_on_scroll{false};
     int m_interval{5};
     atomic<bool> m_muted{false};
     atomic<bool> m_headphones{false};

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -51,6 +51,7 @@ namespace modules {
     pulseaudio_t m_pulseaudio;
 
     int m_interval{5};
+    bool m_unmute_on_scroll{false};
     atomic<bool> m_muted{false};
     atomic<int> m_volume{0};
     atomic<double> m_decibels{0};

--- a/src/modules/alsa.cpp
+++ b/src/modules/alsa.cpp
@@ -28,6 +28,7 @@ namespace modules {
     // Load configuration values
     m_mapped = m_conf.get(name(), "mapped", m_mapped);
     m_interval = m_conf.get(name(), "interval", m_interval);
+    m_unmute_on_scroll = m_conf.get(name(), "unmute-on-scroll", m_unmute_on_scroll);
 
     auto master_mixer_name = m_conf.get(name(), "master-mixer", "Master"s);
     auto speaker_mixer_name = m_conf.get(name(), "speaker-mixer", ""s);
@@ -261,6 +262,9 @@ namespace modules {
     }
     const auto& mixers = get_mixers();
     for (auto&& mixer : mixers) {
+      if (m_unmute_on_scroll) {
+        mixer->set_mute(true);
+      }
       m_mapped ? mixer->set_normalized_volume(math_util::cap<float>(mixer->get_normalized_volume() + interval, 0, 100))
                : mixer->set_volume(math_util::cap<float>(mixer->get_volume() + interval, 0, 100));
     }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -23,6 +23,7 @@ namespace modules {
 
     // Load configuration values
     m_interval = m_conf.get(name(), "interval", m_interval);
+    m_unmute_on_scroll = m_conf.get(name(), "unmute-on-scroll", m_unmute_on_scroll);
 
     auto sink_name = m_conf.get(name(), "sink", ""s);
     bool m_max_volume = m_conf.get(name(), "use-ui-max", true);
@@ -156,10 +157,16 @@ namespace modules {
   }
 
   void pulseaudio_module::action_inc() {
+    if (m_unmute_on_scroll) {
+      m_pulseaudio->set_mute(false);
+    }
     m_pulseaudio->inc_volume(m_interval);
   }
 
   void pulseaudio_module::action_dec() {
+    if (m_unmute_on_scroll) {
+      m_pulseaudio->set_mute(false);
+    }
     m_pulseaudio->inc_volume(-m_interval);
   }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Added the option `unmute-on-scroll` to the `alsa` and `pulseaudio` modules. If this option is false (The default) then there is no difference in behaviour from the previous version. If the option is true, when the user uses the scrollwheel on the module, the sound will be unmuted.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Closes #3067

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

It might be worth to mention this as an option in the wiki, so that folks could be aware of it.