### PR TITLE
i3: Add strip-wsnames analog to strip-wsnumbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ([`#3172`](https://github.com/polybar/polybar/pull/3172))
 by [@stringlapse](https://github.com/stringlapse).
 - Added tray-reversed = false option to tray module. Makes tray icons order reversed. ([`#3181`](https://github.com/polybar/polybar/discussions/3181))
+- `internal/i3`: Added `strip-wsnames` analog to `strip-wsnumbers` ([`#3230`](https://github.com/polybar/polybar/pull/3230))
 
 ### Changed
 - `internal/pulseaudio`: Volume adjustments now preserve balance instead of volume ratios ([`#3123`](https://github.com/polybar/polybar/issues/3123), [`#3169`](https://github.com/polybar/polybar/pull/3169)) by [`@parmort`](https://github.com/parmort)

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -96,6 +96,7 @@ namespace modules {
     bool m_pinworkspaces{false};
     bool m_show_urgent{false};
     bool m_strip_wsnumbers{false};
+    bool m_strip_wsnames{false};
     bool m_fuzzy_match{false};
 
     unique_ptr<i3_util::connection_t> m_ipc;


### PR DESCRIPTION
<!-- Please read our contributing guide before opening a PR: https://github.com/polybar/polybar/blob/master/CONTRIBUTING.md -->

## What type of PR is this? (check all applicable)

* [ ] Refactor
* [X] Feature
* [ ] Bug Fix
* [ ] Optimization
* [ ] Documentation Update
* [ ] Other: *Replace this with a description of the type of this PR*

## Description
<!--
  Document user-facing changes in this PR (for example: new config options, changed behavior).

  You can also motivate design decisions here.
-->

Add support for stripping the name of i3 workspaces similar to how it can be done with their number. This brings polybar up to par with i3bar in that regard.

## Related Issues & Documents
<!-- For example: Fixes #1234, Closes #6789 -->

https://i3wm.org/docs/userguide.html#_strip_workspace_numbers_name

## Documentation (check all applicable)

* [X] This PR requires changes to the Wiki documentation (describe the changes)
* [ ] This PR requires changes to the documentation inside the git repo (please add them to the PR).
* [ ] Does not require documentation changes

A section about `strip-wsnames` needs to be added to the wiki page of the i3 module. The description of `strip-wsnumbers` should probably also be made a bit preciser:

```
; This will split the workspace name on ':' and only keep the second part
; Default: false
strip-wsnumbers = true

; This will split the workspace name on ':' and only keep the first part
; Default: false
; New in version 3.8.0
strip-wsnames = true
```