### PR TITLE
add missing cstdint includes

### DIFF
--- a/include/ipc/decoder.hpp
+++ b/include/ipc/decoder.hpp
@@ -5,6 +5,8 @@
 #include "errors.hpp"
 #include "ipc/msg.hpp"
 
+#include <cstdint>
+
 POLYBAR_NS
 
 namespace ipc {

--- a/include/ipc/encoder.hpp
+++ b/include/ipc/encoder.hpp
@@ -4,6 +4,8 @@
 #include "errors.hpp"
 #include "ipc/msg.hpp"
 
+#include <cstdint>
+
 POLYBAR_NS
 
 namespace ipc {

--- a/include/ipc/msg.hpp
+++ b/include/ipc/msg.hpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 
 #include <array>
+#include <cstdint>
 
 POLYBAR_NS
 

--- a/include/utils/color.hpp
+++ b/include/utils/color.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <cstdint>
 
 #include "common.hpp"
 

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 
 #include "common.hpp"

--- a/src/ipc/encoder.cpp
+++ b/src/ipc/encoder.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <cstdint>
 
 POLYBAR_NS
 

--- a/src/utils/color.cpp
+++ b/src/utils/color.cpp
@@ -1,6 +1,7 @@
 #include "utils/color.hpp"
 
 #include <algorithm>
+#include <cstdint>
 
 POLYBAR_NS
 


### PR DESCRIPTION
In GCC 15, cstdint is less commonly included in stdlib headers so we need explicit includes: https://gcc.gnu.org/gcc-15/porting_to.html

See-Also: https://bugs.gentoo.org/937526

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

No user facing changes, just build time fixes for GCC 15.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

https://bugs.gentoo.org/937526
https://gcc.gnu.org/gcc-15/porting_to.html


## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
