### PR TITLE
James/task/add timezone to date module

### DIFF
--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -31,6 +31,8 @@ namespace modules {
     // @deprecated: Use <label>
     static constexpr auto TAG_DATE = "<date>";
 
+    static std::mutex tz_mutex;
+
     label_t m_label;
 
     string m_dateformat;

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -41,6 +41,8 @@ namespace modules {
     string m_date;
     string m_time;
 
+    string m_timezone;
+
     // Single stringstream to be used to gather the results of std::put_time
     std::stringstream datetime_stream;
 

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -6,6 +6,8 @@
 POLYBAR_NS
 
 namespace modules {
+  std::mutex date_module::tz_mutex;
+
   template class module<date_module>;
 
   date_module::date_module(const bar_settings& bar, string name_, const config& config)
@@ -44,6 +46,9 @@ namespace modules {
 
   bool date_module::update() {
     auto time = std::time(nullptr);
+
+    // Lock the mutex to prevent other threads from modifying TZ
+    std::lock_guard<std::mutex> lock(tz_mutex);
 
     const char* old_tz = getenv("TZ");
 

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -109,6 +109,6 @@ namespace modules {
     m_toggled = !m_toggled;
     wakeup();
   }
-} // namespace modules
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -6,90 +6,109 @@
 POLYBAR_NS
 
 namespace modules {
-  template class module<date_module>;
+template class module<date_module>;
 
-  date_module::date_module(const bar_settings& bar, string name_, const config& config)
-      : timer_module<date_module>(bar, move(name_), config) {
-    if (!m_bar.locale.empty()) {
-      datetime_stream.imbue(std::locale(m_bar.locale.c_str()));
-    }
-
-    m_router->register_action(EVENT_TOGGLE, [this]() { action_toggle(); });
-
-    m_dateformat = m_conf.get(name(), "date", ""s);
-    m_dateformat_alt = m_conf.get(name(), "date-alt", ""s);
-    m_timeformat = m_conf.get(name(), "time", ""s);
-    m_timeformat_alt = m_conf.get(name(), "time-alt", ""s);
-
-    if (m_dateformat.empty() && m_timeformat.empty()) {
-      throw module_error("No date or time format specified");
-    }
-
-    set_interval(1s);
-
-    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_DATE});
-
-    if (m_formatter->has(TAG_DATE)) {
-      m_log.warn("%s: The format tag `<date>` is deprecated, use `<label>` instead.", name());
-
-      m_formatter->get(DEFAULT_FORMAT)->value =
-          string_util::replace_all(m_formatter->get(DEFAULT_FORMAT)->value, TAG_DATE, TAG_LABEL);
-    }
-
-    if (m_formatter->has(TAG_LABEL)) {
-      m_label = load_optional_label(m_conf, name(), "label", "%date%");
-    }
+date_module::date_module(const bar_settings& bar, string name_, const config& config)
+    : timer_module<date_module>(bar, move(name_), config) {
+  if (!m_bar.locale.empty()) {
+    datetime_stream.imbue(std::locale(m_bar.locale.c_str()));
   }
 
-  bool date_module::update() {
-    auto time = std::time(nullptr);
+  m_router->register_action(EVENT_TOGGLE, [this]() { action_toggle(); });
 
-    auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
-    // Clear stream contents
-    datetime_stream.str("");
-    datetime_stream << std::put_time(localtime(&time), date_format.c_str());
-    auto date_string = datetime_stream.str();
+  m_dateformat = m_conf.get(name(), "date", ""s);
+  m_dateformat_alt = m_conf.get(name(), "date-alt", ""s);
+  m_timeformat = m_conf.get(name(), "time", ""s);
+  m_timeformat_alt = m_conf.get(name(), "time-alt", ""s);
+  m_timezone = m_conf.get(name(), "timezone", ""s);
 
-    auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
-    // Clear stream contents
-    datetime_stream.str("");
-    datetime_stream << std::put_time(localtime(&time), time_format.c_str());
-    auto time_string = datetime_stream.str();
-
-    if (m_date == date_string && m_time == time_string) {
-      return false;
-    }
-
-    m_date = date_string;
-    m_time = time_string;
-
-    if (m_label) {
-      m_label->reset_tokens();
-      m_label->replace_token("%date%", m_date);
-      m_label->replace_token("%time%", m_time);
-    }
-
-    return true;
+  if (m_dateformat.empty() && m_timeformat.empty()) {
+    throw module_error("No date or time format specified");
   }
 
-  bool date_module::build(builder* builder, const string& tag) const {
-    if (tag == TAG_LABEL) {
-      if (!m_dateformat_alt.empty() || !m_timeformat_alt.empty()) {
-        builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "", m_label);
-      } else {
-        builder->node(m_label);
-      }
+  set_interval(1s);
+
+  m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_DATE});
+
+  if (m_formatter->has(TAG_DATE)) {
+    m_log.warn("%s: The format tag `<date>` is deprecated, use `<label>` instead.", name());
+
+    m_formatter->get(DEFAULT_FORMAT)->value =
+        string_util::replace_all(m_formatter->get(DEFAULT_FORMAT)->value, TAG_DATE, TAG_LABEL);
+  }
+
+  if (m_formatter->has(TAG_LABEL)) {
+    m_label = load_optional_label(m_conf, name(), "label", "%date%");
+  }
+}
+
+bool date_module::update() {
+  auto time = std::time(nullptr);
+
+  const char* old_tz = getenv("TZ");
+
+  auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
+  // Clear stream contents
+  datetime_stream.str("");
+
+  if (!m_timezone.empty()) {
+    setenv("TZ", m_timezone.c_str(), 1);
+    tzset();
+  }
+
+  datetime_stream << std::put_time(localtime(&time), date_format.c_str());
+
+  if (!m_timezone.empty()) {
+    if (old_tz) {
+      setenv("TZ", old_tz, 1);
     } else {
-      return false;
+      unsetenv("TZ");
     }
-
-    return true;
+    tzset();
   }
 
-  void date_module::action_toggle() {
-    m_toggled = !m_toggled;
-    wakeup();
+  auto date_string = datetime_stream.str();
+
+  auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
+  // Clear stream contents
+  datetime_stream.str("");
+  datetime_stream << std::put_time(localtime(&time), time_format.c_str());
+  auto time_string = datetime_stream.str();
+
+  if (m_date == date_string && m_time == time_string) {
+    return false;
   }
-}  // namespace modules
+
+  m_date = date_string;
+  m_time = time_string;
+
+  if (m_label) {
+    m_label->reset_tokens();
+    m_label->replace_token("%date%", m_date);
+    m_label->replace_token("%time%", m_time);
+  }
+
+  return true;
+}
+
+bool date_module::build(builder* builder, const string& tag) const {
+  if (tag == TAG_LABEL) {
+    if (!m_dateformat_alt.empty() || !m_timeformat_alt.empty()) {
+      builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "", m_label);
+    } else {
+      builder->node(m_label);
+    }
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+void date_module::action_toggle() {
+  m_toggled = !m_toggled;
+  wakeup();
+}
+} // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -91,24 +91,24 @@ namespace modules {
     return true;
   }
 
-bool date_module::build(builder* builder, const string& tag) const {
-  if (tag == TAG_LABEL) {
-    if (!m_dateformat_alt.empty() || !m_timeformat_alt.empty()) {
-      builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "", m_label);
+  bool date_module::build(builder* builder, const string& tag) const {
+    if (tag == TAG_LABEL) {
+      if (!m_dateformat_alt.empty() || !m_timeformat_alt.empty()) {
+        builder->action(mousebtn::LEFT, *this, EVENT_TOGGLE, "", m_label);
+      } else {
+        builder->node(m_label);
+      }
     } else {
-      builder->node(m_label);
+      return false;
     }
-  } else {
-    return false;
+
+    return true;
   }
 
-  return true;
-}
-
-void date_module::action_toggle() {
-  m_toggled = !m_toggled;
-  wakeup();
-}
+  void date_module::action_toggle() {
+    m_toggled = !m_toggled;
+    wakeup();
+  }
 } // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -6,90 +6,90 @@
 POLYBAR_NS
 
 namespace modules {
-template class module<date_module>;
+  template class module<date_module>;
 
-date_module::date_module(const bar_settings& bar, string name_, const config& config)
-    : timer_module<date_module>(bar, move(name_), config) {
-  if (!m_bar.locale.empty()) {
-    datetime_stream.imbue(std::locale(m_bar.locale.c_str()));
-  }
-
-  m_router->register_action(EVENT_TOGGLE, [this]() { action_toggle(); });
-
-  m_dateformat = m_conf.get(name(), "date", ""s);
-  m_dateformat_alt = m_conf.get(name(), "date-alt", ""s);
-  m_timeformat = m_conf.get(name(), "time", ""s);
-  m_timeformat_alt = m_conf.get(name(), "time-alt", ""s);
-  m_timezone = m_conf.get(name(), "timezone", ""s);
-
-  if (m_dateformat.empty() && m_timeformat.empty()) {
-    throw module_error("No date or time format specified");
-  }
-
-  set_interval(1s);
-
-  m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_DATE});
-
-  if (m_formatter->has(TAG_DATE)) {
-    m_log.warn("%s: The format tag `<date>` is deprecated, use `<label>` instead.", name());
-
-    m_formatter->get(DEFAULT_FORMAT)->value =
-        string_util::replace_all(m_formatter->get(DEFAULT_FORMAT)->value, TAG_DATE, TAG_LABEL);
-  }
-
-  if (m_formatter->has(TAG_LABEL)) {
-    m_label = load_optional_label(m_conf, name(), "label", "%date%");
-  }
-}
-
-bool date_module::update() {
-  auto time = std::time(nullptr);
-
-  const char* old_tz = getenv("TZ");
-
-  auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
-  // Clear stream contents
-  datetime_stream.str("");
-
-  if (!m_timezone.empty()) {
-    setenv("TZ", m_timezone.c_str(), 1);
-    tzset();
-  }
-
-  datetime_stream << std::put_time(localtime(&time), date_format.c_str());
-
-  if (!m_timezone.empty()) {
-    if (old_tz) {
-      setenv("TZ", old_tz, 1);
-    } else {
-      unsetenv("TZ");
+  date_module::date_module(const bar_settings& bar, string name_, const config& config)
+      : timer_module<date_module>(bar, move(name_), config) {
+    if (!m_bar.locale.empty()) {
+      datetime_stream.imbue(std::locale(m_bar.locale.c_str()));
     }
-    tzset();
+
+    m_router->register_action(EVENT_TOGGLE, [this]() { action_toggle(); });
+
+    m_dateformat = m_conf.get(name(), "date", ""s);
+    m_dateformat_alt = m_conf.get(name(), "date-alt", ""s);
+    m_timeformat = m_conf.get(name(), "time", ""s);
+    m_timeformat_alt = m_conf.get(name(), "time-alt", ""s);
+    m_timezone = m_conf.get(name(), "timezone", ""s);
+
+    if (m_dateformat.empty() && m_timeformat.empty()) {
+      throw module_error("No date or time format specified");
+    }
+
+    set_interval(1s);
+
+    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_DATE});
+
+    if (m_formatter->has(TAG_DATE)) {
+      m_log.warn("%s: The format tag `<date>` is deprecated, use `<label>` instead.", name());
+
+      m_formatter->get(DEFAULT_FORMAT)->value =
+          string_util::replace_all(m_formatter->get(DEFAULT_FORMAT)->value, TAG_DATE, TAG_LABEL);
+    }
+
+    if (m_formatter->has(TAG_LABEL)) {
+      m_label = load_optional_label(m_conf, name(), "label", "%date%");
+    }
   }
 
-  auto date_string = datetime_stream.str();
+  bool date_module::update() {
+    auto time = std::time(nullptr);
 
-  auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
-  // Clear stream contents
-  datetime_stream.str("");
-  datetime_stream << std::put_time(localtime(&time), time_format.c_str());
-  auto time_string = datetime_stream.str();
+    const char* old_tz = getenv("TZ");
 
-  if (m_date == date_string && m_time == time_string) {
-    return false;
+    auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
+    // Clear stream contents
+    datetime_stream.str("");
+
+    if (!m_timezone.empty()) {
+      setenv("TZ", m_timezone.c_str(), 1);
+      tzset();
+    }
+
+    datetime_stream << std::put_time(localtime(&time), date_format.c_str());
+
+    if (!m_timezone.empty()) {
+      if (old_tz) {
+        setenv("TZ", old_tz, 1);
+      } else {
+        unsetenv("TZ");
+      }
+      tzset();
+    }
+
+    auto date_string = datetime_stream.str();
+
+    auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
+    // Clear stream contents
+    datetime_stream.str("");
+    datetime_stream << std::put_time(localtime(&time), time_format.c_str());
+    auto time_string = datetime_stream.str();
+
+    if (m_date == date_string && m_time == time_string) {
+      return false;
+    }
+
+    m_date = date_string;
+    m_time = time_string;
+
+    if (m_label) {
+      m_label->reset_tokens();
+      m_label->replace_token("%date%", m_date);
+      m_label->replace_token("%time%", m_time);
+    }
+
+    return true;
   }
-
-  m_date = date_string;
-  m_time = time_string;
-
-  if (m_label) {
-    m_label->reset_tokens();
-    m_label->replace_token("%date%", m_date);
-    m_label->replace_token("%time%", m_time);
-  }
-
-  return true;
-}
 
 bool date_module::build(builder* builder, const string& tag) const {
   if (tag == TAG_LABEL) {


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Added a `timezone` config option for the date module.

Follows the Linux timezone convention (ie: Europe/London).

If no timezone specified, just uses the local timezone.

## Related Issues & Documents
Closes #596 

I see that there have been several attempts for this issue.

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

Documentation change for the wiki mentions that the `timezone` config now exists for date module. Here is a sample config that I'm using:

```
[module/datepst]
type = internal/date
interval = 1

date = %H:%M %Z

timezone = "America/Los_Angeles"

label = %date%
label-foreground = ${colors.disabled}
```
