### PR TITLE
Fix missing cstdint header for compiling with gcc15.

### DIFF
--- a/include/common.hpp
+++ b/include/common.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 #include "settings.hpp"
 


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [ ] Feature
* [x] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->
This is essentially upstreaming a patch I've done for the upcoming Alpine release, to make gcc15 happy with polybar.

In gcc15 the STL headers have been reworked, and `cstdint` must be explicitly included for types `uintXY_t` to be defined.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->
See https://gcc.gnu.org/gcc-15/porting_to.html for the details.

## Documentation (check all applicable)


* [ ] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [x] Does not require documentation changes
