### PR TITLE
Add Freetype to fix build on Arch

### DIFF
--- a/cmake/libpoly.cmake
+++ b/cmake/libpoly.cmake
@@ -47,6 +47,7 @@ endif()
 
 find_package(Threads REQUIRED)
 find_package(CairoFC REQUIRED)
+find_package(Freetype REQUIRED)
 
 find_package(LibUV 1.3.0 REQUIRED)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -161,6 +161,7 @@ target_link_libraries(poly PUBLIC
   Cairo::CairoFC
   xpp
   LibUV::LibUV
+  freetype
   )
 
 if (TARGET i3ipc++)


### PR DESCRIPTION
Adds an explicit dependency on Freetype, which was being used without one.

<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description

While some of the code in Polybar directly uses Freetype, it wasn't being explicitly linked in. Apparently this worked on Arch until relatively recently -- it looks like the PKGBUILD was building circa September. However, if you check out Polybar and build it today, it doesn't build, reporting missing Freetype symbols.

Note: this is my first time ever touching CMake, so I might have done this wrong. It seems like every project uses it a little differently.

## Related Issues & Documents

Fixed #3220

## Documentation (check all applicable)

* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
