### PR TITLE
fix: check if git top-level directory matches CMake project source (#3152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Build
 - Fixed compiler error in GCC 15 ([`#3159`](https://github.com/polybar/polybar/pull/3159))
+- Fixed version detection if release tarball is built in another repository. ([`#3152`](https://github.com/polybar/polybar/issues/3152), [`#3156`](https://github.com/polybar/polybar/pull/3156))
 
 ## [3.7.2] - 2024-08-17
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,40 @@ project(polybar CXX)
 # a version string is used, so the file supports comments
 file(STRINGS version.txt version_txt REGEX "^[0-9]+\\.[0-9]+\\.[0-9]+.*$" LIMIT_COUNT 1)
 
-# If we are in a git repo we can get the version information from git describe
-execute_process(COMMAND git describe --tags --dirty=-dev
+
+execute_process(COMMAND git rev-parse --show-toplevel
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  RESULT_VARIABLE git_result
-  OUTPUT_VARIABLE git_describe
+  RESULT_VARIABLE git_top_dir_result
+  OUTPUT_VARIABLE git_top_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
 
-if(git_result EQUAL "0")
-  set(APP_VERSION "${git_describe}")
-else()
-  message(STATUS "Could not detect version with git, falling back to built-in version information.")
-  set(APP_VERSION "${version_txt}")
+# Set fallback first, override if more information (from git) is found
+set(APP_VERSION "${version_txt}")
+
+# Prevent formatting errors & resolve symlinks (REALPATH)
+get_filename_component(resolved_project_source_dir ${PROJECT_SOURCE_DIR} REALPATH)
+if(NOT ("${git_top_dir}" STREQUAL ""))
+  get_filename_component(git_top_dir ${git_top_dir} REALPATH)
 endif()
+
+if(git_top_dir_result EQUAL "0" AND git_top_dir STREQUAL resolved_project_source_dir)
+  # If we are in a git repo we can get the version information from git describe
+  execute_process(COMMAND git describe --tags --dirty=-dev
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE git_describe_result
+    OUTPUT_VARIABLE git_describe
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+
+  if(git_describe_result EQUAL "0")
+    set(APP_VERSION "${git_describe}")
+  else()
+    message(STATUS "Could not detect version with git, falling back to built-in version information.")
+  endif()
+
+else()
+  message(STATUS "CMake and git directory mismatch, falling back to built-in version information.") # Assuming that if git rev-parse doesn't return 0, git describe won't either
+endif()
+
 
 # Set the default installation prefix to /usr
 # Otherwise the default value is /usr/local which causes the default config


### PR DESCRIPTION
Backports #3156 (which fixes #3152) to 3.7.3