### PR TITLE
fix: Stop counting iowait towards CPU utilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ by [@stringlapse](https://github.com/stringlapse).
 ### Changed
 - `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([`#3123`](https://github.com/polybar/polybar/issues/3123), [`#3169`](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)
 - When the `-r` flag is provided, and RandR reports zero connected active screens, polybar will not restart. This fixes polybar dying on some laptops when the lid is closed. ([`#3078`](https://github.com/polybar/polybar/pull/3078))).
+- The `internal/cpu` module no longer counts time spent waiting on I/O devices (`iowait`) towards cpu load
 
 ## [3.7.2] - 2024-08-17
 ### Fixed

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -9,12 +9,11 @@ POLYBAR_NS
 namespace modules {
   enum class cpu_state { NORMAL = 0, WARN };
   struct cpu_time {
-    unsigned long long user;
-    unsigned long long nice;
-    unsigned long long system;
-    unsigned long long idle;
-    unsigned long long steal;
-    unsigned long long total;
+    long long user;
+    long long nice;
+    long long system;
+    long long idle;
+    long long iowait;
   };
 
   using cpu_time_t = unique_ptr<cpu_time>;

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -7,53 +7,53 @@
 POLYBAR_NS
 
 namespace modules {
-  enum class cpu_state { NORMAL = 0, WARN };
-  struct cpu_time {
-    long long user;
-    long long nice;
-    long long system;
-    long long idle;
-    long long iowait;
-  };
+enum class cpu_state { NORMAL = 0, WARN };
+struct cpu_time {
+  long long user;
+  long long nice;
+  long long system;
+  long long idle;
+  long long iowait;
+};
 
-  using cpu_time_t = unique_ptr<cpu_time>;
+using cpu_time_t = unique_ptr<cpu_time>;
 
-  class cpu_module : public timer_module<cpu_module> {
-   public:
-    explicit cpu_module(const bar_settings&, string, const config&);
+class cpu_module : public timer_module<cpu_module> {
+ public:
+  explicit cpu_module(const bar_settings&, string, const config&);
 
-    bool update();
-    string get_format() const;
-    bool build(builder* builder, const string& tag) const;
+  bool update();
+  string get_format() const;
+  bool build(builder* builder, const string& tag) const;
 
-    static constexpr auto TYPE = CPU_TYPE;
+  static constexpr auto TYPE = CPU_TYPE;
 
-   protected:
-    bool read_values();
-    float get_load(size_t core) const;
+ protected:
+  bool read_values();
+  float get_load(size_t core) const;
 
-   private:
-    static constexpr auto TAG_LABEL = "<label>";
-    static constexpr auto TAG_LABEL_WARN = "<label-warn>";
-    static constexpr auto TAG_BAR_LOAD = "<bar-load>";
-    static constexpr auto TAG_RAMP_LOAD = "<ramp-load>";
-    static constexpr auto TAG_RAMP_LOAD_PER_CORE = "<ramp-coreload>";
-    static constexpr auto FORMAT_WARN = "format-warn";
+ private:
+  static constexpr auto TAG_LABEL = "<label>";
+  static constexpr auto TAG_LABEL_WARN = "<label-warn>";
+  static constexpr auto TAG_BAR_LOAD = "<bar-load>";
+  static constexpr auto TAG_RAMP_LOAD = "<ramp-load>";
+  static constexpr auto TAG_RAMP_LOAD_PER_CORE = "<ramp-coreload>";
+  static constexpr auto FORMAT_WARN = "format-warn";
 
-    label_t m_label;
-    label_t m_labelwarn;
-    progressbar_t m_barload;
-    ramp_t m_rampload;
-    ramp_t m_rampload_core;
-    spacing_val m_ramp_padding{spacing_type::SPACE, 1U};
+  label_t m_label;
+  label_t m_labelwarn;
+  progressbar_t m_barload;
+  ramp_t m_rampload;
+  ramp_t m_rampload_core;
+  spacing_val m_ramp_padding{spacing_type::SPACE, 1U};
 
-    vector<cpu_time_t> m_cputimes;
-    vector<cpu_time_t> m_cputimes_prev;
+  vector<cpu_time_t> m_cputimes;
+  vector<cpu_time_t> m_cputimes_prev;
 
-    float m_totalwarn = 80;
-    float m_total = 0;
-    vector<float> m_load;
-  };
-}  // namespace modules
+  float m_totalwarn = 80;
+  float m_total = 0;
+  vector<float> m_load;
+};
+} // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -12,175 +12,174 @@
 POLYBAR_NS
 
 namespace modules {
-  template class module<cpu_module>;
+template class module<cpu_module>;
 
-  cpu_module::cpu_module(const bar_settings& bar, string name_, const config& config)
-      : timer_module<cpu_module>(bar, move(name_), config) {
-    set_interval(1s);
-    m_totalwarn = m_conf.get(name(), "warn-percentage", m_totalwarn);
-    m_ramp_padding = m_conf.get(name(), "ramp-coreload-spacing", m_ramp_padding);
+cpu_module::cpu_module(const bar_settings& bar, string name_, const config& config)
+    : timer_module<cpu_module>(bar, move(name_), config) {
+  set_interval(1s);
+  m_totalwarn = m_conf.get(name(), "warn-percentage", m_totalwarn);
+  m_ramp_padding = m_conf.get(name(), "ramp-coreload-spacing", m_ramp_padding);
 
-    m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
-    m_formatter->add_optional(FORMAT_WARN, {TAG_LABEL_WARN, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
+  m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
+  m_formatter->add_optional(FORMAT_WARN, {TAG_LABEL_WARN, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 
-    // warmup cpu times
-    read_values();
-    read_values();
+  // warmup cpu times
+  read_values();
+  read_values();
 
-    if (m_formatter->has(TAG_LABEL)) {
-      m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%percentage%%");
-    }
-    if (m_formatter->has(TAG_LABEL_WARN)) {
-      m_labelwarn = load_optional_label(m_conf, name(), TAG_LABEL_WARN, "%percentage%%");
-    }
-    if (m_formatter->has(TAG_BAR_LOAD)) {
-      m_barload = load_progressbar(m_bar, m_conf, name(), TAG_BAR_LOAD);
-    }
-    if (m_formatter->has(TAG_RAMP_LOAD)) {
-      m_rampload = load_ramp(m_conf, name(), TAG_RAMP_LOAD);
-    }
-    if (m_formatter->has(TAG_RAMP_LOAD_PER_CORE)) {
-      m_rampload_core = load_ramp(m_conf, name(), TAG_RAMP_LOAD_PER_CORE);
+  if (m_formatter->has(TAG_LABEL)) {
+    m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%percentage%%");
+  }
+  if (m_formatter->has(TAG_LABEL_WARN)) {
+    m_labelwarn = load_optional_label(m_conf, name(), TAG_LABEL_WARN, "%percentage%%");
+  }
+  if (m_formatter->has(TAG_BAR_LOAD)) {
+    m_barload = load_progressbar(m_bar, m_conf, name(), TAG_BAR_LOAD);
+  }
+  if (m_formatter->has(TAG_RAMP_LOAD)) {
+    m_rampload = load_ramp(m_conf, name(), TAG_RAMP_LOAD);
+  }
+  if (m_formatter->has(TAG_RAMP_LOAD_PER_CORE)) {
+    m_rampload_core = load_ramp(m_conf, name(), TAG_RAMP_LOAD_PER_CORE);
+  }
+}
+
+bool cpu_module::update() {
+  if (!read_values()) {
+    return false;
+  }
+
+  m_total = 0.0f;
+  m_load.clear();
+
+  auto cores_n = m_cputimes.size();
+  if (!cores_n) {
+    return false;
+  }
+
+  vector<string> percentage_cores;
+  for (size_t i = 0; i < cores_n; i++) {
+    auto load = get_load(i);
+    m_total += load;
+    m_load.emplace_back(load);
+
+    if (m_label || m_labelwarn) {
+      percentage_cores.emplace_back(to_string(static_cast<int>(load + 0.5)));
     }
   }
 
-  bool cpu_module::update() {
-    if (!read_values()) {
-      return false;
+  m_total = m_total / static_cast<float>(cores_n);
+
+  const auto replace_tokens = [&](label_t& label) {
+    label->reset_tokens();
+    label->replace_token("%percentage%", to_string(static_cast<int>(m_total + 0.5)));
+    label->replace_token("%percentage-sum%", to_string(static_cast<int>(m_total * static_cast<float>(cores_n) + 0.5)));
+    label->replace_token("%percentage-cores%", string_util::join(percentage_cores, "% ") + "%");
+
+    for (size_t i = 0; i < percentage_cores.size(); i++) {
+      label->replace_token("%percentage-core" + to_string(i + 1) + "%", percentage_cores[i]);
     }
+  };
 
-    m_total = 0.0f;
-    m_load.clear();
+  if (m_label) {
+    replace_tokens(m_label);
+  }
+  if (m_labelwarn) {
+    replace_tokens(m_labelwarn);
+  }
 
-    auto cores_n = m_cputimes.size();
-    if (!cores_n) {
-      return false;
-    }
+  return true;
+}
 
-    vector<string> percentage_cores;
-    for (size_t i = 0; i < cores_n; i++) {
-      auto load = get_load(i);
-      m_total += load;
-      m_load.emplace_back(load);
+string cpu_module::get_format() const {
+  if (m_total >= m_totalwarn && m_formatter->has_format(FORMAT_WARN)) {
+    return FORMAT_WARN;
+  } else {
+    return DEFAULT_FORMAT;
+  }
+}
 
-      if (m_label || m_labelwarn) {
-        percentage_cores.emplace_back(to_string(static_cast<int>(load + 0.5)));
+bool cpu_module::build(builder* builder, const string& tag) const {
+  if (tag == TAG_LABEL) {
+    builder->node(m_label);
+  } else if (tag == TAG_LABEL_WARN) {
+    builder->node(m_labelwarn);
+  } else if (tag == TAG_BAR_LOAD) {
+    builder->node(m_barload->output(m_total));
+  } else if (tag == TAG_RAMP_LOAD) {
+    builder->node(m_rampload->get_by_percentage_with_borders(m_total, 0.0f, m_totalwarn));
+  } else if (tag == TAG_RAMP_LOAD_PER_CORE) {
+    auto i = 0;
+    for (auto&& load : m_load) {
+      if (i++ > 0) {
+        builder->spacing(m_ramp_padding);
       }
+      builder->node(m_rampload_core->get_by_percentage_with_borders(load, 0.0f, m_totalwarn));
     }
+    builder->node(builder->flush());
+  } else {
+    return false;
+  }
+  return true;
+}
 
-    m_total = m_total / static_cast<float>(cores_n);
+bool cpu_module::read_values() {
+  m_cputimes_prev.swap(m_cputimes);
+  m_cputimes.clear();
 
-    const auto replace_tokens = [&](label_t& label) {
-      label->reset_tokens();
-      label->replace_token("%percentage%", to_string(static_cast<int>(m_total + 0.5)));
-      label->replace_token(
-          "%percentage-sum%", to_string(static_cast<int>(m_total * static_cast<float>(cores_n) + 0.5)));
-      label->replace_token("%percentage-cores%", string_util::join(percentage_cores, "% ") + "%");
+  try {
+    std::ifstream in(PATH_CPU_INFO);
+    string str;
 
-      for (size_t i = 0; i < percentage_cores.size(); i++) {
-        label->replace_token("%percentage-core" + to_string(i + 1) + "%", percentage_cores[i]);
+    while (std::getline(in, str) && str.compare(0, 3, "cpu") == 0) {
+      // skip line with accumulated value
+      if (str.compare(0, 4, "cpu ") == 0) {
+        continue;
       }
-    };
 
-    if (m_label) {
-      replace_tokens(m_label);
-    }
-    if (m_labelwarn) {
-      replace_tokens(m_labelwarn);
-    }
+      auto values = string_util::split(str, ' ');
 
-    return true;
+      m_cputimes.emplace_back(new cpu_time);
+      m_cputimes.back()->user = std::stoull(values[1], nullptr, 10);
+      m_cputimes.back()->nice = std::stoull(values[2], nullptr, 10);
+      m_cputimes.back()->system = std::stoull(values[3], nullptr, 10);
+      m_cputimes.back()->idle = std::stoull(values[4], nullptr, 10);
+      m_cputimes.back()->iowait = std::stoull(values[5], nullptr, 10);
+    }
+  } catch (const std::ios_base::failure& e) {
+    m_log.err("Failed to read CPU values (what: %s)", e.what());
   }
 
-  string cpu_module::get_format() const {
-    if (m_total >= m_totalwarn && m_formatter->has_format(FORMAT_WARN)) {
-      return FORMAT_WARN;
-    } else {
-      return DEFAULT_FORMAT;
-    }
+  return !m_cputimes.empty();
+}
+
+float cpu_module::get_load(size_t core) const {
+  if (m_cputimes.empty() || m_cputimes_prev.empty()) {
+    return 0;
+  } else if (core >= m_cputimes.size() || core >= m_cputimes_prev.size()) {
+    return 0;
   }
 
-  bool cpu_module::build(builder* builder, const string& tag) const {
-    if (tag == TAG_LABEL) {
-      builder->node(m_label);
-    } else if (tag == TAG_LABEL_WARN) {
-      builder->node(m_labelwarn);
-    } else if (tag == TAG_BAR_LOAD) {
-      builder->node(m_barload->output(m_total));
-    } else if (tag == TAG_RAMP_LOAD) {
-      builder->node(m_rampload->get_by_percentage_with_borders(m_total, 0.0f, m_totalwarn));
-    } else if (tag == TAG_RAMP_LOAD_PER_CORE) {
-      auto i = 0;
-      for (auto&& load : m_load) {
-        if (i++ > 0) {
-          builder->spacing(m_ramp_padding);
-        }
-        builder->node(m_rampload_core->get_by_percentage_with_borders(load, 0.0f, m_totalwarn));
-      }
-      builder->node(builder->flush());
-    } else {
-      return false;
-    }
-    return true;
+  auto& latest = m_cputimes[core];
+  auto& prev = m_cputimes_prev[core];
+
+  // The iowait counter can go backwards, so be safe with all
+  auto system_diff = std::max(latest->system - prev->system, 0ll);
+  auto user_diff = std::max(latest->user - prev->user, 0ll);
+  user_diff += std::max(latest->nice - prev->nice, 0ll);
+  auto wait_diff = std::max(latest->iowait - prev->iowait, 0ll);
+  auto idle_diff = std::max(latest->idle - prev->idle, 0ll);
+
+  auto total_diff = system_diff + user_diff + wait_diff + idle_diff;
+
+  if (total_diff == 0) {
+    return 0;
   }
 
-  bool cpu_module::read_values() {
-    m_cputimes_prev.swap(m_cputimes);
-    m_cputimes.clear();
+  float percentage = ((float)(system_diff + user_diff) / total_diff) * 100;
 
-    try {
-      std::ifstream in(PATH_CPU_INFO);
-      string str;
-
-      while (std::getline(in, str) && str.compare(0, 3, "cpu") == 0) {
-        // skip line with accumulated value
-        if (str.compare(0, 4, "cpu ") == 0) {
-          continue;
-        }
-
-        auto values = string_util::split(str, ' ');
-
-        m_cputimes.emplace_back(new cpu_time);
-        m_cputimes.back()->user = std::stoull(values[1], nullptr, 10);
-        m_cputimes.back()->nice = std::stoull(values[2], nullptr, 10);
-        m_cputimes.back()->system = std::stoull(values[3], nullptr, 10);
-        m_cputimes.back()->idle = std::stoull(values[4], nullptr, 10);
-        m_cputimes.back()->iowait = std::stoull(values[5], nullptr, 10);
-      }
-    } catch (const std::ios_base::failure& e) {
-      m_log.err("Failed to read CPU values (what: %s)", e.what());
-    }
-
-    return !m_cputimes.empty();
-  }
-
-  float cpu_module::get_load(size_t core) const {
-    if (m_cputimes.empty() || m_cputimes_prev.empty()) {
-      return 0;
-    } else if (core >= m_cputimes.size() || core >= m_cputimes_prev.size()) {
-      return 0;
-    }
-
-    auto& latest = m_cputimes[core];
-    auto& prev = m_cputimes_prev[core];
-
-    // The iowait counter can go backwards, so be safe with all
-    auto system_diff = std::max(latest->system - prev->system, 0ll);
-    auto user_diff = std::max(latest->user - prev->user, 0ll);
-    user_diff += std::max(latest->nice - prev->nice, 0ll);
-    auto wait_diff = std::max(latest->iowait - prev->iowait, 0ll);
-    auto idle_diff = std::max(latest->idle - prev->idle, 0ll);
-
-    auto total_diff = system_diff + user_diff + wait_diff + idle_diff;
-
-    if (total_diff == 0) {
-      return 0;
-    }
-
-    float percentage = ((float) (system_diff + user_diff) / total_diff) * 100;
-
-    return math_util::cap<float>(percentage, 0, 100);
-  }
-}  // namespace modules
+  return math_util::cap<float>(percentage, 0, 100);
+}
+} // namespace modules
 
 POLYBAR_NS_END


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [x] Refactor
* [x] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
If the cpu is spending a lot of time in iowait, it is still idle but some process is waiting on io. The system itself is not under load.

This is especially annoying with ghostty, as it spends most time waiting on io_uring, which drives up the CPU usage reported by polybar to around 50% or more. Other system monitors, such as htop or btop, do not count iowait towards utilization and only report ~5% CPU utilization instead.

This is discussed in more detail at https://github.com/ghostty-org/ghostty/discussions/3224.

The kde system monitor was recently adjusted to behave similarly: https://invent.kde.org/plasma/ksystemstats/-/merge_requests/104/.

I also removed the accounting for `steal`. I am not sure how to treat it, but it seems pretty specialized? I can re-add it though, if you prefer that.

## Related Issues & Documents
https://github.com/ghostty-org/ghostty/discussions/3224
https://invent.kde.org/plasma/ksystemstats/-/merge_requests/104/.

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes

As far as I can tell the behaviour isn't actually documented anywhere, but maybe I missed it.