### PR TITLE
fix(pulseaudio): Preserve channel balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([#3123](https://github.com/polybar/polybar/issues/3123), [#3169](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)
+- `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([`#3123`](https://github.com/polybar/polybar/issues/3123), [`#3169`](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)
 
 ## [3.7.2] - 2024-08-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - An option `unmute-on-scroll` for `internal/pulseaudio` and `internal/alsa` to unmute audio when the user scrolls on the widget.
 
+### Changed
+
+- `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([#3123](https://github.com/polybar/polybar/issues/3123), [#3169](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)
+
 ## [3.7.2] - 2024-08-17
 ### Fixed
 - `custom/script`: When a script with `tail = true` received multiple lines quickly, only the first would get displayed ([`#3117`](https://github.com/polybar/polybar/issues/3117), [`#3119`](https://github.com/polybar/polybar/pull/3119)) by [@Isak05](https://github.com/Isak05)


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
Instead of preserving the proportions of PulseAudio channels, we now preserve the balance between the channels. This mirrors pulsemixer's approach.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
Fixes #3123

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
