### PR TITLE
feat(audio): Allow label-volume in muted format

### DIFF
--- a/src/modules/alsa.cpp
+++ b/src/modules/alsa.cpp
@@ -77,7 +77,7 @@ namespace modules {
 
     // Add formats and elements
     m_formatter->add(FORMAT_VOLUME, TAG_LABEL_VOLUME, {TAG_RAMP_VOLUME, TAG_LABEL_VOLUME, TAG_BAR_VOLUME});
-    m_formatter->add(FORMAT_MUTED, TAG_LABEL_MUTED, {TAG_RAMP_VOLUME, TAG_LABEL_MUTED, TAG_BAR_VOLUME});
+    m_formatter->add(FORMAT_MUTED, TAG_LABEL_MUTED, {TAG_RAMP_VOLUME, TAG_LABEL_MUTED, TAG_BAR_VOLUME, TAG_LABEL_VOLUME});
 
     if (m_formatter->has(TAG_BAR_VOLUME)) {
       m_bar_volume = load_progressbar(m_bar, m_conf, name(), TAG_BAR_VOLUME);

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -37,7 +37,7 @@ namespace modules {
 
     // Add formats and elements
     m_formatter->add(FORMAT_VOLUME, TAG_LABEL_VOLUME, {TAG_RAMP_VOLUME, TAG_LABEL_VOLUME, TAG_BAR_VOLUME});
-    m_formatter->add(FORMAT_MUTED, TAG_LABEL_MUTED, {TAG_RAMP_VOLUME, TAG_LABEL_MUTED, TAG_BAR_VOLUME});
+    m_formatter->add(FORMAT_MUTED, TAG_LABEL_MUTED, {TAG_RAMP_VOLUME, TAG_LABEL_MUTED, TAG_BAR_VOLUME, TAG_LABEL_VOLUME});
 
     if (m_formatter->has(TAG_BAR_VOLUME)) {
       m_bar_volume = load_progressbar(m_bar, m_conf, name(), TAG_BAR_VOLUME);


### PR DESCRIPTION
Until c552df3b6603 ("fix: Modules did not validate tags used in formats") it was possible to use the volume label in the muted format. This made sense as the volume level can change while muted and it allowed for example following formats:

    format-volume = "<ramp-volume>  <label-volume> "
    format-muted  =  <label-muted> (<label-volume>)

Add label-volume to the format-muted allowlist to re-enable this feature.

---

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Add `<label-volume>` to the comment describing the available tags of `format-muted` in both the alsa and the pulseaudio wiki page.