### PR TITLE
fix(script): Receiving multiple lines rapidly only displays first line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `custom/script`: When a script with `tail = true` received multiple lines quickly, only the first would get displayed ([`#3117`](https://github.com/polybar/polybar/issues/3117), [`#3119`](https://github.com/polybar/polybar/pull/3119)) by [@Isak05](https://github.com/Isak05)
 
 ## [3.7.1] - 2023-11-27
 ### Build

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -119,7 +119,7 @@ namespace modules {
 
   template <typename Impl>
   string module<Impl>::contents() {
-    if (m_changed) {
+    if (m_changed.exchange(false)) {
       m_log.info("%s: Rebuilding cache", name());
       m_cache = CAST_MOD(Impl)->get_output();
       // Make sure builder is really empty
@@ -129,7 +129,6 @@ namespace modules {
         m_builder->control(tags::controltag::R);
         m_cache += m_builder->flush();
       }
-      m_changed = false;
     }
     return m_cache;
   }

--- a/include/utils/command.hpp
+++ b/include/utils/command.hpp
@@ -92,6 +92,7 @@ class command<output_policy::REDIRECTED> : private command<output_policy::IGNORE
 
   void tail(std::function<void(string)> cb);
   string readline();
+  bool wait_for_data(int timeout_ms);
 
   int get_stdout(int c);
   int get_stdin(int c);

--- a/src/adapters/script_runner.cpp
+++ b/src/adapters/script_runner.cpp
@@ -155,7 +155,7 @@ script_runner::interval script_runner::run_tail() {
   assert(fd != -1);
 
   while (!m_stopping && cmd.is_running() && !io_util::poll(fd, POLLHUP, 0)) {
-    if (io_util::poll_read(fd, 250)) {
+    if (cmd.wait_for_data(250)) {
       auto changed = set_output(cmd.readline());
 
       if (changed) {

--- a/src/utils/command.cpp
+++ b/src/utils/command.cpp
@@ -202,6 +202,14 @@ string command<output_policy::REDIRECTED>::readline() {
 }
 
 /**
+ * Wait until there is data in the output stream or until timeout_ms milliseconds
+ */
+bool command<output_policy::REDIRECTED>::wait_for_data(int timeout_ms) {
+  return (m_stdout_reader && m_stdout_reader->rdbuf()->in_avail() > 0) ||
+          io_util::poll_read(get_stdout(PIPE_READ), timeout_ms);
+}
+
+/**
  * Get command output channel
  */
 int command<output_policy::REDIRECTED>::get_stdout(int c) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
When a script with `tail = true` received multiple lines quickly, the ones after the first would get buffered and never displayed.

Also, if the cache started rebuilding right after the first line and the second line was received while doing so, then the second line would't get displayed.

## Related Issues & Documents
Fixes #3117

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
