### PR TITLE
fix(i3): Properly render non-full-width windows

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,20 +32,15 @@ Checks: '
         '
 
 CheckOptions:
-  - key:             modernize-loop-convert.NamingStyle
-    value:           lower_case
-  - key:             readability-identifier-naming.ClassCase
-    value:           lower_case
-  - key:             readability-identifier-naming.ClassConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.ClassMethodCase
-    value:           lower_case
-  - key:             readability-identifier-naming.MemberCase
-    value:           lower_case
-  - key:             readability-identifier-naming.ProtectedMemberPrefix
-    value:           'm_'
-  - key:             readability-identifier-naming.PrivateMemberPrefix
-    value:           'm_'
+  cppcoreguidelines-avoid-do-while.IgnoreMacros: true
+  modernize-loop-convert.NamingStyle: lower_case
+  readability-identifier-naming.ClassCase: lower_case
+  readability-identifier-naming.ClassConstantCase: UPPER_CASE
+  readability-identifier-naming.ClassMethodCase: lower_case
+  readability-identifier-naming.MemberCase: lower_case
+  readability-identifier-naming.ProtectedMemberPrefix: 'm_'
+  readability-identifier-naming.PrivateMemberPrefix: 'm_'
+
 HeaderFilterRegex: ''
 WarningsAsErrors: ''
 AnalyzeTemporaryDtors: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 -  Token min-length calculations would behave differently when non-ASCII characters appear in the token ([`#3074`](https://github.com/polybar/polybar/issues/3074), [`#3087`](https://github.com/polybar/polybar/pull/3087)) by [@nklloyd](https://github.com/nklloyd)
+-  i3: Fix duplicated rendering for non-full-width bars ([`#3091`](https://github.com/polybar/polybar/pull/3091), [`#3060`](https://github.com/polybar/polybar/issues/3060))
 - `internal/backlight`: Module could display the literal `%percentage%` token if the backlight reports a value of 0 at startup ([`#3081`](https://github.com/polybar/polybar/pull/3081)) by [@unclechu](https://github.com/unclechu)
 
 ## [3.7.1] - 2023-11-27

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -86,14 +86,6 @@ renderer::renderer(connection& conn, signal_emitter& sig, const config& conf, co
   {
     m_pixmap = m_connection.generate_id();
     m_connection.create_pixmap(m_depth, m_pixmap, m_window, m_bar.size.w, m_bar.size.h);
-
-    uint32_t configure_mask = 0;
-    std::array<uint32_t, 32> configure_values{};
-    xcb_params_cw_t configure_params{};
-
-    XCB_AUX_ADD_PARAM(&configure_mask, &configure_params, back_pixmap, m_pixmap);
-    connection::pack_values(configure_mask, &configure_params, configure_values);
-    m_connection.change_window_attributes_checked(m_window, configure_mask, configure_values.data());
   }
 
   m_log.trace("renderer: Allocate graphic contexts");
@@ -372,8 +364,8 @@ void renderer::flush() {
   highlight_clickable_areas();
 
   m_surface->flush();
-  // Clear entire window so that the new pixmap is shown
-  m_connection.clear_area(0, m_window, 0, 0, m_bar.size.w, m_bar.size.h);
+  // Copy pixmap onto the window
+  m_connection.copy_area(m_pixmap, m_window, m_gcontext, 0, 0, 0, 0, m_bar.size.w, m_bar.size.h);
   m_connection.flush();
 
   if (!m_snapshot_dst.empty()) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Without override-redirect, i3 will not allow you to have a non-full-width bar. But polybar simply ignores that request and continues to render the user-requested width instead of the width i3 has configured the window to be.

With the 3.7 release, we started setting the window's backing pixmap to the rendering pixmap. In the case above, the pixmap would only be allocted for the smaller width and when i3 maps the window, it repeats the backing pixmap to fill the entire window.

At the point where i3 maps the window, the pixmap contains an initial render of the bar without module content and that render is then duplicated.

Reverting back to the old approach of simply copying over the pixmap after each render does not have that problem and the remainder of the bar is black (or fully transparent with a compositor).
   
Ideally, polybar would respect the width i3 configures for it, but that
would break many existing setups that rely on non-full-width bars in i3

Fixes #3060

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
