### PR TITLE
Fix backlight initial value matching the actual brightness level

### DIFF
--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -67,7 +67,7 @@ namespace modules {
     brightness_handle m_val;
     brightness_handle m_max;
 
-    int m_percentage = 0;
+    int m_percentage = -1;
 
     chrono::duration<double> m_interval{};
     chrono::steady_clock::time_point m_lastpoll;


### PR DESCRIPTION
The initial value is `0`. If the actual brightness is also `0` you see `%percentage%` token as text, it’s not being replaced. Since `m_brightness` is an `int` the initial value could be just `-1` since the actual brightness is never goes below zero. Thus this bug will never show up again because actual brightness on first render won’t match the “old” `m_brightness` value.

See also for more detailed explanation of the bug: https://github.com/polybar/polybar/discussions/3079#discussioncomment-8169932

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
