### PR TITLE
Implement tray-reversed option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/battery`: Added `ramp-charging` tag.
 ([`#3172`](https://github.com/polybar/polybar/pull/3172))
 by [@stringlapse](https://github.com/stringlapse).
-- Added tray-reversed = false option to tray module. Makes tray icons order reversed. (#3181)
+- Added tray-reversed = false option to tray module. Makes tray icons order reversed. ([`#3181`](https://github.com/polybar/polybar/discussions/3181))
 
 ### Changed
 - `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([`#3123`](https://github.com/polybar/polybar/issues/3123), [`#3169`](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `internal/battery`: Added `ramp-charging` tag.
 ([`#3172`](https://github.com/polybar/polybar/pull/3172))
 by [@stringlapse](https://github.com/stringlapse).
+- Added tray-reversed = false option to tray module. Makes tray icons order reversed. (#3181)
 
 ### Changed
 - `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([`#3123`](https://github.com/polybar/polybar/issues/3123), [`#3169`](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -67,6 +67,11 @@ struct tray_settings {
   rgba foreground{};
 
   /**
+   * Reverse the order of tray icons
+   */
+  bool reversed{false};
+
+  /**
    * Window ID of tray selection owner.
    *
    * Matches the bar window

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -75,6 +75,7 @@ void manager::setup(const config& conf, const string& section_name) {
   m_opts.foreground = conf.get(section_name, "tray-foreground", m_bar_opts.foreground);
 
   m_opts.selection_owner = m_bar_opts.x_data.window;
+  m_opts.reversed = conf.get(section_name, "tray-reversed", false);
 
   m_log.info("tray: spacing=%upx padding=%upx size=%upx", m_opts.spacing, m_opts.padding, client_height);
 
@@ -250,7 +251,7 @@ void manager::reconfigure_clients() {
 
   unsigned count = 0;
 
-  for (auto& client : m_clients) {
+  auto reconfigure_client = [&] (auto& client) {
     try {
       client->ensure_state();
 
@@ -266,6 +267,16 @@ void manager::reconfigure_clients() {
       m_log.err("Failed to reconfigure %s, removing ... (%s)", client->name(), err.what());
       client.reset();
       has_error = true;
+    }
+  };
+
+  if (m_opts.reversed) {
+    for (auto it = m_clients.rbegin(); it != m_clients.rend(); ++it) {
+      reconfigure_client(*it);
+    }
+  } else {
+    for (auto it = m_clients.begin(); it != m_clients.end(); ++it) {
+      reconfigure_client(*it);
     }
   }
 

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -75,7 +75,7 @@ void manager::setup(const config& conf, const string& section_name) {
   m_opts.foreground = conf.get(section_name, "tray-foreground", m_bar_opts.foreground);
 
   m_opts.selection_owner = m_bar_opts.x_data.window;
-  m_opts.reversed = conf.get(section_name, "tray-reversed", false);
+  m_opts.reversed = conf.get(section_name, "tray-reversed", m_opts.reversed);
 
   m_log.info("tray: spacing=%upx padding=%upx size=%upx", m_opts.spacing, m_opts.padding, client_height);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
New config option 'tray-reversed' for tray module that makes icons appear in reversed order.

## Related Issues & Documents
Closes #3183 

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes
Update tray module wiki page