### PR TITLE
ci: Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
         if: ${{ matrix.polybar_build_type == 'tests' }}
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           # We provide our own coverage files
           disable_search: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       COLOR: "ON"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
       - name: Install Dependencies
@@ -48,7 +48,7 @@ jobs:
             python3-xcbgen \
             libuv1-dev \
             xcb-proto
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           ref: ${{ github.event.inputs.ref }}
@@ -115,7 +115,7 @@ jobs:
           if [ "$POLYBAR_BUILD_TYPE" = "tests" ]; then
             sudo apt-get install -y lcov
           fi
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           ref: ${{ github.event.inputs.ref }}
@@ -157,7 +157,7 @@ jobs:
           verbose: true
       - name: Upload Logs
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cmake
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       # Checks out the target tag
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_TAG }}
           submodules: true
@@ -55,7 +55,7 @@ jobs:
 
       - name: Get Upload URL
         id: get_upload_url
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -83,7 +83,7 @@ jobs:
 
       # Adds a download section to the beginning of the release body
       - name: Update Release Body
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         env:
           # Existing release body, fetched in the get_upload_url step.
           RELEASE_BODY: ${{ env.RELEASE_BODY }}


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [x] Other: *CI*

## Description
`checkout` is bumped from v3 to v4, there shouldn't be any breaking changes (just bumps the node version)

`upload-artifact` is bumped from v2 to v4, our use case shouldn't break

`github-script` is bumped from v3 to v7. I don't see any breaking changes that should affect us. Again mainly a nodejs version bump

Also adds the codecov token to the coverage action. This is required for uploads on the `master` branch.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
