### PR TITLE
fix(render): Deal with incomplete wallpapers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,6 +40,7 @@ CheckOptions:
   readability-identifier-naming.MemberCase: lower_case
   readability-identifier-naming.ProtectedMemberPrefix: 'm_'
   readability-identifier-naming.PrivateMemberPrefix: 'm_'
+  readability-simplify-boolean-expr.SimplifyDeMorgan: false
 
 HeaderFilterRegex: ''
 WarningsAsErrors: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/backlight`: Module could display the literal `%percentage%` token if the backlight reports a value of 0 at startup ([`#3081`](https://github.com/polybar/polybar/pull/3081)) by [@unclechu](https://github.com/unclechu)
 - `internal/tray`: Fix crash during restarting, when tray icons were not removed proberly ([`#3111`](https://github.com/polybar/polybar/issues/3111), [`#3112`](https://github.com/polybar/polybar/pull/3112))
 - `custom/ipc`: Module would display the literal `%output%` token before the initial hook finished executing ([`#3131`](https://github.com/polybar/polybar/issues/3131), [`#3140`](https://github.com/polybar/polybar/pull/3140))
+- renderer: Pseudo-transparency rendering artifacts when wallpaper does not fill entire screen ([`#3096`](https://github.com/polybar/polybar/pull/3096), [`#3041`](https://github.com/polybar/polybar/issues/3041))
 
 ## [3.7.1] - 2023-11-27
 ### Build


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

If the root pixmap does not fully cover the bar window, some pseudo-transparent areas were filled with unitialized data, causing pixelation or other rendering artifacts.

Now, observed background slices are first filled with black to make sure this does not happen and they print an error if not the full pixmap can be filled.


## Related Issues & Documents

Fixes #3041

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
