### PR TITLE
fix: don't restart if zero active screens are reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- When the `-r` flag is provided, and RandR reports zero connected active screens, Polybar will not restart. This fixes Polybar dying on some laptops when the lid is closed. [`#3078`](https://github.com/polybar/polybar/pull/3078).
+
 ## [3.7.1] - 2023-11-27
 ### Build
 - Fixed missing header when using `libc++` in clang 15 and below

--- a/include/components/screen.hpp
+++ b/include/components/screen.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common.hpp"
 #include "components/types.hpp"
 #include "events/signal_emitter.hpp"
@@ -49,7 +51,7 @@ class screen : public xpp::event::sink<evt::map_notify, evt::randr_screen_change
    */
   uint32_t m_root_mask{0};
 
-  bool have_monitors_changed() const;
+  std::pair<bool, int> have_monitors_changed() const;
 };
 
 POLYBAR_NS_END


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [X] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

On laptops and similar devices, RandR sometimes returns zero active screens, for example when closing a laptop's lid before it suspends.

Don't restart in that case because the new polybar instance will see zero screens and quit. Instead, just ignore those kind of events.


## Related Issues & Documents

Fixes #2418. 

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [X] Does not require documentation changes
