### PR TITLE
Fix backlight initial value matching the actual brightness level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `internal/backlight`: Module could display the literal `%percentage%` token if the backlight reports a value of 0 at startup ([`#3081`](https://github.com/polybar/polybar/pull/3081)) by [@unclechu](https://github.com/unclechu)
 
 ## [3.7.1] - 2023-11-27
 ### Build

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -67,7 +67,7 @@ namespace modules {
     brightness_handle m_val;
     brightness_handle m_max;
 
-    int m_percentage = 0;
+    int m_percentage = -1;
 
     chrono::duration<double> m_interval{};
     chrono::steady_clock::time_point m_lastpoll;

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -67,6 +67,11 @@ namespace modules {
     brightness_handle m_val;
     brightness_handle m_max;
 
+    /**
+     * Initial value set to a negative number so that any value read from the backlight file triggers an update during
+     * the first read.
+     * Otherwise, tokens may not be replaced
+     */
     int m_percentage = -1;
 
     chrono::duration<double> m_interval{};


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Applies #3080 to the 3.7.2 hotfix branch. Thanks to @unclechu for fixing this!

## Related Issues & Documents

Closes #3080

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
