### PR TITLE
bspwm separator fix

### DIFF
--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -378,6 +378,9 @@ namespace modules {
         label->replace_token("%icon%", icon->get());
         label->replace_token("%index%", to_string(++workspace_n));
 
+        if (tag[0] == 'f' && label->get().empty()){
+          continue;
+        }
         m_monitors.back()->workspaces.emplace_back(workspace_mask, move(label));
       }
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

I have no idea what I'm doing but I stumbled across the same problem as issue #1630 .
It is expected that module/bspwm wouldn't create a separator for empty workspaces when label-empty is set to nothing. I just added one continue inside if statement and now there is no unnecessary separators.

Before:
![snip_09-19-2024_21-13-24](https://github.com/user-attachments/assets/b83b6120-a635-4e67-829c-d3f760f4f46d)
After:
![snip_09-19-2024_21-13-53](https://github.com/user-attachments/assets/02ddcf8e-b635-4e54-a486-fb65ec392e56)

Corresponding part of my module/bspwm config:
```
label-empty = ""

label-separator = "∙"
label-separator-padding = 18px
label-separator-foreground = ${colors.color1}
```


## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
