### PR TITLE
feat(tray): added option to show tray icons sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ([`#3172`](https://github.com/polybar/polybar/pull/3172))
 by [@stringlapse](https://github.com/stringlapse).
 - Added tray-reversed = false option to tray module. Makes tray icons order reversed. ([`#3181`](https://github.com/polybar/polybar/discussions/3181))
+- Added tray-sorted = false option to tray module. Makes tray icons ordering consistent through reloads. ([`#3189`](https://github.com/polybar/polybar/pull/3189) by [@anhnamtran](https://github.com/anhnamtran))
 
 ### Changed
 - `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([`#3123`](https://github.com/polybar/polybar/issues/3123), [`#3169`](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)

--- a/include/x11/tray_client.hpp
+++ b/include/x11/tray_client.hpp
@@ -62,6 +62,8 @@ class client : public non_copyable_mixin, public non_movable_mixin {
 
   void update_bg() const;
 
+  bool operator<(const client& other) const;
+
  protected:
   void observe_background();
 

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -72,6 +72,11 @@ struct tray_settings {
   bool reversed{false};
 
   /**
+   * Sort the order of tray icons by their WM_NAME
+   */
+  bool sorted{true};
+
+  /**
    * Window ID of tray selection owner.
    *
    * Matches the bar window
@@ -157,7 +162,6 @@ class manager
   signal_emitter& m_sig;
   const logger& m_log;
   vector<unique_ptr<client>> m_clients;
-
   tray_settings m_opts{};
   const bar_settings& m_bar_opts;
 

--- a/src/x11/tray_client.cpp
+++ b/src/x11/tray_client.cpp
@@ -369,6 +369,10 @@ void client::observe_background() {
   update_bg();
 }
 
+bool client::operator<(client const& other) const {
+  return m_name < other.m_name;
+}
+
 } // namespace tray
 
 POLYBAR_NS_END

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -76,6 +76,7 @@ void manager::setup(const config& conf, const string& section_name) {
 
   m_opts.selection_owner = m_bar_opts.x_data.window;
   m_opts.reversed = conf.get(section_name, "tray-reversed", m_opts.reversed);
+  m_opts.sorted = conf.get(section_name, "tray-sorted", m_opts.sorted);
 
   m_log.info("tray: spacing=%upx padding=%upx size=%upx", m_opts.spacing, m_opts.padding, client_height);
 
@@ -270,6 +271,15 @@ void manager::reconfigure_clients() {
     }
   };
 
+  if(m_opts.sorted) {
+    // compare the inner clients not the unique_ptrs
+    auto client_comp = [&] (std::unique_ptr<client>& l, std::unique_ptr<client>& r) {
+      return *l < *r;
+    };
+    // std::sort uses introsort, which avoid performance degradation on an already sorted array
+    // which reduces performance impact of multiple calls to sort tray items.
+    std::sort(m_clients.begin(), m_clients.end(), client_comp);
+  }
   if (m_opts.reversed) {
     for (auto it = m_clients.rbegin(); it != m_clients.rend(); ++it) {
       reconfigure_client(*it);


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [x] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

The new tray module current will render the tray icons in more or less arbitrary order. This change adds an option to the module to sort the icons by their WM_NAME.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

## Documentation (check all applicable)

* [x] This PR requires changes to the Wiki documentation (describe the changes)
  * A new configuration option is added to the tray module
* [x] This PR requires changes to the documentation inside the git repo (please add them to the PR).
  * A new configuration option is added to the tray module
* [ ] Does not require documentation changes
