### PR TITLE
fix(ci): Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           script: |
             const tag = '${{ env.RELEASE_TAG }}';
             console.log(`Getting Upload URL for '${tag}'`);
-            const release = await github.repos.getReleaseByTag({
+            const release = await github.rest.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag: tag
@@ -97,7 +97,7 @@ jobs:
             body += `[${fname}](${url}) (**sha256**: \`${hash}\`)\n\n`
             body += process.env.RELEASE_BODY;
 
-            const release = await github.repos.updateRelease({
+            const release = await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: '${{ env.RELEASE_ID}}',


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

* [x] Other: *CI*

## Description
github.* doesn't exist anymore. Instead everything there is now available under github.rest.*

## Related Issues & Documents
Ref: https://github.com/octokit/plugin-rest-endpoint-methods.js/releases/tag/v5.0.0

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
