### PR TITLE
allow for partial highlighting

### DIFF
--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -126,6 +126,7 @@ class renderer : public renderer_interface,
   cairo_pattern_t* m_cornermask{};
 
   cairo_operator_t m_comp_bg{CAIRO_OPERATOR_SOURCE};
+  cairo_operator_t m_comp_hl{CAIRO_OPERATOR_OVER};
   cairo_operator_t m_comp_fg{CAIRO_OPERATOR_OVER};
   cairo_operator_t m_comp_ol{CAIRO_OPERATOR_OVER};
   cairo_operator_t m_comp_ul{CAIRO_OPERATOR_OVER};

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -39,12 +39,16 @@ namespace modules {
     static constexpr auto FORMAT_MUTED = "format-muted";
 
     static constexpr auto TAG_RAMP_VOLUME = "<ramp-volume>";
+    static constexpr auto TAG_RAMP_MUTED = "<ramp-muted>";
     static constexpr auto TAG_BAR_VOLUME = "<bar-volume>";
+    static constexpr auto TAG_BAR_MUTED = "<bar-muted>";
     static constexpr auto TAG_LABEL_VOLUME = "<label-volume>";
     static constexpr auto TAG_LABEL_MUTED = "<label-muted>";
 
     progressbar_t m_bar_volume;
+    progressbar_t m_bar_muted;
     ramp_t m_ramp_volume;
+    ramp_t m_ramp_muted;
     label_t m_label_volume;
     label_t m_label_muted;
 

--- a/include/tags/context.hpp
+++ b/include/tags/context.hpp
@@ -26,6 +26,7 @@ namespace tags {
 
     void apply_bg(color_value c);
     void apply_fg(color_value c);
+    void apply_hl(highlight_value h);
     void apply_ol(color_value c);
     void apply_ul(color_value c);
     void apply_font(int font);
@@ -37,6 +38,7 @@ namespace tags {
 
     rgba get_bg() const;
     rgba get_fg() const;
+    std::tuple<rgba, rgba, double> get_hl() const;
     rgba get_ol() const;
     rgba get_ul() const;
     int get_font() const;
@@ -55,6 +57,10 @@ namespace tags {
      * Foreground color
      */
     rgba m_fg{};
+    /**
+     * Highlight colors
+     */
+    std::tuple<rgba, rgba, double> m_hl{};
     /**
      * Overline color
      */
@@ -82,8 +88,8 @@ namespace tags {
 
     std::pair<alignment, int> m_relative_tray_position{alignment::NONE, 0};
 
-  private:
-      const bar_settings &m_settings;
+   private:
+    const bar_settings& m_settings;
   };
 } // namespace tags
 

--- a/include/tags/parser.hpp
+++ b/include/tags/parser.hpp
@@ -41,6 +41,7 @@ namespace tags {
   }
 
   DEFINE_INVALID_ERROR(color_error, "color");
+  DEFINE_INVALID_ERROR(highlight_error, "highlight");
   DEFINE_INVALID_ERROR(font_error, "font index");
   DEFINE_INVALID_ERROR(control_error, "control tag");
   DEFINE_INVALID_ERROR(offset_error, "offset");
@@ -125,6 +126,8 @@ namespace tags {
     void parse_single_tag_content();
 
     color_value parse_color();
+    static color_value parse_color(string s);
+    highlight_value parse_highlight();
     int parse_fontindex();
     extent_val parse_offset();
     controltag parse_control();
@@ -154,6 +157,6 @@ namespace tags {
     size_t buf_pos;
   };
 
-}  // namespace tags
+} // namespace tags
 
 POLYBAR_NS_END

--- a/include/tags/types.hpp
+++ b/include/tags/types.hpp
@@ -16,6 +16,7 @@ namespace tags {
     A, // mouse action
     B, // background color
     F, // foreground color
+    H, // highlight color
     T, // font index
     O, // pixel offset
     R, // flip colors
@@ -51,6 +52,17 @@ namespace tags {
     color_type type;
   };
 
+  struct highlight_value {
+    /**
+     * Two colors and a percentage on which to split them
+     *
+     * Only used if type == HIGHLIGHT
+     */
+    color_value left_color;
+    color_value right_color;
+    double percentage;
+  };
+
   /**
    * Stores information about an action
    *
@@ -79,6 +91,10 @@ namespace tags {
        * Used for 'F', 'G', 'o', 'u' formatting tags.
        */
       color_value color;
+      /**
+       * Used for 'H' formatting tags.
+       */
+      highlight_value highlight;
       /**
        * For for 'A' tags
        */

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -37,10 +37,13 @@ namespace modules {
 
     // Add formats and elements
     m_formatter->add(FORMAT_VOLUME, TAG_LABEL_VOLUME, {TAG_RAMP_VOLUME, TAG_LABEL_VOLUME, TAG_BAR_VOLUME});
-    m_formatter->add(FORMAT_MUTED, TAG_LABEL_MUTED, {TAG_RAMP_VOLUME, TAG_LABEL_MUTED, TAG_BAR_VOLUME});
+    m_formatter->add(FORMAT_MUTED, TAG_LABEL_MUTED, {TAG_RAMP_MUTED, TAG_LABEL_MUTED, TAG_BAR_MUTED});
 
     if (m_formatter->has(TAG_BAR_VOLUME)) {
       m_bar_volume = load_progressbar(m_bar, m_conf, name(), TAG_BAR_VOLUME);
+    }
+    if (m_formatter->has(TAG_BAR_MUTED)) {
+      m_bar_muted = load_progressbar(m_bar, m_conf, name(), TAG_BAR_MUTED);
     }
     if (m_formatter->has(TAG_LABEL_VOLUME, FORMAT_VOLUME)) {
       m_label_volume = load_optional_label(m_conf, name(), TAG_LABEL_VOLUME, "%percentage%%");
@@ -50,6 +53,9 @@ namespace modules {
     }
     if (m_formatter->has(TAG_RAMP_VOLUME)) {
       m_ramp_volume = load_ramp(m_conf, name(), TAG_RAMP_VOLUME);
+    }
+    if (m_formatter->has(TAG_RAMP_MUTED)) {
+      m_ramp_muted = load_ramp(m_conf, name(), TAG_RAMP_MUTED);
     }
   }
 
@@ -144,8 +150,12 @@ namespace modules {
   bool pulseaudio_module::build(builder* builder, const string& tag) const {
     if (tag == TAG_BAR_VOLUME) {
       builder->node(m_bar_volume->output(m_volume));
+    } else if (tag == TAG_BAR_MUTED) {
+      builder->node(m_bar_muted->output(m_volume));
     } else if (tag == TAG_RAMP_VOLUME) {
       builder->node(m_ramp_volume->get_by_percentage(m_volume));
+    } else if (tag == TAG_RAMP_MUTED) {
+      builder->node(m_ramp_muted->get_by_percentage(m_volume));
     } else if (tag == TAG_LABEL_VOLUME) {
       builder->node(m_label_volume);
     } else if (tag == TAG_LABEL_MUTED) {

--- a/src/tags/context.cpp
+++ b/src/tags/context.cpp
@@ -11,6 +11,20 @@ namespace tags {
     }
   }
 
+  static std::tuple<rgba, rgba, double> get_highlight(highlight_value h, rgba fallback) {
+    rgba left = h.left_color.val;
+    rgba right = h.right_color.val;
+    if (h.left_color.type == color_type::RESET) {
+      left = fallback;
+    }
+    if (h.right_color.type == color_type::RESET) {
+      right = fallback;
+    }
+    return std::tie(left, right, h.percentage);
+  }
+
+  static double no_hl = 100.0;
+
   context::context(const bar_settings& settings) : m_settings(settings) {
     reset();
   }
@@ -26,6 +40,10 @@ namespace tags {
 
   void context::apply_fg(color_value c) {
     m_fg = get_color(c, m_settings.foreground);
+  }
+
+  void context::apply_hl(highlight_value h) {
+    m_hl = get_highlight(h, m_settings.background);
   }
 
   void context::apply_ol(color_value c) {
@@ -77,6 +95,7 @@ namespace tags {
   void context::apply_reset() {
     m_bg = m_settings.background;
     m_fg = m_settings.foreground;
+    m_hl = std::tie(m_settings.background, m_settings.background, no_hl);
     m_ul = m_settings.underline.color;
     m_ol = m_settings.overline.color;
     m_font = 0;
@@ -90,6 +109,10 @@ namespace tags {
 
   rgba context::get_fg() const {
     return m_fg;
+  }
+
+  std::tuple<rgba, rgba, double> context::get_hl() const {
+    return m_hl;
   }
 
   rgba context::get_ol() const {
@@ -119,6 +142,6 @@ namespace tags {
   std::pair<alignment, int> context::get_relative_tray_position() const {
     return m_relative_tray_position;
   }
-}  // namespace tags
+} // namespace tags
 
 POLYBAR_NS_END

--- a/src/tags/dispatch.cpp
+++ b/src/tags/dispatch.cpp
@@ -59,6 +59,9 @@ namespace tags {
               case tags::syntaxtag::F:
                 m_ctxt->apply_fg(el.tag_data.color);
                 break;
+              case tags::syntaxtag::H:
+                m_ctxt->apply_hl(el.tag_data.highlight);
+                break;
               case tags::syntaxtag::T:
                 m_ctxt->apply_font(el.tag_data.font);
                 break;


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Add a new format tag `%{H}` that splits the contained text into two regions based on a percentage. Each region can be given a different background color.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
No related issue, no worries if this doesn't get merged. It was mostly for my own use anyway.

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes) - The formatting page should be updated to include the new tag.
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
