### PR TITLE
fix: check if git top-level directory matches CMake project source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,34 @@ project(polybar CXX)
 # a version string is used, so the file supports comments
 file(STRINGS version.txt version_txt REGEX "^[0-9]+\\.[0-9]+\\.[0-9]+.*$" LIMIT_COUNT 1)
 
-# If we are in a git repo we can get the version information from git describe
-execute_process(COMMAND git describe --tags --dirty=-dev
+
+execute_process(COMMAND git rev-parse --show-toplevel
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  RESULT_VARIABLE git_result
-  OUTPUT_VARIABLE git_describe
+  RESULT_VARIABLE git_top_dir_result
+  OUTPUT_VARIABLE git_top_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
 
-if(git_result EQUAL "0")
-  set(APP_VERSION "${git_describe}")
+# Set fallback first, override if more information (from git) is found
+set(APP_VERSION "${version_txt}")
+
+if(git_top_dir_result EQUAL "0" AND git_top_dir STREQUAL PROJECT_SOURCE_DIR)
+  # If we are in a git repo we can get the version information from git describe
+  execute_process(COMMAND git describe --tags --dirty=-dev
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE git_describe_result
+    OUTPUT_VARIABLE git_describe
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+
+  if(git_describe_result EQUAL "0")
+    set(APP_VERSION "${git_describe}")
+  else()
+    message(STATUS "Could not detect version with git, falling back to built-in version information.")
+  endif()
+
 else()
-  message(STATUS "Could not detect version with git, falling back to built-in version information.")
-  set(APP_VERSION "${version_txt}")
+  message(STATUS "CMake and git directory mismatch, falling back to built-in version information.") # Assuming that if git rev-parse doesn't return 0, git describe won't either
 endif()
+
 
 # Set the default installation prefix to /usr
 # Otherwise the default value is /usr/local which causes the default config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,13 @@ execute_process(COMMAND git rev-parse --show-toplevel
 # Set fallback first, override if more information (from git) is found
 set(APP_VERSION "${version_txt}")
 
-if(git_top_dir_result EQUAL "0" AND git_top_dir STREQUAL PROJECT_SOURCE_DIR)
+# Prevent formatting errors & resolve symlinks (REALPATH)
+get_filename_component(resolved_project_source_dir ${PROJECT_SOURCE_DIR} REALPATH)
+if(NOT ("${git_top_dir}" STREQUAL ""))
+  get_filename_component(git_top_dir ${git_top_dir} REALPATH)
+endif()
+
+if(git_top_dir_result EQUAL "0" AND git_top_dir STREQUAL resolved_project_source_dir)
   # If we are in a git repo we can get the version information from git describe
   execute_process(COMMAND git describe --tags --dirty=-dev
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
Checks if command `git rev-parse --show-toplevel` matches CMake variable `PROJECT_SOURCE_DIR` if it does, then it checks for the git tags for version information as it was doing before.
If directories do not match, it falls back to version.txt

**Considerations**:
- Code assumes that if `git rev-parse ...` does not return 0, `git describe ...` won't either.
- Message shown on mismatch (`CMake and git directory mismatch, falling back to built-in version information.`) could be clearer and also include that `git` may not be installed
- > This still may get "wrong" results if someone is just putting the polybar sources at the top of some other repo. But that case is not distinguishable from polybar forks anyway and is acceptable


## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Fixes #3152 
## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
