### PR TITLE
fix(modules/battery): make rate positive if negative

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -65,7 +65,7 @@ namespace modules {
     }
 
     m_rate_reader = make_unique<rate_reader>([this] {
-      unsigned long rate{std::strtoul(file_util::contents(m_frate).c_str(), nullptr, 10)};
+      unsigned long rate{static_cast<unsigned long>(std::abs(std::strtol(file_util::contents(m_frate).c_str(), nullptr, 10)))};
       unsigned long volt{std::strtoul(file_util::contents(m_fvoltage).c_str(), nullptr, 10) / 1000UL};
       unsigned long now{std::strtoul(file_util::contents(m_fcapnow).c_str(), nullptr, 10)};
       unsigned long max{std::strtoul(file_util::contents(m_fcapfull).c_str(), nullptr, 10)};


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

On the Lenovo X13s, the battery firmware returns a negative value for `power_now`, which is interpreted by the battery module as `0UL` because it converts the `string` to `unsigned long`. This should be read as a `long` instead, as the kernel specifies that `power_now` is an `int`: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/include/linux/power_supply.h?h=v6.0.11#n99

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
