### PR TITLE
Add a OSS mixer module.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,8 @@ usage() {
           Include support for internal/i3 (requires i3); disabled by default.
       ${COLORS[GREEN]}-a, --alsa${COLORS[OFF]}
           Include support for internal/alsa (requires alsalib); disabled by default.
+      ${COLORS[GREEN]}-o, --oss${COLORS[OFF]}
+          Include support for internal/oss; disabled by default.
       ${COLORS[GREEN]}-p, --pulseaudio${COLORS[OFF]}
           Include support for internal/pulseaudio (requires libpulse); disabled by default.
       ${COLORS[GREEN]}-n, --network${COLORS[OFF]}
@@ -89,6 +91,7 @@ set_build_opts() {
     [[ -z "$USE_GCC" ]] && USE_GCC="OFF"
     [[ -z "$ENABLE_I3" ]] && ENABLE_I3="OFF"
     [[ -z "$ENABLE_ALSA" ]] && ENABLE_ALSA="OFF"
+    [[ -z "$ENABLE_OSS" ]] && ENABLE_OSS="OFF"
     [[ -z "$ENABLE_PULSEAUDIO" ]] && ENABLE_PULSEAUDIO="OFF"
     [[ -z "$ENABLE_NETWORK" ]] && ENABLE_NETWORK="OFF"
     [[ -z "$ENABLE_MPD" ]] && ENABLE_MPD="OFF"
@@ -110,6 +113,11 @@ set_build_opts() {
   if [[ -z "$ENABLE_ALSA" ]]; then
     read -r -p "$(msg "Include support for \"internal/alsa\" (requires alsalib) --------- [y/N]: ")" -n 1 p && echo
     [[ "${p^^}" != "Y" ]] && ENABLE_ALSA="OFF" || ENABLE_ALSA="ON"
+  fi
+
+  if [[ -z "$ENABLE_OSS" ]]; then
+    read -r -p "$(msg "Include support for \"internal/oss\" ----------------------------- [y/N]: ")" -n 1 p && echo
+    [[ "${p^^}" != "Y" ]] && ENABLE_OSS="OFF" || ENABLE_OSS="ON"
   fi
 
   if [[ -z "$ENABLE_PULSEAUDIO" ]]; then
@@ -182,6 +190,7 @@ main() {
   cmake                                       \
     -DCMAKE_CXX_COMPILER="${CXX}"             \
     -DENABLE_ALSA:BOOL="${ENABLE_ALSA}"       \
+    -DENABLE_OSS:BOOL="${ENABLE_OSS}"         \
     -DENABLE_PULSEAUDIO:BOOL="${ENABLE_PULSEAUDIO}"\
     -DENABLE_I3:BOOL="${ENABLE_I3}"           \
     -DENABLE_MPD:BOOL="${ENABLE_MPD}"         \
@@ -212,6 +221,8 @@ while [[ "$1" == -* ]]; do
       ENABLE_I3=ON; shift ;;
     -a|--alsa)
       ENABLE_ALSA=ON; shift ;;
+    -o|--oss)
+      ENABLE_OSS=ON; shift ;;
     -p|--pulseaudio)
       ENABLE_PULSEAUDIO=ON; shift ;;
     -n|--network)
@@ -225,6 +236,7 @@ while [[ "$1" == -* ]]; do
     --all-features)
       ENABLE_I3=ON
       ENABLE_ALSA=ON
+      ENABLE_OSS=ON
       ENABLE_PULSEAUDIO=ON
       ENABLE_NETWORK=ON
       ENABLE_MPD=ON

--- a/cmake/05-summary.cmake
+++ b/cmake/05-summary.cmake
@@ -37,6 +37,7 @@ if (BUILD_LIBPOLY)
   colored_option("   i3" ENABLE_I3)
   colored_option("   mpd" ENABLE_MPD MPD_VERSION)
   colored_option("   network (${WIRELESS_LIB})" ENABLE_NETWORK NETWORK_LIBRARY_VERSION)
+  colored_option("   oss" ENABLE_OSS)
   colored_option("   pulseaudio" ENABLE_PULSEAUDIO PULSEAUDIO_VERSION)
   colored_option("   xkeyboard" WITH_XKB Xcb_XKB_VERSION)
 

--- a/include/adapters/oss.hpp
+++ b/include/adapters/oss.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#if defined __OpenBSD__
+#  include <soundcard.h>
+#else
+#  include <sys/soundcard.h>
+#endif
+
+#include "common.hpp"
+#include "settings.hpp"
+
+POLYBAR_NS
+
+namespace oss {
+  DEFINE_ERROR(oss_exception);
+
+  class mixer {
+   public:
+    explicit mixer(string&& mixer_device_path, string&& mixer_channel_name);
+    ~mixer();
+
+    mixer(const mixer& o) = delete;
+    mixer& operator=(const mixer& o) = delete;
+
+    const string& get_name();
+    const string& get_sound_card();
+
+    bool wait(int timeout = -1);
+
+    int get_volume();
+    void set_volume(float percentage);
+    void set_mute(bool mode);
+    void toggle_mute();
+    bool is_muted();
+
+   private:
+    string m_device_path;
+    int m_fd{-1};
+    int m_channel{SOUND_MIXER_NONE};
+    int m_stereodevs;
+  };
+}
+
+POLYBAR_NS_END

--- a/include/modules/meta/all.hpp
+++ b/include/modules/meta/all.hpp
@@ -34,6 +34,9 @@
 #if ENABLE_ALSA
 #include "modules/alsa.hpp"
 #endif
+#if ENABLE_OSS
+#include "modules/oss.hpp"
+#endif
 #if ENABLE_PULSEAUDIO
 #include "modules/pulseaudio.hpp"
 #endif

--- a/include/modules/meta/types.hpp
+++ b/include/modules/meta/types.hpp
@@ -19,6 +19,7 @@ namespace modules {
   static constexpr const char MEMORY_TYPE[] = "internal/memory";
   static constexpr const char MPD_TYPE[] = "internal/mpd";
   static constexpr const char NETWORK_TYPE[] = "internal/network";
+  static constexpr const char OSS_TYPE[] = "internal/oss";
   static constexpr const char PULSEAUDIO_TYPE[] = "internal/pulseaudio";
   static constexpr const char TEMPERATURE_TYPE[] = "internal/temperature";
   static constexpr const char TRAY_TYPE[] = "internal/tray";

--- a/include/modules/oss.hpp
+++ b/include/modules/oss.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "modules/meta/event_module.hpp"
+#include "modules/meta/types.hpp"
+#include "settings.hpp"
+
+POLYBAR_NS
+
+// fwd
+namespace oss {
+  class mixer;
+}  // namespace oss
+
+namespace modules {
+  using mixer_t = shared_ptr<oss::mixer>;
+
+  class oss_module : public event_module<oss_module> {
+   public:
+    explicit oss_module(const bar_settings&, string, const config&);
+
+    void teardown();
+    bool has_event();
+    bool update();
+    string get_format() const;
+    string get_output();
+    bool build(builder* builder, const string& tag) const;
+
+    static constexpr auto TYPE = OSS_TYPE;
+
+    static constexpr auto EVENT_INC = "inc";
+    static constexpr auto EVENT_DEC = "dec";
+    static constexpr auto EVENT_TOGGLE = "toggle";
+
+   protected:
+    void action_inc();
+    void action_dec();
+    void action_toggle();
+
+    void change_volume(int interval);
+
+    void action_epilogue();
+
+   private:
+    static constexpr auto FORMAT_VOLUME = "format-volume";
+    static constexpr auto FORMAT_MUTED = "format-muted";
+
+    static constexpr auto TAG_RAMP_VOLUME = "<ramp-volume>";
+    static constexpr auto TAG_BAR_VOLUME = "<bar-volume>";
+    static constexpr auto TAG_LABEL_VOLUME = "<label-volume>";
+    static constexpr auto TAG_LABEL_MUTED = "<label-muted>";
+
+    progressbar_t m_bar_volume;
+    ramp_t m_ramp_volume;
+    label_t m_label_volume;
+    label_t m_label_muted;
+
+    mixer_t m_mixer;
+    bool m_unmute_on_scroll{false};
+    int m_interval{5};
+    atomic<bool> m_muted{false};
+    atomic<int> m_volume{0};
+  };
+}  // namespace modules
+
+POLYBAR_NS_END

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -13,6 +13,7 @@ extern const char* const APP_VERSION;
 #cmakedefine01 WITH_LIBNL
 #cmakedefine01 ENABLE_I3
 #cmakedefine01 ENABLE_CURL
+#cmakedefine01 ENABLE_OSS
 #cmakedefine01 ENABLE_PULSEAUDIO
 
 #define WITH_XRANDR 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,11 @@ set(NETWORK_SOURCES
   $<IF:$<BOOL:${WITH_LIBNL}>,${src_dir}/adapters/net_nl.cpp,${src_dir}/adapters/net_iw.cpp>
   )
 
+set(OSS_SOURCES
+  ${src_dir}/adapters/oss.cpp
+  ${src_dir}/modules/oss.cpp
+  )
+
 set(PULSEAUDIO_SOURCES
   ${src_dir}/adapters/pulseaudio.cpp
   ${src_dir}/modules/pulseaudio.cpp
@@ -145,6 +150,7 @@ set(POLY_SOURCES
   $<$<BOOL:${ENABLE_I3}>:${I3_SOURCES}>
   $<$<BOOL:${ENABLE_MPD}>:${MPD_SOURCES}>
   $<$<BOOL:${ENABLE_NETWORK}>:${NETWORK_SOURCES}>
+  $<$<BOOL:${ENABLE_OSS}>:${OSS_SOURCES}>
   $<$<BOOL:${ENABLE_PULSEAUDIO}>:${PULSEAUDIO_SOURCES}>
   $<$<BOOL:${WITH_XCURSOR}>:${XCURSOR_SOURCES}>
   $<$<BOOL:${WITH_XKB}>:${XKB_SOURCES}>

--- a/src/adapters/oss.cpp
+++ b/src/adapters/oss.cpp
@@ -1,0 +1,177 @@
+#include <cmath>
+#include <cstring>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/ioctl.h>
+
+#include "errors.hpp"
+#include "adapters/oss.hpp"
+
+POLYBAR_NS
+
+namespace oss {
+  string sound_device_names[] = SOUND_DEVICE_NAMES;
+
+  void throw_exception(string&& message = "", int error_code = 0) {
+    if (error_code != 0)
+      message += ": " + string{strerror(error_code)};
+    throw oss_exception(message.c_str());
+  }
+
+  /**
+   * Construct mixer object
+   */
+  mixer::mixer(string&& mixer_device_path, string&& mixer_channel_name)
+      : m_device_path(std::forward<string>(mixer_device_path)) {
+    if ((m_fd = open(m_device_path.c_str(), O_RDWR)) == -1) {
+      throw_exception("Failed to open mixer", errno);
+    }
+
+    for (int i = 0; i < SOUND_MIXER_NONE; i++) {
+      if (strcasecmp(mixer_channel_name.c_str(), sound_device_names[i].c_str()) == 0) {
+        m_channel = i;
+        break;
+      }
+    }
+    if (m_channel == SOUND_MIXER_NONE) {
+      throw_exception("Mixer name is not valid");
+    }
+
+    int mask;
+    if (ioctl(m_fd, MIXER_READ(m_channel), &mask) == -1) {
+      throw_exception("Mixer is not available on the soundcard");
+    }
+
+    if (ioctl(m_fd, SOUND_MIXER_READ_STEREODEVS, &m_stereodevs) == -1) {
+      throw_exception("Cannot determine stereo/mono channels", errno);
+    }
+  }
+
+  /**
+   * Deconstruct mixer
+   */
+  mixer::~mixer() {
+    if (m_fd != -1) {
+      close(m_fd);
+    }
+  }
+
+  /**
+   * Get mixer name
+   */
+  const string& mixer::get_name() {
+    return sound_device_names[m_channel];
+  }
+
+  /**
+   * Get the name of the soundcard that is associated with the mixer
+   */
+  const string& mixer::get_sound_card() {
+#if defined(SOUND_MIXER_INFO)
+    mixer_info mi;
+    if (ioctl(m_fd, SOUND_MIXER_INFO, &mi) == -1) {
+      throw_exception("Failed to get mixer info", errno);
+    }
+    std::string *name = new std::string{mi.name};
+    return *name;
+#else
+    return m_device_path;
+#endif
+  }
+
+  /**
+   * Wait for events
+   */
+  bool mixer::wait(int timeout) {
+    struct timeval to;
+    to.tv_sec = timeout / 1000;
+    to.tv_usec = (timeout-to.tv_sec) * 1000;
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(m_fd, &fds);
+    if (select(m_fd+1, &fds, NULL, NULL, &to) == -1) {
+      throw_exception("Failed to wait for events", errno);
+    }
+    return FD_ISSET(m_fd, &fds);
+  }
+
+  /**
+   * Get volume in percentage
+   */
+  int mixer::get_volume() {
+	uint32_t vol;
+    if (ioctl(m_fd, MIXER_READ(m_channel), &vol) == -1) {
+      throw_exception("Undefined mixer channel was accessed");
+    }
+	return ((1<<m_channel) & m_stereodevs)
+        ? ((vol & 0x7f) + ((vol & 0x7f00)>>8)) / 2
+        : (vol & 0x7f);
+  }
+
+  /**
+   * Set volume to given percentage
+   */
+  void mixer::set_volume(float percentage) {
+    uint32_t vol = ((1<<m_channel) & m_stereodevs)
+        ? ((uint8_t)percentage) + ((uint8_t)percentage<<8)
+        : ((uint8_t)percentage);
+    if (ioctl(m_fd, MIXER_WRITE(m_channel), &vol) == -1) {
+      throw_exception("Undefined mixer channel was accessed");
+    }
+  }
+
+  /**
+   * Set mute state
+   */
+  void mixer::set_mute(bool mode) {
+#ifdef SOUND_MIXER_READ_MUTE
+    int mutemask;
+    if (ioctl(m_fd, SOUND_MIXER_READ_MUTE, &mutemask) == -1) {
+      throw_exception("Undefined mixer channel was accessed");
+    }
+    if (mode) {
+      mutemask &= ~(1 << m_channel);
+    }
+    else {
+      mutemask |= (1 << m_channel);
+    }
+    if (ioctl(m_fd, SOUND_MIXER_WRITE_MUTE, &mutemask) == -1) {
+      throw_exception("Undefined mixer channel was accessed");
+    }
+#endif
+  }
+
+  /**
+   * Toggle mute state
+   */
+  void mixer::toggle_mute() {
+#ifdef SOUND_MIXER_READ_MUTE
+    int mutemask;
+    if (ioctl(m_fd, SOUND_MIXER_READ_MUTE, &mutemask) == -1) {
+      throw_exception("Undefined mixer channel was accessed");
+    }
+    mutemask ^= (1 << m_channel);
+    if (ioctl(m_fd, SOUND_MIXER_WRITE_MUTE, &mutemask) == -1) {
+      throw_exception("Undefined mixer channel was accessed");
+    }
+#endif
+  }
+
+  /**
+   * Get current mute state
+   */
+  bool mixer::is_muted() {
+#ifdef SOUND_MIXER_READ_MUTE
+    int mutemask;
+    if (ioctl(m_fd, SOUND_MIXER_READ_MUTE, &mutemask) == -1) {
+      throw_exception("Undefined mixer channel was accessed");
+    }
+    return (mutemask & (1 << m_channel));
+#else
+    return false;
+#endif
+  }
+}
+
+POLYBAR_NS_END

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -339,6 +339,11 @@ bool controller::try_forward_legacy_action(const string& cmd) {
     A_MAP("voldown", alsa_module, EVENT_DEC),
     A_MAP("volmute", alsa_module, EVENT_TOGGLE),
 #endif
+#if ENABLE_OSS
+    A_MAP("volup", oss_module, EVENT_INC),
+    A_MAP("voldown", oss_module, EVENT_DEC),
+    A_MAP("volmute", oss_module, EVENT_TOGGLE),
+#endif
 #if ENABLE_PULSEAUDIO
     A_MAP("pa_volup", pulseaudio_module, EVENT_INC),
     A_MAP("pa_voldown", pulseaudio_module, EVENT_DEC),

--- a/src/modules/meta/factory.cpp
+++ b/src/modules/meta/factory.cpp
@@ -78,6 +78,11 @@ namespace modules {
 #else
       map_entry_unsupported<ALSA_TYPE>(),
 #endif
+#if ENABLE_OSS
+      map_entry<oss_module>(),
+#else
+      map_entry_unsupported<OSS_TYPE>(),
+#endif
 #if ENABLE_PULSEAUDIO
       map_entry<pulseaudio_module>(),
 #else

--- a/src/modules/oss.cpp
+++ b/src/modules/oss.cpp
@@ -1,0 +1,181 @@
+#include "modules/oss.hpp"
+
+#include "adapters/oss.hpp"
+#include "drawtypes/label.hpp"
+#include "drawtypes/progressbar.hpp"
+#include "drawtypes/ramp.hpp"
+#include "modules/meta/base.inl"
+#include "settings.hpp"
+#include "utils/math.hpp"
+
+POLYBAR_NS
+
+using namespace oss;
+
+namespace modules {
+  template class module<oss_module>;
+
+  oss_module::oss_module(const bar_settings& bar, string name_, const config& config)
+      : event_module<oss_module>(bar, std::move(name_), config) {
+    if (m_handle_events) {
+      m_router->register_action(EVENT_DEC, [this]() { action_dec(); });
+      m_router->register_action(EVENT_INC, [this]() { action_inc(); });
+      m_router->register_action(EVENT_TOGGLE, [this]() { action_toggle(); });
+    }
+
+    // Load configuration values
+    m_interval = m_conf.get(name(), "interval", m_interval);
+    m_unmute_on_scroll = m_conf.get(name(), "unmute-on-scroll", m_unmute_on_scroll);
+
+    auto mixer_name = m_conf.get(name(), "mixer", "vol"s);
+    auto m_device_name = m_conf.get(name(), "device", "/dev/mixer"s);
+
+    // Setup mixers
+    try {
+      m_mixer.reset(new mixer_t::element_type{std::move(m_device_name), std::move(mixer_name)});
+    } catch (const oss_exception& err) {
+      throw module_error(err.what());
+    }
+
+    // Add formats and elements
+    m_formatter->add(FORMAT_VOLUME, TAG_LABEL_VOLUME, {TAG_RAMP_VOLUME, TAG_LABEL_VOLUME, TAG_BAR_VOLUME});
+    m_formatter->add(FORMAT_MUTED, TAG_LABEL_MUTED, {TAG_RAMP_VOLUME, TAG_LABEL_MUTED, TAG_BAR_VOLUME});
+
+    if (m_formatter->has(TAG_BAR_VOLUME)) {
+      m_bar_volume = load_progressbar(m_bar, m_conf, name(), TAG_BAR_VOLUME);
+    }
+    if (m_formatter->has(TAG_LABEL_VOLUME, FORMAT_VOLUME)) {
+      m_label_volume = load_optional_label(m_conf, name(), TAG_LABEL_VOLUME, "%percentage%%");
+    }
+    if (m_formatter->has(TAG_LABEL_MUTED, FORMAT_MUTED)) {
+      m_label_muted = load_optional_label(m_conf, name(), TAG_LABEL_MUTED, "%percentage%%");
+    }
+    if (m_formatter->has(TAG_RAMP_VOLUME)) {
+      m_ramp_volume = load_ramp(m_conf, name(), TAG_RAMP_VOLUME);
+    }
+  }
+
+  void oss_module::teardown() {
+  }
+
+  bool oss_module::has_event() {
+    // Poll for mixer events
+    try {
+      if (m_mixer && m_mixer->wait(25)) {
+        return true;
+      }
+    } catch (const oss_exception& e) {
+      m_log.err("%s: %s", name(), e.what());
+    }
+
+    return false;
+  }
+
+  bool oss_module::update() {
+    // Get volume, mute
+    m_volume = 100;
+    m_muted = false;
+
+    try {
+      if (m_mixer) {
+        m_volume = m_volume * m_mixer->get_volume() / 100.0f;
+        m_muted = m_muted || m_mixer->is_muted();
+      }
+    } catch (const oss_exception& err) {
+      m_log.err("%s: Failed to query mixer (%s)", name(), err.what());
+    }
+
+    // Replace label tokens
+    if (m_label_volume) {
+      m_label_volume->reset_tokens();
+      m_label_volume->replace_token("%percentage%", to_string(m_volume));
+    }
+
+    if (m_label_muted) {
+      m_label_muted->reset_tokens();
+      m_label_muted->replace_token("%percentage%", to_string(m_volume));
+    }
+
+    return true;
+  }
+
+  string oss_module::get_format() const {
+    return m_muted ? FORMAT_MUTED : FORMAT_VOLUME;
+  }
+
+  string oss_module::get_output() {
+    // Get the module output early so that
+    // the format prefix/suffix also gets wrapper
+    // with the cmd handlers
+    string output{module::get_output()};
+
+    if (m_handle_events) {
+      auto click_middle = m_conf.get(name(), "click-middle", ""s);
+      auto click_right = m_conf.get(name(), "click-right", ""s);
+
+      if (!click_middle.empty()) {
+        m_builder->action(mousebtn::MIDDLE, click_middle);
+      }
+
+      if (!click_right.empty()) {
+        m_builder->action(mousebtn::RIGHT, click_right);
+      }
+
+      m_builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "");
+      m_builder->action(mousebtn::SCROLL_UP, *this, EVENT_INC, "");
+      m_builder->action(mousebtn::SCROLL_DOWN, *this, EVENT_DEC, "");
+    }
+
+    m_builder->node(output);
+
+    return m_builder->flush();
+  }
+
+  bool oss_module::build(builder* builder, const string& tag) const {
+    if (tag == TAG_BAR_VOLUME) {
+      builder->node(m_bar_volume->output(m_volume));
+    } else if (tag == TAG_RAMP_VOLUME) {
+      builder->node(m_ramp_volume->get_by_percentage(m_volume));
+    } else if (tag == TAG_LABEL_VOLUME) {
+      builder->node(m_label_volume);
+    } else if (tag == TAG_LABEL_MUTED) {
+      builder->node(m_label_muted);
+    } else {
+      return false;
+    }
+    return true;
+  }
+
+  void oss_module::action_inc() {
+    change_volume(m_interval);
+  }
+
+  void oss_module::action_dec() {
+    change_volume(-m_interval);
+  }
+
+  void oss_module::action_toggle() {
+    if (!m_mixer) {
+      return;
+    }
+
+    m_mixer->set_mute(m_muted || m_mixer->is_muted());
+
+    action_epilogue();
+  }
+
+  void oss_module::change_volume(int interval) {
+    if (m_unmute_on_scroll) {
+      m_mixer->set_mute(true);
+    }
+    m_mixer->set_volume(math_util::cap<float>(m_mixer->get_volume() + interval, 0, 100));
+    action_epilogue();
+  }
+
+  void oss_module::action_epilogue() {
+    m_mixer->wait(0);
+  }
+
+} // namespace modules
+
+POLYBAR_NS_END

--- a/src/settings.cpp.cmake
+++ b/src/settings.cpp.cmake
@@ -33,13 +33,14 @@ bool version_details(const std::vector<std::string>& args) {
 // clang-format off
 void print_build_info(bool extended) {
   printf("%s %s\n\n", APP_NAME, APP_VERSION);
-  printf("Features: %calsa %ccurl %ci3 %cmpd %cnetwork(%s) %cpulseaudio %cxkeyboard\n",
+  printf("Features: %calsa %ccurl %ci3 %cmpd %cnetwork(%s) %coss %cpulseaudio %cxkeyboard\n",
     (ENABLE_ALSA       ? '+' : '-'),
     (ENABLE_CURL       ? '+' : '-'),
     (ENABLE_I3         ? '+' : '-'),
     (ENABLE_MPD        ? '+' : '-'),
     (ENABLE_NETWORK    ? '+' : '-'),
     WIRELESS_LIB,
+    (ENABLE_OSS        ? '+' : '-'),
     (ENABLE_PULSEAUDIO ? '+' : '-'),
     (ENABLE_XKEYBOARD  ? '+' : '-'));
   if (extended) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [X] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

Hi, I just began a few weeks ago to use polybar on freebsd and love it. Something I am missing would be a mixer module for freebsd base sound api, OSS (which can be used on other systems), so I had a look to write one and wondered if you would be interested in accepting such module.

My code is based mostly on the ALSA module, but with a few caveats:
 - No headphone support (OSS sees a separate soundcard)
 - No equivalent to mapped (yet)

I found that this module will build on Linux without any specific dependency (tested on debian, soundcard.h provided by linux-libc-dev), but would not recommend to run it even for a testsuite there as ALSA OSS compat layer has been described as broken forever.

Given I mostly based it on the ALSA module, I hope it will meet the project coding conventions and best practices.

I realize this code will not interest that many people, but one good thing with OSS is that it doesn't change a bit, I'd expect this code to be a burden only in the case of a polybar refactoring.

Thanks for your work and reviewing this request.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

No issue related

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

This change should go with a new wiki page, for which the ALSA module doc can be a start with only a few changes (device, mixer fields, removing headphone/mapped entries). I'll write this if the project express interest in going forward integrating this module.