### PR TITLE
 fix(modules/battery): fix battery state not reporting as full on trickle charge

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -305,7 +305,9 @@ namespace modules {
    */
   battery_module::state battery_module::current_state() {
     auto charge = read(*m_capacity_reader);
-    if (charge >= m_fullat) {
+    auto rate = read(*m_rate_reader);
+
+    if (charge >= m_fullat || (charge > 0 && rate == 0)) {
       return battery_module::state::FULL;
     } else if (!read(*m_state_reader)) {
       return charge <= m_lowat ? battery_module::state::LOW : battery_module::state::DISCHARGING;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [X] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Many laptops allow for setting a charge threshold when using them mostly plugged in, in order to maintain the battery health in a good state. Currently polybar does not check for this and always sets the battery state to charging, even when the reported charging rate is zero (trickle charge).

This PR aims to fix this, by also checking the battery rate value.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [X] Does not require documentation changes
