### PR TITLE
fix(file_util::pick): ensure files are readable before picking them

### DIFF
--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -82,6 +82,7 @@ class fd_stream : public StreamType {
 
 namespace file_util {
   bool exists(const string& filename);
+  bool readable(const string& filename);
   bool is_file(const string& filename);
   bool is_dir(const string& filename);
   string pick(const vector<string>& filenames);

--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -81,24 +81,24 @@ class fd_stream : public StreamType {
 };
 
 namespace file_util {
-  bool exists(const string& filename);
-  bool readable(const string& filename);
-  bool is_file(const string& filename);
-  bool is_dir(const string& filename);
-  string pick(const vector<string>& filenames);
-  string contents(const string& filename);
-  void write_contents(const string& filename, const string& contents);
-  bool is_fifo(const string& filename);
-  vector<string> glob(string pattern);
-  string expand(const string& path, const string& relative_to = {});
-  string get_config_path();
-  vector<string> list_files(const string& dirname);
-  string dirname(const string& path);
+bool exists(const string& filename);
+bool readable(const string& filename);
+bool is_file(const string& filename);
+bool is_dir(const string& filename);
+string pick(const vector<string>& filenames);
+string contents(const string& filename);
+void write_contents(const string& filename, const string& contents);
+bool is_fifo(const string& filename);
+vector<string> glob(string pattern);
+string expand(const string& path, const string& relative_to = {});
+string get_config_path();
+vector<string> list_files(const string& dirname);
+string dirname(const string& path);
 
-  template <typename... Args>
-  decltype(auto) make_file_descriptor(Args&&... args) {
-    return std::make_unique<file_descriptor>(forward<Args>(args)...);
-  }
-}  // namespace file_util
+template <typename... Args>
+decltype(auto) make_file_descriptor(Args&&... args) {
+  return std::make_unique<file_descriptor>(forward<Args>(args)...);
+}
+} // namespace file_util
 
 POLYBAR_NS_END

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -56,7 +56,7 @@ file_descriptor::operator bool() {
   return static_cast<const file_descriptor&>(*this);
 }
 file_descriptor::operator bool() const {
-  errno = 0;  // reset since fcntl only changes it on error
+  errno = 0; // reset since fcntl only changes it on error
   if ((fcntl(m_fd, F_GETFD) == -1) || errno == EBADF) {
     errno = EBADF;
     return false;
@@ -140,244 +140,244 @@ int fd_streambuf::underflow() {
 // }}}
 
 namespace file_util {
-  /**
-   * Checks if the given file exist
-   *
-   * May also return false if the file status  cannot be read
-   *
-   * Sets errno when returning false
-   */
-  bool exists(const string& filename) {
-    struct stat buffer {};
-    return stat(filename.c_str(), &buffer) == 0;
+/**
+ * Checks if the given file exist
+ *
+ * May also return false if the file status  cannot be read
+ *
+ * Sets errno when returning false
+ */
+bool exists(const string& filename) {
+  struct stat buffer {};
+  return stat(filename.c_str(), &buffer) == 0;
+}
+
+/**
+ * Checks if the given file is actually readable
+ *
+ * Doing an actual read is necessary to confirm that reading
+ * will actually succeed. For example, some battery firmware
+ * will return ENODATA when charge_now is read, as it is not
+ * implemented in the firmware, despite the file existing
+ * and having a+r permissions.
+ */
+bool readable(const string& filename) {
+  char c;
+  std::ifstream in(filename, std::ifstream::in);
+  in.get(c);
+  return in.good();
+}
+
+/**
+ * Checks if the given path exists and is a file
+ */
+bool is_file(const string& filename) {
+  struct stat buffer {};
+
+  if (stat(filename.c_str(), &buffer) != 0) {
+    return false;
   }
 
-  /**
-   * Checks if the given file is actually readable
-   *
-   * Doing an actual read is necessary to confirm that reading
-   * will actually succeed. For example, some battery firmware
-   * will return ENODATA when charge_now is read, as it is not
-   * implemented in the firmware, despite the file existing
-   * and having a+r permissions.
-   */
-  bool readable(const string& filename) {
-    char c;
+  return S_ISREG(buffer.st_mode);
+}
+
+/**
+ * Checks if the given path exists and is a file
+ */
+bool is_dir(const string& filename) {
+  struct stat buffer {};
+
+  if (stat(filename.c_str(), &buffer) != 0) {
+    return false;
+  }
+
+  return S_ISDIR(buffer.st_mode);
+}
+
+/**
+ * Picks the first existing and readable file out of given entries
+ */
+string pick(const vector<string>& filenames) {
+  for (auto&& f : filenames) {
+    if (exists(f) && readable(f)) {
+      return f;
+    }
+  }
+  return "";
+}
+
+/**
+ * Gets the contents of the given file
+ */
+string contents(const string& filename) {
+  try {
+    string contents;
+    string line;
     std::ifstream in(filename, std::ifstream::in);
-    in.get(c);
-    return in.good();
-  }
-
-  /**
-   * Checks if the given path exists and is a file
-   */
-  bool is_file(const string& filename) {
-    struct stat buffer {};
-
-    if (stat(filename.c_str(), &buffer) != 0) {
-      return false;
+    while (std::getline(in, line)) {
+      contents += line + '\n';
     }
-
-    return S_ISREG(buffer.st_mode);
-  }
-
-  /**
-   * Checks if the given path exists and is a file
-   */
-  bool is_dir(const string& filename) {
-    struct stat buffer {};
-
-    if (stat(filename.c_str(), &buffer) != 0) {
-      return false;
-    }
-
-    return S_ISDIR(buffer.st_mode);
-  }
-
-  /**
-   * Picks the first existing and readable file out of given entries
-   */
-  string pick(const vector<string>& filenames) {
-    for (auto&& f : filenames) {
-      if (exists(f) && readable(f)) {
-        return f;
-      }
-    }
+    return contents;
+  } catch (const std::ifstream::failure& e) {
     return "";
   }
+}
 
-  /**
-   * Gets the contents of the given file
-   */
-  string contents(const string& filename) {
-    try {
-      string contents;
-      string line;
-      std::ifstream in(filename, std::ifstream::in);
-      while (std::getline(in, line)) {
-        contents += line + '\n';
-      }
-      return contents;
-    } catch (const std::ifstream::failure& e) {
-      return "";
-    }
+/**
+ * Writes the contents of the given file
+ */
+void write_contents(const string& filename, const string& contents) {
+  std::ofstream out(filename, std::ofstream::out);
+  if (!(out << contents)) {
+    throw std::system_error(errno, std::system_category(), "failed to write to " + filename);
+  }
+}
+
+/**
+ * Checks if the given file is a named pipe
+ */
+bool is_fifo(const string& filename) {
+  struct stat buffer {};
+  return stat(filename.c_str(), &buffer) == 0 && S_ISFIFO(buffer.st_mode);
+}
+
+/**
+ * Get glob results using given pattern
+ */
+vector<string> glob(string pattern) {
+  glob_t result{};
+  vector<string> ret;
+
+  // Manually expand tilde to fix builds using versions of libc
+  // that doesn't provide the GLOB_TILDE flag (musl for example)
+  if (pattern[0] == '~') {
+    pattern.replace(0, 1, env_util::get("HOME"));
   }
 
-  /**
-   * Writes the contents of the given file
-   */
-  void write_contents(const string& filename, const string& contents) {
-    std::ofstream out(filename, std::ofstream::out);
-    if (!(out << contents)) {
-      throw std::system_error(errno, std::system_category(), "failed to write to " + filename);
+  if (::glob(pattern.c_str(), 0, nullptr, &result) == 0) {
+    for (size_t i = 0_z; i < result.gl_pathc; ++i) {
+      ret.emplace_back(result.gl_pathv[i]);
     }
+    globfree(&result);
   }
 
-  /**
-   * Checks if the given file is a named pipe
+  return ret;
+}
+
+/**
+ * Path expansion
+ *
+ * `relative_to` must be a directory
+ */
+string expand(const string& path, const string& relative_to) {
+  /*
+   * This doesn't capture all cases for absolute paths but the other cases
+   * (tilde and env variable) have the initial '/' character in their
+   * expansion already and will thus not require adding '/' to the beginning.
    */
-  bool is_fifo(const string& filename) {
-    struct stat buffer {};
-    return stat(filename.c_str(), &buffer) == 0 && S_ISFIFO(buffer.st_mode);
+  bool is_absolute = !path.empty() && (path.at(0) == '/');
+  vector<string> p_exploded = string_util::split(path, '/');
+  for (auto& section : p_exploded) {
+    switch (section[0]) {
+      case '$':
+        section = env_util::get(section.substr(1));
+        break;
+      case '~':
+        section = env_util::get("HOME");
+        break;
+    }
+  }
+  string ret = string_util::join(p_exploded, "/");
+  // Don't add an initial slash for relative paths
+  if (ret[0] != '/' && is_absolute) {
+    ret.insert(0, 1, '/');
   }
 
-  /**
-   * Get glob results using given pattern
-   */
-  vector<string> glob(string pattern) {
-    glob_t result{};
-    vector<string> ret;
+  is_absolute = !ret.empty() && (ret.at(0) == '/');
 
-    // Manually expand tilde to fix builds using versions of libc
-    // that doesn't provide the GLOB_TILDE flag (musl for example)
-    if (pattern[0] == '~') {
-      pattern.replace(0, 1, env_util::get("HOME"));
-    }
+  if (!is_absolute && !relative_to.empty()) {
+    return relative_to + "/" + ret;
+  }
+  return ret;
+}
 
-    if (::glob(pattern.c_str(), 0, nullptr, &result) == 0) {
-      for (size_t i = 0_z; i < result.gl_pathc; ++i) {
-        ret.emplace_back(result.gl_pathv[i]);
-      }
-      globfree(&result);
-    }
+/*
+ * Search for polybar config and returns the path if found
+ */
+string get_config_path() {
+  const static string suffix = "/polybar/config";
 
-    return ret;
+  vector<string> possible_paths;
+
+  if (env_util::has("XDG_CONFIG_HOME")) {
+    auto path = env_util::get("XDG_CONFIG_HOME") + suffix;
+
+    possible_paths.push_back(path);
+    possible_paths.push_back(path + ".ini");
   }
 
-  /**
-   * Path expansion
-   *
-   * `relative_to` must be a directory
-   */
-  string expand(const string& path, const string& relative_to) {
-    /*
-     * This doesn't capture all cases for absolute paths but the other cases
-     * (tilde and env variable) have the initial '/' character in their
-     * expansion already and will thus not require adding '/' to the beginning.
-     */
-    bool is_absolute = !path.empty() && (path.at(0) == '/');
-    vector<string> p_exploded = string_util::split(path, '/');
-    for (auto& section : p_exploded) {
-      switch (section[0]) {
-        case '$':
-          section = env_util::get(section.substr(1));
-          break;
-        case '~':
-          section = env_util::get("HOME");
-          break;
-      }
-    }
-    string ret = string_util::join(p_exploded, "/");
-    // Don't add an initial slash for relative paths
-    if (ret[0] != '/' && is_absolute) {
-      ret.insert(0, 1, '/');
-    }
+  if (env_util::has("HOME")) {
+    auto path = env_util::get("HOME") + "/.config" + suffix;
 
-    is_absolute = !ret.empty() && (ret.at(0) == '/');
-
-    if (!is_absolute && !relative_to.empty()) {
-      return relative_to + "/" + ret;
-    }
-    return ret;
+    possible_paths.push_back(path);
+    possible_paths.push_back(path + ".ini");
   }
+
+  vector<string> xdg_config_dirs;
 
   /*
-   * Search for polybar config and returns the path if found
+   *Ref: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
    */
-  string get_config_path() {
-    const static string suffix = "/polybar/config";
+  if (env_util::has("XDG_CONFIG_DIRS")) {
+    xdg_config_dirs = string_util::split(env_util::get("XDG_CONFIG_DIRS"), ':');
+  } else {
+    xdg_config_dirs.push_back("/etc/xdg");
+  }
 
-    vector<string> possible_paths;
+  for (const string& xdg_config_dir : xdg_config_dirs) {
+    possible_paths.push_back(xdg_config_dir + suffix + ".ini");
+  }
 
-    if (env_util::has("XDG_CONFIG_HOME")) {
-      auto path = env_util::get("XDG_CONFIG_HOME") + suffix;
+  possible_paths.push_back("/etc" + suffix + ".ini");
 
-      possible_paths.push_back(path);
-      possible_paths.push_back(path + ".ini");
+  for (const string& p : possible_paths) {
+    if (exists(p)) {
+      return p;
     }
+  }
 
-    if (env_util::has("HOME")) {
-      auto path = env_util::get("HOME") + "/.config" + suffix;
+  return "";
+}
 
-      possible_paths.push_back(path);
-      possible_paths.push_back(path + ".ini");
-    }
-
-    vector<string> xdg_config_dirs;
-
-    /*
-     *Ref: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-     */
-    if (env_util::has("XDG_CONFIG_DIRS")) {
-      xdg_config_dirs = string_util::split(env_util::get("XDG_CONFIG_DIRS"), ':');
-    } else {
-      xdg_config_dirs.push_back("/etc/xdg");
-    }
-
-    for (const string& xdg_config_dir : xdg_config_dirs) {
-      possible_paths.push_back(xdg_config_dir + suffix + ".ini");
-    }
-
-    possible_paths.push_back("/etc" + suffix + ".ini");
-
-    for (const string& p : possible_paths) {
-      if (exists(p)) {
-        return p;
+/**
+ * Return a list of file names in a directory.
+ */
+vector<string> list_files(const string& dirname) {
+  vector<string> files;
+  DIR* dir;
+  if ((dir = opendir(dirname.c_str())) != NULL) {
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != NULL) {
+      // Type can be unknown for filesystems that do not support d_type
+      if ((ent->d_type & DT_REG) ||
+          ((ent->d_type & DT_UNKNOWN) && strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0)) {
+        files.push_back(ent->d_name);
       }
     }
+    closedir(dir);
+    return files;
+  }
+  throw system_error("Failed to open directory stream for " + dirname);
+}
 
-    return "";
+string dirname(const string& path) {
+  const auto pos = path.find_last_of('/');
+  if (pos != string::npos) {
+    return path.substr(0, pos + 1);
   }
 
-  /**
-   * Return a list of file names in a directory.
-   */
-  vector<string> list_files(const string& dirname) {
-    vector<string> files;
-    DIR* dir;
-    if ((dir = opendir(dirname.c_str())) != NULL) {
-      struct dirent* ent;
-      while ((ent = readdir(dir)) != NULL) {
-        // Type can be unknown for filesystems that do not support d_type
-        if ((ent->d_type & DT_REG) ||
-            ((ent->d_type & DT_UNKNOWN) && strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0)) {
-          files.push_back(ent->d_name);
-        }
-      }
-      closedir(dir);
-      return files;
-    }
-    throw system_error("Failed to open directory stream for " + dirname);
-  }
-
-  string dirname(const string& path) {
-    const auto pos = path.find_last_of('/');
-    if (pos != string::npos) {
-      return path.substr(0, pos + 1);
-    }
-
-    return string{};
-  }
-}  // namespace file_util
+  return string{};
+}
+} // namespace file_util
 
 POLYBAR_NS_END

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -153,6 +153,22 @@ namespace file_util {
   }
 
   /**
+   * Checks if the given file is actually readable
+   *
+   * Doing an actual read is necessary to confirm that reading
+   * will actually succeed. For example, some battery firmware
+   * will return ENODATA when charge_now is read, as it is not
+   * implemented in the firmware, despite the file existing
+   * and having a+r permissions.
+   */
+  bool readable(const string& filename) {
+    char c;
+    std::ifstream in(filename, std::ifstream::in);
+    in.get(c);
+    return in.good();
+  }
+
+  /**
    * Checks if the given path exists and is a file
    */
   bool is_file(const string& filename) {
@@ -179,11 +195,11 @@ namespace file_util {
   }
 
   /**
-   * Picks the first existing file out of given entries
+   * Picks the first existing and readable file out of given entries
    */
   string pick(const vector<string>& filenames) {
     for (auto&& f : filenames) {
-      if (exists(f)) {
+      if (exists(f) && readable(f)) {
         return f;
       }
     }


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

the firmware of the Lenovo X13s does not expose charge_now or
charge_full, but the files still exist, so file_util::pick() will still
choose that over energy_now/energy_full. This leads to the battery
module erroneously outputting "0%" at all times. If charge_now or
charge_full is read, it will return ENODATA, so simply reading 1 char
and checking the status should determine if the file should actually be
picked.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
